### PR TITLE
allow optional pcr0 values config and clean up exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/react",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "MIT",
   "type": "module",
   "files": [

--- a/src/lib/attestationForView.ts
+++ b/src/lib/attestationForView.ts
@@ -2,30 +2,11 @@ import { encode } from "@stablelib/base64";
 import { type AttestationDocument } from "./attestation";
 import awsRootCertDer from "../assets/aws_root.der";
 import { X509Certificate } from "@peculiar/x509";
+import { validatePcr0Hash, type Pcr0ValidationResult, type PcrConfig } from "./pcr";
 
 export const AWS_ROOT_CERT_DER = awsRootCertDer;
 
 export const EXPECTED_ROOT_CERT_HASH = "641a0321a3e244efe456463195d606317ed7cdcc3c1756e09893f3c68f79bb5b";
-
-export const VALID_PCR0_VALUES = [
-  "eeddbb58f57c38894d6d5af5e575fbe791c5bf3bbcfb5df8da8cfcf0c2e1da1913108e6a762112444740b88c163d7f4b",
-  "74ed417f88cb0ca76c4a3d10f278bd010f1d3f95eafb254d4732511bb50e404507a4049b779c5230137e4091a5582271",
-  "9043fcab93b972d3c14ad2dc8fa78ca7ad374fc937c02435681772a003f7a72876bc4d578089b5c4cf3fe9b480f1aabb",
-  "52c3595b151d93d8b159c257301bfd5aa6f49210de0c55a6cd6df5ebeee44e4206cab950500f5d188f7fa14e6d900b75",
-  "91cb67311e910cce68cd5b7d0de77aa40610d87c6681439b44c46c3ff786ae643956ab2c812478a1da8745b259f07a45",
-  "859065ac81b81d3735130ba08b8af72a7256b603fefb74faabae25ed28cca6edcaa7c10ea32b5948d675c18a9b0f2b1d",
-  "acd82a7d3943e23e95a9dc3ce0b0107ea358d6287f9e3afa245622f7c7e3e0a66142a928b6efcc02f594a95366d3a99d"
-];
-
-export const VALID_PCR0_VALUES_DEV = [
-  "62c0407056217a4c10764ed9045694c29fa93255d3cc04c2f989cdd9a1f8050c8b169714c71f1118ebce2fcc9951d1a9",
-  "cb95519905443f9f66f05f63c548b61ad1561a27fd5717b69285861aaea3c3063fe12a2571773b67fea3c6c11b4d8ec6",
-  "deb5895831b5e4286f5a2dcf5e9c27383821446f8df2b465f141d10743599be20ba3bb381ce063bf7139cc89f7f61d4c",
-  "70ba26c6af1ec3b57ce80e1adcc0ee96d70224d4c7a078f427895cdf68e1c30f09b5ac4c456588d872f3f21ff77c036b",
-  "669404ea71435b8f498b48db7816a5c2ab1d258b1a77685b11d84d15a73189504d79c4dee13a658de9f4a0cbfc39cfe8",
-  "a791bf92c25ffdfd372660e460a0e238c6778c090672df6509ae4bc065cf8668b6baac6b6a11d554af53ee0ff0172ad5",
-  "c4285443b87b9b12a6cea3bef1064ec060f652b235a297095975af8f134e5ed65f92d70d4616fdec80af9dff48bb9f35"
-];
 
 export type ParsedAttestationView = {
   moduleId: string;
@@ -46,6 +27,7 @@ export type ParsedAttestationView = {
   userData: string | null;
   nonce: string | null;
   cert0hash: string;
+  validatedPcr0Hash: Pcr0ValidationResult | null;
 };
 
 function toHexString(data: Uint8Array | number[]): string {
@@ -61,7 +43,8 @@ async function calculateCertHash(data: ArrayBuffer): Promise<string> {
 
 export async function parseAttestationForView(
   document: AttestationDocument,
-  cabundle: Uint8Array[]
+  cabundle: Uint8Array[],
+  pcrConfig?: PcrConfig
 ): Promise<ParsedAttestationView> {
   // Add logging to see what we're getting
   console.log("Raw timestamp:", document.timestamp);
@@ -74,6 +57,10 @@ export async function parseAttestationForView(
       value: toHexString(value)
     }))
     .filter((pcr) => !pcr.value.match(/^0+$/));
+
+  // Find PCR0 and validate it
+  const pcr0 = pcrs.find(pcr => pcr.id === 0);
+  const validatedPcr0Hash = pcr0 ? validatePcr0Hash(pcr0.value, pcrConfig) : null;
 
   // Parse certificates - cabundle first, then leaf certificate
   const certificates = [...cabundle, document.certificate].map((certBytes) => {
@@ -111,6 +98,7 @@ export async function parseAttestationForView(
     certificates,
     userData: document.user_data ? decoder.decode(document.user_data) : null,
     nonce: document.nonce ? decoder.decode(document.nonce) : null,
-    cert0hash
+    cert0hash,
+    validatedPcr0Hash
   };
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -7,28 +7,18 @@ export type {
   GoogleAuthResponse
 } from "./api";
 
-// Export types and components from main
-export type { OpenSecretAuthState, OpenSecretContextType } from "./main";
-
 // Export the provider and context
 export { OpenSecretProvider, OpenSecretContext } from "./main";
 
 // Export the hook
 export { useOpenSecret } from "./context";
 
-// Export key functions that might be useful
-export { setApiUrl } from "./api";
-
-// Export getAttestation
-export { getAttestation } from "./getAttestation";
-
-export { authenticate } from "./attestation";
+// Export types needed by consumers
+export type { OpenSecretAuthState, OpenSecretContextType } from "./main";
 export type { AttestationDocument } from "./attestation";
-
-// Export attestationForView
-export { parseAttestationForView } from "./attestationForView";
 export type { ParsedAttestationView } from "./attestationForView";
-export { EXPECTED_ROOT_CERT_HASH, VALID_PCR0_VALUES, VALID_PCR0_VALUES_DEV, AWS_ROOT_CERT_DER } from "./attestationForView";
+export type { PcrConfig, Pcr0ValidationResult } from "./pcr";
 
-// Export crypto stuff
+// Export crypto utilities
+// TODO: these can actually just be used internally by the password reset function
 export { generateSecureSecret, hashSecret } from "./crypto";

--- a/src/lib/pcr.ts
+++ b/src/lib/pcr.ts
@@ -1,0 +1,71 @@
+/**
+ * Valid PCR0 values for production environments
+ */
+const DEFAULT_PCR0_VALUES = [
+    "eeddbb58f57c38894d6d5af5e575fbe791c5bf3bbcfb5df8da8cfcf0c2e1da1913108e6a762112444740b88c163d7f4b",
+    "74ed417f88cb0ca76c4a3d10f278bd010f1d3f95eafb254d4732511bb50e404507a4049b779c5230137e4091a5582271",
+    "9043fcab93b972d3c14ad2dc8fa78ca7ad374fc937c02435681772a003f7a72876bc4d578089b5c4cf3fe9b480f1aabb",
+    "52c3595b151d93d8b159c257301bfd5aa6f49210de0c55a6cd6df5ebeee44e4206cab950500f5d188f7fa14e6d900b75",
+    "91cb67311e910cce68cd5b7d0de77aa40610d87c6681439b44c46c3ff786ae643956ab2c812478a1da8745b259f07a45",
+    "859065ac81b81d3735130ba08b8af72a7256b603fefb74faabae25ed28cca6edcaa7c10ea32b5948d675c18a9b0f2b1d",
+    "acd82a7d3943e23e95a9dc3ce0b0107ea358d6287f9e3afa245622f7c7e3e0a66142a928b6efcc02f594a95366d3a99d"
+];
+
+/**
+ * Valid PCR0 values for development environments
+ */
+const DEFAULT_PCR0_VALUES_DEV = [
+    "62c0407056217a4c10764ed9045694c29fa93255d3cc04c2f989cdd9a1f8050c8b169714c71f1118ebce2fcc9951d1a9",
+    "cb95519905443f9f66f05f63c548b61ad1561a27fd5717b69285861aaea3c3063fe12a2571773b67fea3c6c11b4d8ec6",
+    "deb5895831b5e4286f5a2dcf5e9c27383821446f8df2b465f141d10743599be20ba3bb381ce063bf7139cc89f7f61d4c",
+    "70ba26c6af1ec3b57ce80e1adcc0ee96d70224d4c7a078f427895cdf68e1c30f09b5ac4c456588d872f3f21ff77c036b",
+    "669404ea71435b8f498b48db7816a5c2ab1d258b1a77685b11d84d15a73189504d79c4dee13a658de9f4a0cbfc39cfe8",
+    "a791bf92c25ffdfd372660e460a0e238c6778c090672df6509ae4bc065cf8668b6baac6b6a11d554af53ee0ff0172ad5",
+    "c4285443b87b9b12a6cea3bef1064ec060f652b235a297095975af8f134e5ed65f92d70d4616fdec80af9dff48bb9f35"
+];
+
+export type Pcr0ValidationResult = {
+    isMatch: boolean;
+    text: string;
+};
+
+export type PcrConfig = {
+    pcr0Values?: string[];
+    pcr0DevValues?: string[];
+};
+
+/**
+ * Validates a PCR0 hash and returns information about the match
+ * @param hash - The PCR0 hash to validate
+ * @param config - Optional configuration with custom PCR0 values
+ * @returns Object containing match status and descriptive text
+ */
+export function validatePcr0Hash(hash: string, config?: PcrConfig): Pcr0ValidationResult {
+    const validPcr0Values = [...(config?.pcr0Values || []), ...DEFAULT_PCR0_VALUES];
+    const validPcr0DevValues = [...(config?.pcr0DevValues || []), ...DEFAULT_PCR0_VALUES_DEV];
+
+    if (validPcr0Values.includes(hash)) {
+        return {
+            isMatch: true,
+            text: "PCR0 matches a known good value"
+        };
+    }
+    
+    if (validPcr0DevValues.includes(hash)) {
+        return {
+            isMatch: true,
+            text: "PCR0 matches development enclave"
+        };
+    }
+    
+    return {
+        isMatch: false,
+        text: "PCR0 does not match a known good value"
+    };
+}
+
+
+
+  
+
+  


### PR DESCRIPTION
this makes it so the library consumer can pass in extra pcr0 values. also make some of these attestation functions that were standalone instead exported by the `OpenSecretContext` so they can use those custom pcr0 values and also so the burden isn't on the caller to do ceremony that we can handle