### PR TITLE
Derivation paths for private key operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,40 @@ The `useOpenSecret` hook provides access to the OpenSecret API. It returns an ob
 - `generateThirdPartyToken(audience: string): Promise<{ token: string }>`: Generates a JWT token for use with pre-authorized third-party services (e.g. "https://api.devservice.com"). Developers must register this URL in advance (coming soon).
 
 #### Cryptographic Methods
-- `getPrivateKey(): Promise<PrivateKeyResponse>`: Retrieves the user's private key mnemonic phrase. This is used for cryptographic operations and should be kept secure.
+- `getPrivateKey(): Promise<{ mnemonic: string }>`: Retrieves the user's private key mnemonic phrase. This is used for cryptographic operations and should be kept secure.
 
-- `getPublicKey(algorithm: 'schnorr' | 'ecdsa'): Promise<PublicKeyResponse>`: Retrieves the user's public key for the specified signing algorithm. Supports two algorithms:
+- `getPrivateKeyBytes(derivationPath?: string): Promise<{ private_key: string }>`: Retrieves the private key bytes for a given BIP32 derivation path. If no path is provided, returns the master private key bytes.
+  - Supports both absolute (starting with "m/") and relative paths
+  - Supports hardened derivation using either ' or h notation
+    Examples:
+    - Absolute path: "m/44'/0'/0'/0/0"
+    - Relative path: "0'/0'/0'/0/0"
+    - Hardened notation: "44'" or "44h"
+  - Common paths:
+    - BIP44 (Legacy): `m/44'/0'/0'/0/0`
+    - BIP49 (SegWit): `m/49'/0'/0'/0/0`
+    - BIP84 (Native SegWit): `m/84'/0'/0'/0/0`
+    - BIP86 (Taproot): `m/86'/0'/0'/0/0`
+
+- `getPublicKey(algorithm: 'schnorr' | 'ecdsa', derivationPath?: string): Promise<PublicKeyResponse>`: Retrieves the user's public key for the specified signing algorithm and optional derivation path. The derivation path determines which child key pair is used, allowing different public keys to be generated from the same master key. This is useful for:
+  - Separating keys by purpose (e.g., different chains or applications)
+  - Generating deterministic addresses
+  - Supporting different address formats (Legacy, SegWit, Native SegWit, Taproot)
+  
+  Supports two algorithms:
   - `'schnorr'`: For Schnorr signatures
   - `'ecdsa'`: For ECDSA signatures
 
-- `signMessage(messageBytes: Uint8Array, algorithm: 'schnorr' | 'ecdsa'): Promise<SignatureResponse>`: Signs a message using the specified algorithm. The message must be provided as a Uint8Array of bytes. Returns a signature that can be verified using the corresponding public key.
+- `signMessage(messageBytes: Uint8Array, algorithm: 'schnorr' | 'ecdsa', derivationPath?: string): Promise<SignatureResponse>`: Signs a message using the specified algorithm and optional derivation path. The message must be provided as a Uint8Array of bytes. Returns a signature that can be verified using the corresponding public key.
+  
+  Example message preparation:
+  ```typescript
+  // From string
+  const messageBytes = new TextEncoder().encode("Hello, World!");
+  
+  // From hex
+  const messageBytes = new Uint8Array(Buffer.from("deadbeef", "hex"));
+  ```
 
 ### AI Integration
 

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -188,8 +188,29 @@ export type OpenSecretContextType = {
   getPrivateKey: typeof api.fetchPrivateKey;
 
   /**
+   * Retrieves the private key bytes for a given derivation path
+   * @param derivationPath - Optional BIP32 derivation path (e.g. "m/44'/0'/0'/0/0")
+   * @returns A promise resolving to the private key bytes response
+   * @throws {Error} If:
+   * - The private key bytes cannot be retrieved
+   * - The derivation path is invalid
+   * 
+   * @description
+   * - If no derivation path is provided, returns the master private key bytes
+   * - Supports both absolute (starting with "m/") and relative paths
+   * - Supports hardened derivation using either ' or h notation
+   * - Common paths:
+   *   - BIP44 (Legacy): m/44'/0'/0'/0/0
+   *   - BIP49 (SegWit): m/49'/0'/0'/0/0
+   *   - BIP84 (Native SegWit): m/84'/0'/0'/0/0
+   *   - BIP86 (Taproot): m/86'/0'/0'/0/0
+   */
+  getPrivateKeyBytes: typeof api.fetchPrivateKeyBytes;
+
+  /**
    * Retrieves the user's public key for the specified algorithm
    * @param algorithm - The signing algorithm ('schnorr' or 'ecdsa')
+   * @param derivationPath - Optional BIP32 derivation path
    * @returns A promise resolving to the public key response
    * @throws {Error} If the public key cannot be retrieved
    */
@@ -199,6 +220,7 @@ export type OpenSecretContextType = {
    * Signs a message using the specified algorithm
    * @param messageBytes - The message to sign as a Uint8Array
    * @param algorithm - The signing algorithm ('schnorr' or 'ecdsa')
+   * @param derivationPath - Optional BIP32 derivation path
    * @returns A promise resolving to the signature response
    * @throws {Error} If the message signing fails
    */
@@ -329,6 +351,7 @@ export const OpenSecretContext = createContext<OpenSecretContextType>({
   initiateGoogleAuth: async () => ({ auth_url: "", csrf_token: "" }),
   handleGoogleCallback: async () => { },
   getPrivateKey: api.fetchPrivateKey,
+  getPrivateKeyBytes: api.fetchPrivateKeyBytes,
   getPublicKey: api.fetchPublicKey,
   signMessage: api.signMessage,
   aiCustomFetch: async () => new Response(),
@@ -605,6 +628,7 @@ export function OpenSecretProvider({
     initiateGoogleAuth,
     handleGoogleCallback,
     getPrivateKey: api.fetchPrivateKey,
+    getPrivateKeyBytes: api.fetchPrivateKeyBytes,
     getPublicKey: api.fetchPublicKey,
     signMessage: api.signMessage,
     aiCustomFetch: aiCustomFetch || (async () => new Response()),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for specifying derivation paths in cryptographic operations.
  - Introduced a method to retrieve private key bytes.
  - Enhanced functionality for key management and message signing.
  - New UI elements for inputting derivation paths and retrieving corresponding keys.

- **Improvements**
  - Updated method signatures for `getPublicKey`, `signMessage`, and `getPrivateKey` to include optional derivation paths.
  - Improved documentation for key retrieval methods and added details on common derivation paths.

- **Bug Fixes**
  - Clarified return types for cryptographic methods.

These updates provide more granular control over cryptographic key operations, allowing developers to work with specific key derivation paths more effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->