### PR TITLE
Add apple nonce parameter

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -444,7 +444,7 @@ export async function handleGoogleCallback(
  * 1. Generating a secure state parameter to prevent CSRF attacks
  * 2. Getting an authorization URL from the OpenSecret backend
  * 3. Returning the URL that the client should redirect to
- * 
+ *
  * After the user authenticates with Apple, they will be redirected back to your application.
  * The handleAppleCallback function should be used to complete the authentication process.
  */
@@ -481,7 +481,7 @@ export async function initiateAppleAuth(
  * 1. Validating the state parameter to prevent CSRF attacks
  * 2. Exchanging the authorization code for tokens
  * 3. Creating or authenticating the user account
- * 
+ *
  * This function should be called in your OAuth callback route after
  * the user is redirected back from Apple's authentication page.
  */
@@ -530,6 +530,7 @@ export async function handleAppleCallback(
  * @property email - Optional email address (only provided on first sign-in)
  * @property given_name - Optional user's first name (only provided on first sign-in)
  * @property family_name - Optional user's last name (only provided on first sign-in)
+ * @property nonce - Optional nonce for preventing replay attacks
  */
 export type AppleUser = {
   user_identifier: string; // The user's unique ID from Apple
@@ -537,6 +538,7 @@ export type AppleUser = {
   email?: string; // Optional: only provided on first sign-in
   given_name?: string; // Optional: only provided on first sign-in
   family_name?: string; // Optional: only provided on first sign-in
+  nonce?: string; // Optional: nonce for validating the token
 };
 
 /**
@@ -556,6 +558,11 @@ export type AppleUser = {
  *
  * Note: Email and name information are only provided by Apple on the first
  * authentication. Your backend should store this information for future use.
+ *
+ * The nonce parameter (optional) can be provided as part of the appleUser object.
+ * When using Sign in with Apple, you can generate a nonce on your client and pass
+ * it both to Apple during authentication initiation and to this function for validation.
+ * The backend will verify that the nonce in the JWT matches what was provided.
  */
 export async function handleAppleNativeSignIn(
   appleUser: AppleUser,

--- a/website/api/type-aliases/OpenSecretContextType.md
+++ b/website/api/type-aliases/OpenSecretContextType.md
@@ -502,6 +502,50 @@ The derivation paths determine which key is used to generate the public key:
 
 ***
 
+### handleAppleCallback()
+
+> **handleAppleCallback**: (`code`, `state`, `inviteCode`) => `Promise`\<`void`\>
+
+#### Parameters
+
+##### code
+
+`string`
+
+##### state
+
+`string`
+
+##### inviteCode
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### handleAppleNativeSignIn()
+
+> **handleAppleNativeSignIn**: (`appleUser`, `inviteCode?`) => `Promise`\<`void`\>
+
+#### Parameters
+
+##### appleUser
+
+`api.AppleUser`
+
+##### inviteCode?
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
 ### handleGitHubCallback()
 
 > **handleGitHubCallback**: (`code`, `state`, `inviteCode`) => `Promise`\<`void`\>
@@ -547,6 +591,22 @@ The derivation paths determine which key is used to generate the public key:
 #### Returns
 
 `Promise`\<`void`\>
+
+***
+
+### initiateAppleAuth()
+
+> **initiateAppleAuth**: (`inviteCode`) => `Promise`\<`api.AppleAuthResponse`\>
+
+#### Parameters
+
+##### inviteCode
+
+`string`
+
+#### Returns
+
+`Promise`\<`api.AppleAuthResponse`\>
 
 ***
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Apple Sign-In, including native authentication and OAuth callback handling.
  - Introduced nonce-based security enhancements for native Apple Sign-In to help prevent replay attacks.

- **Documentation**
  - Expanded authentication guide with detailed instructions and examples for secure native Apple Sign-In, including nonce generation and usage.
  - Updated API documentation to include new Apple authentication methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->