### PR TITLE
Fix delete api variable name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/react",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "MIT",
   "type": "module",
   "files": [

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1060,7 +1060,7 @@ export async function decryptData(
  * This function:
  * 1. Requires the user to be logged in (uses authenticatedApiCall)
  * 2. Sends a verification email to the user's email address
- * 3. The email contains a UUID that will be needed for confirmation
+ * 3. The email contains a confirmation code that will be needed for confirmation
  * 4. The client must store the plaintext secret for confirmation
  */
 export async function requestAccountDeletion(hashedSecret: string): Promise<void> {
@@ -1077,20 +1077,23 @@ export async function requestAccountDeletion(hashedSecret: string): Promise<void
 
 /**
  * Confirms and completes the account deletion process
- * @param uuid - The UUID from the verification email
+ * @param confirmationCode - The confirmation code from the verification email
  * @param plaintextSecret - The plaintext secret that was hashed in the request step
  * @returns A promise resolving to void
  *
  * @description
  * This function:
  * 1. Requires the user to be logged in (uses authenticatedApiCall)
- * 2. Verifies both the UUID from email and the secret known only to the client
+ * 2. Verifies both the confirmation code from email and the secret known only to the client
  * 3. Permanently deletes the user account and all associated data
  * 4. After successful deletion, the client should clear all local storage and tokens
  */
-export async function confirmAccountDeletion(uuid: string, plaintextSecret: string): Promise<void> {
+export async function confirmAccountDeletion(
+  confirmationCode: string,
+  plaintextSecret: string
+): Promise<void> {
   const confirmData = {
-    uuid,
+    confirmation_code: confirmationCode,
     plaintext_secret: plaintextSecret
   };
   return authenticatedApiCall<typeof confirmData, void>(

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -204,25 +204,25 @@ export type OpenSecretContextType = {
    * This function:
    * 1. Requires the user to be logged in (uses authenticatedApiCall)
    * 2. Sends a verification email to the user's email address
-   * 3. The email contains a UUID that will be needed for confirmation
+   * 3. The email contains a confirmation code that will be needed for confirmation
    * 4. The client must store the plaintext secret for confirmation
    */
   requestAccountDeletion: (hashedSecret: string) => Promise<void>;
 
   /**
    * Confirms and completes the account deletion process
-   * @param uuid - The UUID from the verification email
+   * @param confirmationCode - The confirmation code from the verification email
    * @param plaintextSecret - The plaintext secret that was hashed in the request step
    * @returns A promise resolving to void
    * @throws {Error} If confirmation fails
    *
    * This function:
    * 1. Requires the user to be logged in (uses authenticatedApiCall)
-   * 2. Verifies both the UUID from email and the secret known only to the client
+   * 2. Verifies both the confirmation code from email and the secret known only to the client
    * 3. Permanently deletes the user account and all associated data
    * 4. After successful deletion, the client should clear all local storage and tokens
    */
-  confirmAccountDeletion: (uuid: string, plaintextSecret: string) => Promise<void>;
+  confirmAccountDeletion: (confirmationCode: string, plaintextSecret: string) => Promise<void>;
   initiateGitHubAuth: (inviteCode: string) => Promise<api.GithubAuthResponse>;
   handleGitHubCallback: (code: string, state: string, inviteCode: string) => Promise<void>;
   initiateGoogleAuth: (inviteCode: string) => Promise<api.GoogleAuthResponse>;

--- a/website/docs/guides/authentication.md
+++ b/website/docs/guides/authentication.md
@@ -649,8 +649,8 @@ OpenSecret provides a secure two-step verification process for account deletion,
 
 The process works as follows:
 1. The user requests account deletion, generating a secure client-side secret
-2. OpenSecret sends a verification email with a UUID to the user's email address
-3. The user confirms deletion by providing both the UUID from the email and the original client-side secret
+2. OpenSecret sends a verification email with a confirmation code to the user's email address
+3. The user confirms deletion by providing both the confirmation code from the email and the original client-side secret
 4. The account and all associated data are permanently deleted
 
 To implement account deletion in your application:
@@ -664,7 +664,7 @@ function AccountDeletionFlow() {
   const os = useOpenSecret();
   const [step, setStep] = useState("request"); // 'request' or 'confirm'
   const [secret, setSecret] = useState("");
-  const [uuid, setUuid] = useState("");
+  const [confirmationCode, setConfirmationCode] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
@@ -696,14 +696,14 @@ function AccountDeletionFlow() {
     }
   };
 
-  // Step 2: Confirm the deletion with UUID from email
+  // Step 2: Confirm the deletion with confirmation code from email
   const handleConfirmDeletion = async () => {
     setLoading(true);
     setError("");
 
     try {
-      // Use the UUID from email and the stored secret
-      await os.confirmAccountDeletion(uuid, secret);
+      // Use the confirmation code from email and the stored secret
+      await os.confirmAccountDeletion(confirmationCode, secret);
 
       // Account deleted successfully
       setSuccess(true);
@@ -752,12 +752,12 @@ function AccountDeletionFlow() {
           <input
             type="text"
             placeholder="Enter confirmation code from email"
-            value={uuid}
-            onChange={(e) => setUuid(e.target.value)}
+            value={confirmationCode}
+            onChange={(e) => setConfirmationCode(e.target.value)}
           />
           <button 
             onClick={handleConfirmDeletion}
-            disabled={loading || !uuid}
+            disabled={loading || !confirmationCode}
           >
             {loading ? "Processing..." : "Confirm Deletion"}
           </button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all references in the account deletion flow from "UUID" to "confirmation code" for improved clarity and consistency in user guides and UI descriptions.

- **Refactor**
  - Renamed parameters and variables in the account deletion process to use "confirmation code" instead of "UUID" throughout the application interface and related components.

- **Chores**
  - Incremented the package version to 1.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->