### PR TITLE
refactor: remove unnecessary .clone() calls in Rust SDK

### DIFF
--- a/rust/examples/auth_example.rs
+++ b/rust/examples/auth_example.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
 
             // Try logging in instead
             println!("\n--- User Login ---");
-            match client.login(email.clone(), password, client_id).await {
+            match client.login(email, password, client_id).await {
                 Ok(response) => {
                     println!("✓ Login successful!");
                     println!("  User ID: {}", response.id);

--- a/rust/src/attestation.rs
+++ b/rust/src/attestation.rs
@@ -105,7 +105,7 @@ impl AttestationVerifier {
 
         // Verify nonce
         if let Some(nonce_bytes) = &doc.nonce {
-            let nonce_str = String::from_utf8(nonce_bytes.clone()).map_err(|e| {
+            let nonce_str = String::from_utf8(nonce_bytes.to_vec()).map_err(|e| {
                 Error::AttestationVerificationFailed(format!("Invalid nonce encoding: {}", e))
             })?;
 

--- a/rust/tests/api_integration.rs
+++ b/rust/tests/api_integration.rs
@@ -32,7 +32,7 @@ async fn test_user_profile_api() -> Result<()> {
         Ok(response) => response,
         Err(_) => {
             client
-                .register(test_email.clone(), test_password.clone(), client_id, None)
+                .register(test_email.clone(), test_password, client_id, None)
                 .await?
         }
     };
@@ -361,7 +361,7 @@ async fn test_encryption_decryption() -> Result<()> {
     // Test with BIP-32 derivation path (matching TypeScript test)
     let derivation_path = "m/44'/0'/0'/0/0".to_string();
     let key_options = KeyOptions {
-        private_key_derivation_path: Some(derivation_path.clone()),
+        private_key_derivation_path: Some(derivation_path),
         seed_phrase_derivation_path: None,
     };
     let encrypted_with_path = client
@@ -447,7 +447,7 @@ async fn test_third_party_token() -> Result<()> {
         Ok(response) => response,
         Err(_) => {
             client
-                .register(test_email.clone(), test_password.clone(), client_id, None)
+                .register(test_email, test_password, client_id, None)
                 .await?
         }
     };

--- a/rust/tests/auth_integration.rs
+++ b/rust/tests/auth_integration.rs
@@ -99,7 +99,7 @@ async fn test_login_signup_flow() -> Result<()> {
                     test_email.clone(),
                     test_password.clone(),
                     client_id,
-                    test_name.clone(),
+                    test_name,
                 )
                 .await?;
             println!("✓ User registered with email: {}", test_email);
@@ -127,9 +127,9 @@ async fn test_login_signup_flow() -> Result<()> {
     println!("\nTesting email user re-login...");
     client.perform_attestation_handshake().await?;
     let relogin_response = client
-        .login(test_email.clone(), test_password.clone(), client_id)
+        .login(test_email.clone(), test_password, client_id)
         .await?;
-    assert_eq!(relogin_response.email, Some(test_email.clone()));
+    assert_eq!(relogin_response.email, Some(test_email));
     println!("✓ Email user re-logged in successfully");
 
     println!("\n✅ All auth tests passed!");

--- a/rust/tests/bip85_integration.rs
+++ b/rust/tests/bip85_integration.rs
@@ -213,11 +213,7 @@ async fn test_bip85_message_signing() -> Result<()> {
         private_key_derivation_path: None,
     };
     let bip85_sig = client
-        .sign_message(
-            test_message,
-            SigningAlgorithm::Schnorr,
-            Some(bip85_options.clone()),
-        )
+        .sign_message(test_message, SigningAlgorithm::Schnorr, Some(bip85_options))
         .await?;
     assert!(!bip85_sig.signature.is_empty());
 


### PR DESCRIPTION
- Remove unnecessary clones where variables are moved and not reused
- Replace .clone() with .to_vec() in attestation.rs for better clarity
- Keep necessary clones where values are used multiple times
- Keep necessary clones for thread safety (RwLock guards)

Removed clones:
- examples/auth_example.rs: email and password in login after registration fails
- tests/auth_integration.rs: test_name, final uses of test_email/password
- tests/api_integration.rs: derivation_path, final uses in register calls
- tests/bip85_integration.rs: bip85_options when not reused

🤖 Generated with [Claude Code](https://claude.ai/code)