### PR TITLE
feat: add API key management and authentication to TypeScript and Rus…

### DIFF
--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -273,6 +273,32 @@ pub struct ConfirmAccountDeletionRequest {
     pub plaintext_secret: String,
 }
 
+// API Key Management Types
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKey {
+    pub id: i64,
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyListResponse {
+    pub keys: Vec<ApiKey>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyCreateRequest {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyCreateResponse {
+    pub id: i64,
+    pub key: String, // UUID format, only returned on creation
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+}
+
 // AI/OpenAI API Types
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Model {

--- a/rust/tests/api_keys.rs
+++ b/rust/tests/api_keys.rs
@@ -1,0 +1,246 @@
+use opensecret::{OpenSecretClient, Result};
+use std::env;
+use uuid::Uuid;
+
+async fn setup_test_client() -> Result<OpenSecretClient> {
+    // Load .env.local from OpenSecret-SDK directory
+    let env_path = std::path::Path::new("../.env.local");
+    if env_path.exists() {
+        dotenv::from_path(env_path).ok();
+    } else {
+        // Fallback to standard .env
+        dotenv::dotenv().ok();
+    }
+
+    let api_url = env::var("VITE_OPEN_SECRET_API_URL")
+        .unwrap_or_else(|_| "http://localhost:3000".to_string());
+    let email = env::var("VITE_TEST_EMAIL").expect("VITE_TEST_EMAIL must be set");
+    let password = env::var("VITE_TEST_PASSWORD").expect("VITE_TEST_PASSWORD must be set");
+    let client_id = env::var("VITE_TEST_CLIENT_ID")
+        .expect("VITE_TEST_CLIENT_ID must be set")
+        .parse::<Uuid>()
+        .expect("VITE_TEST_CLIENT_ID must be a valid UUID");
+
+    let client = OpenSecretClient::new(&api_url)?;
+    client.perform_attestation_handshake().await?;
+    client.login(email, password, client_id).await?;
+
+    Ok(client)
+}
+
+#[tokio::test]
+async fn test_create_list_delete_api_key() -> Result<()> {
+    let client = setup_test_client().await?;
+
+    // Create a new API key
+    let key_name = format!("Test Key {}", chrono::Utc::now().timestamp());
+    let created_key = client.create_api_key(key_name.clone()).await?;
+
+    assert_eq!(created_key.name, key_name);
+    assert!(created_key.id > 0);
+    assert!(!created_key.key.is_empty());
+
+    // Verify the key format is a UUID with dashes
+    let uuid_result = Uuid::parse_str(&created_key.key);
+    assert!(uuid_result.is_ok(), "API key should be a valid UUID");
+
+    // List API keys and verify the new key is present
+    let keys = client.list_api_keys().await?;
+    let found_key = keys.iter().find(|k| k.id == created_key.id);
+
+    assert!(found_key.is_some());
+    assert_eq!(found_key.unwrap().name, key_name);
+
+    // Delete the API key
+    client.delete_api_key(created_key.id).await?;
+
+    // Verify the key is deleted
+    let keys_after_delete = client.list_api_keys().await?;
+    let deleted_key = keys_after_delete.iter().find(|k| k.id == created_key.id);
+    assert!(deleted_key.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_api_key_authentication() -> Result<()> {
+    // Load .env.local from OpenSecret-SDK directory
+    let env_path = std::path::Path::new("../.env.local");
+    if env_path.exists() {
+        dotenv::from_path(env_path).ok();
+    } else {
+        dotenv::dotenv().ok();
+    }
+
+    let api_url = env::var("VITE_OPEN_SECRET_API_URL")
+        .unwrap_or_else(|_| "http://localhost:3000".to_string());
+    let email = env::var("VITE_TEST_EMAIL").expect("VITE_TEST_EMAIL must be set");
+    let password = env::var("VITE_TEST_PASSWORD").expect("VITE_TEST_PASSWORD must be set");
+    let client_id = env::var("VITE_TEST_CLIENT_ID")
+        .expect("VITE_TEST_CLIENT_ID must be set")
+        .parse::<Uuid>()
+        .expect("VITE_TEST_CLIENT_ID must be a valid UUID");
+
+    // First create an API key using regular auth
+    let client = OpenSecretClient::new(&api_url)?;
+    client.perform_attestation_handshake().await?;
+    client.login(email, password, client_id).await?;
+
+    let key_name = format!("Test API Key {}", chrono::Utc::now().timestamp());
+    let created_key = client.create_api_key(key_name).await?;
+    let api_key = created_key.key.clone();
+    let api_key_id = created_key.id;
+
+    // Now create a new client with just the API key
+    let api_client = OpenSecretClient::new_with_api_key(&api_url, api_key.clone())?;
+    api_client.perform_attestation_handshake().await?;
+
+    // Test fetching models with API key authentication
+    let models = api_client.get_models().await?;
+    assert!(!models.data.is_empty());
+
+    // Test that the models endpoint works
+    let model_exists = models
+        .data
+        .iter()
+        .any(|m| m.id.contains("llama") || m.id.contains("gpt"));
+    assert!(model_exists, "Should have at least one model available");
+
+    // Clean up: delete the API key
+    client.delete_api_key(api_key_id).await?;
+
+    Ok(())
+}
+
+// Skip non-streaming test since server only supports streaming
+// The streaming test below covers the API key functionality
+
+#[tokio::test]
+async fn test_streaming_chat_with_api_key() -> Result<()> {
+    use futures::StreamExt;
+    use opensecret::{ChatCompletionRequest, ChatMessage};
+
+    // Load .env.local from OpenSecret-SDK directory
+    let env_path = std::path::Path::new("../.env.local");
+    if env_path.exists() {
+        dotenv::from_path(env_path).ok();
+    } else {
+        dotenv::dotenv().ok();
+    }
+
+    let api_url = env::var("VITE_OPEN_SECRET_API_URL")
+        .unwrap_or_else(|_| "http://localhost:3000".to_string());
+    let email = env::var("VITE_TEST_EMAIL").expect("VITE_TEST_EMAIL must be set");
+    let password = env::var("VITE_TEST_PASSWORD").expect("VITE_TEST_PASSWORD must be set");
+    let client_id = env::var("VITE_TEST_CLIENT_ID")
+        .expect("VITE_TEST_CLIENT_ID must be set")
+        .parse::<Uuid>()
+        .expect("VITE_TEST_CLIENT_ID must be a valid UUID");
+
+    // First create an API key using regular auth
+    let client = OpenSecretClient::new(&api_url)?;
+    client.perform_attestation_handshake().await?;
+    client.login(email, password, client_id).await?;
+
+    let key_name = format!("Test Stream Key {}", chrono::Utc::now().timestamp());
+    let created_key = client.create_api_key(key_name).await?;
+    let api_key = created_key.key.clone();
+    let api_key_id = created_key.id;
+
+    // Create a new client with the API key
+    let api_client = OpenSecretClient::new_with_api_key(&api_url, api_key)?;
+    api_client.perform_attestation_handshake().await?;
+
+    // Test streaming chat completion
+    let request = ChatCompletionRequest {
+        model: "ibnzterrell/Meta-Llama-3.3-70B-Instruct-AWQ-INT4".to_string(),
+        messages: vec![ChatMessage {
+            role: "user".to_string(),
+            content: "Please reply with exactly and only the word 'echo'".to_string(),
+        }],
+        temperature: Some(0.1),
+        max_tokens: Some(10),
+        stream: Some(true),
+        stream_options: None,
+    };
+
+    let mut stream = api_client.create_chat_completion_stream(request).await?;
+    let mut full_response = String::new();
+
+    while let Some(chunk_result) = stream.next().await {
+        match chunk_result {
+            Ok(chunk) => {
+                if !chunk.choices.is_empty() {
+                    if let Some(content) = &chunk.choices[0].delta.content {
+                        full_response.push_str(content);
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("Stream error: {}", e);
+                break;
+            }
+        }
+    }
+
+    assert_eq!(full_response.trim().to_lowercase(), "echo");
+
+    // Clean up
+    client.delete_api_key(api_key_id).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_multiple_api_keys() -> Result<()> {
+    let client = setup_test_client().await?;
+    let mut key_ids = Vec::new();
+
+    // Create multiple keys
+    for i in 0..3 {
+        let key_name = format!("Test Key {} - {}", i, chrono::Utc::now().timestamp());
+        let created_key = client.create_api_key(key_name).await?;
+        key_ids.push(created_key.id);
+    }
+
+    // List keys and verify all are present
+    let keys = client.list_api_keys().await?;
+    for id in &key_ids {
+        assert!(keys.iter().any(|k| k.id == *id));
+    }
+
+    // Clean up: delete all created keys
+    for id in key_ids {
+        client.delete_api_key(id).await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_invalid_api_key_fails() -> Result<()> {
+    // Load .env.local from OpenSecret-SDK directory
+    let env_path = std::path::Path::new("../.env.local");
+    if env_path.exists() {
+        dotenv::from_path(env_path).ok();
+    } else {
+        dotenv::dotenv().ok();
+    }
+
+    let api_url = env::var("VITE_OPEN_SECRET_API_URL")
+        .unwrap_or_else(|_| "http://localhost:3000".to_string());
+
+    // Create a client with an invalid API key
+    let invalid_key = "550e8400-e29b-41d4-a716-000000000000".to_string();
+    let api_client = OpenSecretClient::new_with_api_key(&api_url, invalid_key)?;
+    api_client.perform_attestation_handshake().await?;
+
+    // This should fail with authentication error
+    let result = api_client.get_models().await;
+    assert!(result.is_err());
+
+    let error_msg = result.unwrap_err().to_string();
+    assert!(error_msg.contains("401") || error_msg.contains("Unauthorized"));
+
+    Ok(())
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,8 +8,17 @@ export type {
   DocumentResponse,
   DocumentUploadInitResponse,
   DocumentStatusRequest,
-  DocumentStatusResponse
+  DocumentStatusResponse,
+  ApiKey,
+  ApiKeyCreateResponse,
+  ApiKeyListResponse
 } from "./api";
+
+// Export API key management functions
+export { createApiKey, listApiKeys, deleteApiKey } from "./api";
+
+// Export AI customization options
+export { createCustomFetch, type CustomFetchOptions } from "./ai";
 
 // Re-export Model type from OpenAI for convenience
 export type { Model } from "openai/resources/models.js";

--- a/src/lib/test/integration/apiKeys.test.ts
+++ b/src/lib/test/integration/apiKeys.test.ts
@@ -1,0 +1,199 @@
+import { expect, test, describe, beforeAll, afterAll } from "bun:test";
+import {
+  fetchLogin,
+  createApiKey,
+  listApiKeys,
+  deleteApiKey,
+  fetchModels
+} from "../../api";
+import { createCustomFetch } from "../../ai";
+import OpenAI from "openai";
+
+const TEST_EMAIL = process.env.VITE_TEST_EMAIL;
+const TEST_PASSWORD = process.env.VITE_TEST_PASSWORD;
+const TEST_CLIENT_ID = process.env.VITE_TEST_CLIENT_ID;
+const API_URL = process.env.VITE_OPEN_SECRET_API_URL;
+
+if (!TEST_EMAIL || !TEST_PASSWORD || !TEST_CLIENT_ID || !API_URL) {
+  throw new Error("Test credentials must be set in .env.local");
+}
+
+async function setupTestUser() {
+  const { access_token, refresh_token } = await fetchLogin(
+    TEST_EMAIL!,
+    TEST_PASSWORD!,
+    TEST_CLIENT_ID!
+  );
+  window.localStorage.setItem("access_token", access_token);
+  window.localStorage.setItem("refresh_token", refresh_token);
+}
+
+describe("API Key Management", () => {
+  beforeAll(async () => {
+    await setupTestUser();
+  });
+
+  test("Create, list, and delete API key", async () => {
+    // Create a new API key
+    const keyName = `Test Key ${Date.now()}`;
+    const createdKey = await createApiKey(keyName);
+    
+    expect(createdKey.name).toBe(keyName);
+    expect(createdKey.id).toBeGreaterThan(0);
+    expect(createdKey.key).toBeDefined();
+    expect(createdKey.created_at).toBeDefined();
+    
+    // Verify the key format is a UUID with dashes
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    expect(createdKey.key).toMatch(uuidRegex);
+    
+    // List API keys and verify the new key is present
+    const keys = await listApiKeys();
+    console.log("Listed keys:", keys);
+    
+    // Check if keys is an array
+    expect(Array.isArray(keys)).toBe(true);
+    const foundKey = keys.find(k => k.id === createdKey.id);
+    
+    expect(foundKey).toBeDefined();
+    expect(foundKey!.name).toBe(keyName);
+    expect(foundKey!.created_at).toBe(createdKey.created_at);
+    // The key field should NOT be present in the list response
+    expect((foundKey as any).key).toBeUndefined();
+    
+    // Delete the API key
+    await deleteApiKey(createdKey.id);
+    
+    // Verify the key is deleted
+    const keysAfterDelete = await listApiKeys();
+    const deletedKey = keysAfterDelete.find(k => k.id === createdKey.id);
+    expect(deletedKey).toBeUndefined();
+  });
+
+  test("Create multiple API keys", async () => {
+    const keyIds: number[] = [];
+    
+    try {
+      // Create multiple keys
+      for (let i = 0; i < 3; i++) {
+        const key = await createApiKey(`Test Key ${i} - ${Date.now()}`);
+        keyIds.push(key.id);
+      }
+      
+      // List keys and verify all are present
+      const keys = await listApiKeys();
+      for (const id of keyIds) {
+        expect(keys.some(k => k.id === id)).toBe(true);
+      }
+    } finally {
+      // Clean up: delete all created keys
+      for (const id of keyIds) {
+        try {
+          await deleteApiKey(id);
+        } catch (error) {
+          console.warn(`Failed to delete key ${id}:`, error);
+        }
+      }
+    }
+  });
+});
+
+describe("API Key Authentication with OpenAI", () => {
+  let testApiKey: string;
+  let testApiKeyId: number;
+
+  beforeAll(async () => {
+    await setupTestUser();
+    
+    // Create an API key for testing
+    const createdKey = await createApiKey(`OpenAI Test Key ${Date.now()}`);
+    testApiKey = createdKey.key;
+    testApiKeyId = createdKey.id;
+  });
+
+  test("OpenAI custom fetch with API key makes a simple request", async () => {
+    const openai = new OpenAI({
+      baseURL: `${API_URL}/v1/`,
+      dangerouslyAllowBrowser: true,
+      apiKey: testApiKey, // Use the API key directly
+      defaultHeaders: {
+        "Accept-Encoding": "identity"
+      },
+      fetch: createCustomFetch({ apiKey: testApiKey })
+    });
+
+    const model = "ibnzterrell/Meta-Llama-3.3-70B-Instruct-AWQ-INT4";
+    const messages = [
+      { role: "user" as const, content: 'please reply with exactly and only the word "echo"' }
+    ];
+
+    const stream = openai.beta.chat.completions.stream({
+      model,
+      messages,
+      stream: true
+    });
+
+    let fullResponse = "";
+
+    for await (const chunk of stream) {
+      const content = chunk.choices[0]?.delta?.content || "";
+      fullResponse += content;
+    }
+
+    await stream.finalChatCompletion();
+
+    expect(fullResponse.trim()).toBe("echo");
+  });
+
+  test("Fetch models with API key authentication", async () => {
+    // Test that fetchModels works with API key
+    const models = await fetchModels(testApiKey);
+    
+    expect(Array.isArray(models)).toBe(true);
+    expect(models.length).toBeGreaterThan(0);
+    
+    // Verify each model has required fields
+    const firstModel = models[0];
+    expect(firstModel.id).toBeDefined();
+    expect(firstModel.object).toBe("model");
+  });
+
+  test("API key authentication fails with invalid key", async () => {
+    const invalidApiKey = "550e8400-e29b-41d4-a716-000000000000"; // Invalid UUID
+    
+    const customFetch = createCustomFetch({ apiKey: invalidApiKey });
+    
+    try {
+      const response = await customFetch(`${API_URL}/v1/models`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+      
+      // Should get 401 Unauthorized
+      expect(response.status).toBe(401);
+    } catch (error) {
+      // If it throws before the response, that's also acceptable
+      expect(error).toBeDefined();
+    }
+  });
+
+  test("JWT auth still works alongside API key support", async () => {
+    // Test that the original JWT-based auth still works
+    const models = await fetchModels();
+    expect(Array.isArray(models)).toBe(true);
+    expect(models.length).toBeGreaterThan(0);
+  });
+
+  // Clean up after all tests
+  afterAll(async () => {
+    if (testApiKeyId) {
+      try {
+        await deleteApiKey(testApiKeyId);
+      } catch (error) {
+        console.warn("Failed to delete test API key:", error);
+      }
+    }
+  });
+});


### PR DESCRIPTION
…t SDKs

This commit implements API key functionality for both SDKs:

TypeScript SDK:
- Add API key CRUD operations (create, list, delete) with encrypted API wrapper
- Enable API key authentication for OpenAI endpoints (/v1/models and /v1/chat/completions)
- Add CustomFetchOptions interface to support API key in createCustomFetch
- Add openAiAuthenticatedApiCall function for OpenAI-specific endpoints
- Export new API key types and functions from index.ts
- Add comprehensive test suite for API key management and authentication

Rust SDK:
- Add API key types (ApiKey, ApiKeyCreateResponse, ApiKeyListResponse)
- Implement API key CRUD operations in Client
- Add API key storage and authentication support in Session
- Enable dual authentication (JWT and API key) for OpenAI endpoints
- Add comprehensive test suite covering all API key functionality

Both implementations:
- Maintain full backward compatibility with existing JWT authentication
- API keys are UUID format with dashes
- Keys are only returned once during creation (not in list operations)
- Only OpenAI endpoints accept API key authentication
- All other endpoints continue to use JWT authentication only

Testing:
- TypeScript: 19/19 tests passing
- Rust: 49/49 tests passing
- No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)