### PR TITLE
feat: make ChatMessage content field flexible to support multiple for…

### DIFF
--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use uuid::Uuid;
 
 // Attestation & Key Exchange Types
@@ -322,7 +323,8 @@ pub struct ModelsResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: String,
-    pub content: String,
+    #[serde(default)]
+    pub content: Value, // Now accepts both string and array formats
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -393,5 +395,5 @@ pub struct ChatMessageDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<String>,
+    pub content: Option<Value>, // Also update delta to accept flexible content
 }

--- a/rust/tests/ai_integration.rs
+++ b/rust/tests/ai_integration.rs
@@ -77,7 +77,7 @@ async fn test_chat_completion_streaming() {
         model: "ibnzterrell/Meta-Llama-3.3-70B-Instruct-AWQ-INT4".to_string(),
         messages: vec![ChatMessage {
             role: "user".to_string(),
-            content: r#"please reply with exactly and only the word "echo""#.to_string(),
+            content: serde_json::json!(r#"please reply with exactly and only the word "echo""#),
         }],
         temperature: Some(0.0),
         max_tokens: Some(10),
@@ -103,8 +103,8 @@ async fn test_chat_completion_streaming() {
         assert_eq!(chunk.object, "chat.completion.chunk");
 
         if !chunk.choices.is_empty() {
-            if let Some(content) = &chunk.choices[0].delta.content {
-                full_response.push_str(content);
+            if let Some(serde_json::Value::String(s)) = &chunk.choices[0].delta.content {
+                full_response.push_str(s);
             }
         }
 
@@ -133,12 +133,13 @@ async fn test_chat_completion_with_system_message() {
         messages: vec![
             ChatMessage {
                 role: "system".to_string(),
-                content: "You are a helpful assistant that always responds with exactly one word."
-                    .to_string(),
+                content: serde_json::json!(
+                    "You are a helpful assistant that always responds with exactly one word."
+                ),
             },
             ChatMessage {
                 role: "user".to_string(),
-                content: "What is 2+2? Answer in one word.".to_string(),
+                content: serde_json::json!("What is 2+2? Answer in one word."),
             },
         ],
         temperature: Some(0.0),
@@ -156,8 +157,8 @@ async fn test_chat_completion_with_system_message() {
     while let Some(result) = stream.next().await {
         let chunk = result.expect("Failed to get chunk");
         if !chunk.choices.is_empty() {
-            if let Some(content) = &chunk.choices[0].delta.content {
-                full_response.push_str(content);
+            if let Some(serde_json::Value::String(s)) = &chunk.choices[0].delta.content {
+                full_response.push_str(s);
             }
         }
     }
@@ -209,7 +210,7 @@ async fn test_guest_user_cannot_use_ai() {
         model: "some-model".to_string(),
         messages: vec![ChatMessage {
             role: "user".to_string(),
-            content: "test".to_string(),
+            content: serde_json::json!("test"),
         }],
         temperature: None,
         max_tokens: None,

--- a/rust/tests/api_keys.rs
+++ b/rust/tests/api_keys.rs
@@ -138,7 +138,7 @@ async fn test_streaming_chat_with_api_key() -> Result<()> {
         model: "ibnzterrell/Meta-Llama-3.3-70B-Instruct-AWQ-INT4".to_string(),
         messages: vec![ChatMessage {
             role: "user".to_string(),
-            content: "Please reply with exactly and only the word 'echo'".to_string(),
+            content: serde_json::json!("Please reply with exactly and only the word 'echo'"),
         }],
         temperature: Some(0.1),
         max_tokens: Some(10),
@@ -153,8 +153,8 @@ async fn test_streaming_chat_with_api_key() -> Result<()> {
         match chunk_result {
             Ok(chunk) => {
                 if !chunk.choices.is_empty() {
-                    if let Some(content) = &chunk.choices[0].delta.content {
-                        full_response.push_str(content);
+                    if let Some(serde_json::Value::String(s)) = &chunk.choices[0].delta.content {
+                        full_response.push_str(s);
                     }
                 }
             }


### PR DESCRIPTION
…mats

Change content field from String to serde_json::Value to allow passthrough of both string and structured content formats (arrays, objects). This enables support for multimodal messages while maintaining backward compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chat messages now accept structured JSON content (not just plain text), enabling arrays and richer payloads.
  - Streaming deltas now align with JSON content, supporting incremental updates that may include non-string values.
  - Messages without content are handled gracefully with sensible defaults, improving robustness for varied client payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->