### PR TITLE
feat: add Whisper transcription API to TypeScript SDK

### DIFF
--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -731,14 +731,14 @@ export const OpenSecretContext = createContext<OpenSecretContextType>({
   generateThirdPartyToken: async () => ({ token: "" }),
   encryptData: api.encryptData,
   decryptData: api.decryptData,
-  fetchModels: api.fetchModels,
+  fetchModels: () => api.fetchModels(undefined),
   uploadDocument: api.uploadDocument,
   checkDocumentStatus: api.checkDocumentStatus,
   uploadDocumentWithPolling: api.uploadDocumentWithPolling,
   createApiKey: api.createApiKey,
   listApiKeys: api.listApiKeys,
   deleteApiKey: api.deleteApiKey,
-  transcribeAudio: api.transcribeAudio
+  transcribeAudio: (file, options) => api.transcribeAudio(file, options)
 });
 
 /**
@@ -1132,14 +1132,14 @@ export function OpenSecretProvider({
     generateThirdPartyToken: api.generateThirdPartyToken,
     encryptData: api.encryptData,
     decryptData: api.decryptData,
-    fetchModels: api.fetchModels,
+    fetchModels: () => api.fetchModels(apiKey),
     uploadDocument: api.uploadDocument,
     checkDocumentStatus: api.checkDocumentStatus,
     uploadDocumentWithPolling: api.uploadDocumentWithPolling,
     createApiKey: api.createApiKey,
     listApiKeys: api.listApiKeys,
     deleteApiKey: api.deleteApiKey,
-    transcribeAudio: api.transcribeAudio
+    transcribeAudio: (file, options) => api.transcribeAudio(file, { ...options, apiKey })
   };
 
   return <OpenSecretContext.Provider value={value}>{children}</OpenSecretContext.Provider>;

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -640,6 +640,37 @@ export type OpenSecretContextType = {
    * Names are unique per user, so this uniquely identifies the key to delete.
    */
   deleteApiKey: typeof api.deleteApiKey;
+
+  /**
+   * Transcribes audio using the Whisper API
+   * @param file - The audio file to transcribe (File or Blob object)
+   * @param options - Optional transcription parameters
+   * @returns A promise resolving to the transcription response
+   * @throws {Error} If the user is not authenticated or transcription fails
+   * 
+   * @description
+   * This function transcribes audio using OpenAI's Whisper model via the encrypted API.
+   * 
+   * Options:
+   * - model: Model to use (default: "whisper-large-v3", routes to Tinfoil's whisper-large-v3-turbo)
+   * - language: Optional ISO-639-1 language code (e.g., "en", "es", "fr")
+   * - prompt: Optional context or previous segment transcript
+   * - response_format: Format of the response (default: "json")
+   * - temperature: Sampling temperature between 0 and 1 (default: 0.0)
+   * 
+   * Supported audio formats: MP3, WAV, MP4, M4A, FLAC, OGG, WEBM
+   * 
+   * Example usage:
+   * ```typescript
+   * const audioFile = new File([audioData], "recording.mp3", { type: "audio/mpeg" });
+   * const result = await context.transcribeAudio(audioFile, {
+   *   language: "en",
+   *   prompt: "This is a technical discussion about AI"
+   * });
+   * console.log(result.text);
+   * ```
+   */
+  transcribeAudio: typeof api.transcribeAudio;
 };
 
 export const OpenSecretContext = createContext<OpenSecretContextType>({
@@ -706,7 +737,8 @@ export const OpenSecretContext = createContext<OpenSecretContextType>({
   uploadDocumentWithPolling: api.uploadDocumentWithPolling,
   createApiKey: api.createApiKey,
   listApiKeys: api.listApiKeys,
-  deleteApiKey: api.deleteApiKey
+  deleteApiKey: api.deleteApiKey,
+  transcribeAudio: api.transcribeAudio
 });
 
 /**
@@ -1106,7 +1138,8 @@ export function OpenSecretProvider({
     uploadDocumentWithPolling: api.uploadDocumentWithPolling,
     createApiKey: api.createApiKey,
     listApiKeys: api.listApiKeys,
-    deleteApiKey: api.deleteApiKey
+    deleteApiKey: api.deleteApiKey,
+    transcribeAudio: api.transcribeAudio
   };
 
   return <OpenSecretContext.Provider value={value}>{children}</OpenSecretContext.Provider>;


### PR DESCRIPTION
- Add transcribeAudio function in api.ts with full encryption support
- Export transcribeAudio from OpenSecret context in main.tsx
- Support optional parameters: model, language, prompt, response_format, temperature
- Add test that chains TTS → Whisper to verify functionality
- Uses whisper-large-v3 model (routes to Tinfoil's whisper-large-v3-turbo)
- Supports all common audio formats (MP3, WAV, MP4, M4A, FLAC, OGG, WEBM)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added audio transcription via Whisper: upload a File/Blob and receive text (default model provided).
  - Exposed transcribeAudio on the app context so components can call transcription directly.
  - Supports optional API-key override for transcription requests.

- Documentation
  - Added usage guidance, parameter details, defaults, supported formats, and error notes for transcribeAudio.

- Tests
  - Added an integration test validating end-to-end audio transcription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->