### PR TITLE
feat: add tool calling types to Rust SDK

### DIFF
--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -62,6 +62,7 @@ pub fn perform_static_key_exchange(
     secret.diffie_hellman(their_public)
 }
 
+#[allow(deprecated)]
 pub fn encrypt_data(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>> {
     let cipher = ChaCha20Poly1305::new_from_slice(key)
         .map_err(|e| Error::Crypto(format!("Failed to create cipher: {}", e)))?;
@@ -81,6 +82,7 @@ pub fn encrypt_data(key: &[u8; 32], plaintext: &[u8]) -> Result<Vec<u8>> {
     Ok(result)
 }
 
+#[allow(deprecated)]
 pub fn decrypt_data(key: &[u8; 32], encrypted_data: &[u8]) -> Result<Vec<u8>> {
     if encrypted_data.len() < 12 {
         return Err(Error::Decryption("Encrypted data too short".to_string()));
@@ -97,6 +99,7 @@ pub fn decrypt_data(key: &[u8; 32], encrypted_data: &[u8]) -> Result<Vec<u8>> {
         .map_err(|e| Error::Decryption(format!("Decryption failed: {}", e)))
 }
 
+#[allow(deprecated)]
 pub fn decrypt_session_key(shared_secret: &SharedSecret, encrypted_data: &str) -> Result<[u8; 32]> {
     let encrypted = BASE64.decode(encrypted_data)?;
 

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -320,11 +320,43 @@ pub struct ModelsResponse {
     pub data: Vec<Model>,
 }
 
+// Tool Calling Types
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tool {
+    #[serde(rename = "type")]
+    pub tool_type: String,
+    pub function: Function,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Function {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub parameters: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub tool_type: String,
+    pub function: FunctionCall,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionCall {
+    pub name: String,
+    pub arguments: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: String,
     #[serde(default)]
     pub content: Value, // Now accepts both string and array formats
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -339,6 +371,10 @@ pub struct ChatCompletionRequest {
     pub stream: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_options: Option<StreamOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<Tool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -396,4 +432,6 @@ pub struct ChatMessageDelta {
     pub role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<Value>, // Also update delta to accept flexible content
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
 }

--- a/rust/tests/ai_integration.rs
+++ b/rust/tests/ai_integration.rs
@@ -78,11 +78,14 @@ async fn test_chat_completion_streaming() {
         messages: vec![ChatMessage {
             role: "user".to_string(),
             content: serde_json::json!(r#"please reply with exactly and only the word "echo""#),
+            tool_calls: None,
         }],
         temperature: Some(0.0),
         max_tokens: Some(10),
         stream: Some(true),
         stream_options: None,
+        tools: None,
+        tool_choice: None,
     };
 
     let mut stream = client
@@ -136,16 +139,20 @@ async fn test_chat_completion_with_system_message() {
                 content: serde_json::json!(
                     "You are a helpful assistant that always responds with exactly one word."
                 ),
+                tool_calls: None,
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: serde_json::json!("What is 2+2? Answer in one word."),
+                tool_calls: None,
             },
         ],
         temperature: Some(0.0),
         max_tokens: Some(10),
         stream: Some(true), // Server only supports streaming
         stream_options: None,
+        tools: None,
+        tool_choice: None,
     };
 
     let mut stream = client
@@ -211,11 +218,14 @@ async fn test_guest_user_cannot_use_ai() {
         messages: vec![ChatMessage {
             role: "user".to_string(),
             content: serde_json::json!("test"),
+            tool_calls: None,
         }],
         temperature: None,
         max_tokens: None,
         stream: Some(true), // Server only supports streaming
         stream_options: None,
+        tools: None,
+        tool_choice: None,
     };
 
     let completion_result = client.create_chat_completion(request).await;

--- a/rust/tests/api_keys.rs
+++ b/rust/tests/api_keys.rs
@@ -139,11 +139,14 @@ async fn test_streaming_chat_with_api_key() -> Result<()> {
         messages: vec![ChatMessage {
             role: "user".to_string(),
             content: serde_json::json!("Please reply with exactly and only the word 'echo'"),
+            tool_calls: None,
         }],
         temperature: Some(0.1),
         max_tokens: Some(10),
         stream: Some(true),
         stream_options: None,
+        tools: None,
+        tool_choice: None,
     };
 
     let mut stream = api_client.create_chat_completion_stream(request).await?;


### PR DESCRIPTION
Adds support for OpenAI tool calling (function calling) to the Rust SDK by adding the necessary types:

- Tool, Function, ToolCall, FunctionCall types
- tools, tool_choice fields on ChatCompletionRequest
- tool_calls field on ChatMessage and ChatMessageDelta

These types enable function calling in the Rust client, matching the capabilities already available in the TypeScript SDK through the OpenAI library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tool/function calling in conversations, allowing assistants to invoke functions and return structured tool responses.
* **Tests**
  * Test suites updated to include the new optional tool-related fields (set to None by default) without changing behavior.
* **Chores**
  * Suppressed deprecation warnings for several crypto-related public APIs to reduce build noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->