### PR TITLE
feat: implement delete all conversations endpoint in Rust and TS SDKs

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -937,6 +937,12 @@ impl OpenSecretClient {
 
     // AI/OpenAI API Methods
 
+    /// Deletes all conversations
+    pub async fn delete_conversations(&self) -> Result<ConversationsDeleteResponse> {
+        self.encrypted_api_call("/v1/conversations", "DELETE", None::<()>)
+            .await
+    }
+
     /// Fetches available AI models
     pub async fn get_models(&self) -> Result<ModelsResponse> {
         self.encrypted_openai_call("/v1/models", "GET", None::<()>)

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -298,6 +298,12 @@ pub struct ApiKeyCreateResponse {
     pub created_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationsDeleteResponse {
+    pub object: String,
+    pub deleted: bool,
+}
+
 // AI/OpenAI API Types
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Model {

--- a/rust/tests/ai_integration.rs
+++ b/rust/tests/ai_integration.rs
@@ -176,6 +176,37 @@ async fn test_chat_completion_with_system_message() {
 }
 
 #[tokio::test]
+async fn test_delete_conversations() {
+    let client = setup_authenticated_client()
+        .await
+        .expect("Failed to setup client");
+
+    // 1. Create a couple of conversations first
+    // Note: Currently the SDK doesn't have create_conversation exposed directly on client struct
+    // but create_chat_completion implicitly creates or uses conversation if we could access it.
+    // However, based on the TS SDK, there's explicit conversation management.
+    // The Rust SDK seems to be catching up.
+    // For now, we'll just call delete_conversations and ensure it returns success,
+    // which covers the API contract even if list is empty.
+
+    // Ideally we would create conversations here, but the Rust SDK client wrapper
+    // doesn't seem to expose explicit conversation creation methods yet based on my earlier grep.
+    // It only has what I added: delete_conversations.
+    // The TS SDK had `createConversation`.
+
+    // Let's verify what methods OpenSecretClient actually has.
+    // I only added `delete_conversations`.
+
+    let result = client
+        .delete_conversations()
+        .await
+        .expect("Failed to delete conversations");
+
+    assert_eq!(result.object, "list.deleted");
+    assert!(result.deleted);
+}
+
+#[tokio::test]
 async fn test_guest_user_cannot_use_ai() {
     // Load .env.local from OpenSecret-SDK directory
     let env_path = std::path::Path::new("../.env.local");

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -6,17 +6,16 @@ export interface CustomFetchOptions {
   apiKey?: string; // Optional API key to use instead of JWT token
 }
 
-export function createCustomFetch(options?: CustomFetchOptions): (
-  input: string | URL | Request,
-  init?: RequestInit
-) => Promise<Response> {
+export function createCustomFetch(
+  options?: CustomFetchOptions
+): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
   return async (requestUrl: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const getAuthHeader = () => {
       // If an API key is provided, use it instead of JWT token
       if (options?.apiKey) {
         return `Bearer ${options.apiKey}`;
       }
-      
+
       // Otherwise, use the standard JWT token
       const currentAccessToken = window.localStorage.getItem("access_token");
       if (!currentAccessToken) {
@@ -164,11 +163,11 @@ export function createCustomFetch(options?: CustomFetchOptions): (
 
               // Return as a binary response with the proper content type
               const headersOut = new Headers(response.headers);
-              headersOut.set('content-type', decryptedData.content_type);
+              headersOut.set("content-type", decryptedData.content_type);
               // Remove headers that are no longer valid for the decoded response
-              headersOut.delete('content-encoding');
-              headersOut.delete('content-length');
-              headersOut.delete('transfer-encoding');
+              headersOut.delete("content-encoding");
+              headersOut.delete("content-length");
+              headersOut.delete("transfer-encoding");
 
               return new Response(bytes, {
                 headers: headersOut,

--- a/src/lib/encryptedApi.ts
+++ b/src/lib/encryptedApi.ts
@@ -88,24 +88,18 @@ export async function openAiAuthenticatedApiCall<T, U>(
   if (!apiKey) {
     return authenticatedApiCall<T, U>(url, method, data, errorMessage);
   }
-  
+
   // For API key auth, call internal encrypted API directly (no refresh logic)
-  const response = await internalEncryptedApiCall<T, U>(
-    url,
-    method,
-    data,
-    apiKey,
-    errorMessage
-  );
-  
+  const response = await internalEncryptedApiCall<T, U>(url, method, data, apiKey, errorMessage);
+
   if (response.error) {
     throw new Error(response.error);
   }
-  
+
   if (!response.data) {
     throw new Error(errorMessage || `Request to ${url} failed`);
   }
-  
+
   return response.data;
 }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -24,7 +24,8 @@ export type {
   ConversationUpdateRequest,
   ConversationItemsResponse,
   ConversationsListResponse,
-  ConversationDeleteResponse
+  ConversationDeleteResponse,
+  ConversationsDeleteResponse
 } from "./api";
 
 // Export API key management functions

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -647,18 +647,18 @@ export type OpenSecretContextType = {
    * @param options - Optional transcription parameters
    * @returns A promise resolving to the transcription response
    * @throws {Error} If the user is not authenticated or transcription fails
-   * 
+   *
    * @description
    * This function transcribes audio using OpenAI's Whisper model via the encrypted API.
-   * 
+   *
    * Options:
    * - model: Model to use (default: "whisper-large-v3", routes to Tinfoil's whisper-large-v3-turbo)
    * - language: Optional ISO-639-1 language code (e.g., "en", "es", "fr")
    * - prompt: Optional context or previous segment transcript
    * - temperature: Sampling temperature between 0 and 1 (default: 0.0)
-   * 
+   *
    * Supported audio formats: MP3, WAV, MP4, M4A, FLAC, OGG, WEBM
-   * 
+   *
    * Example usage:
    * ```typescript
    * const audioFile = new File([audioData], "recording.mp3", { type: "audio/mpeg" });
@@ -752,7 +752,17 @@ export type OpenSecretContextType = {
    * - openai.conversations.items.list()
    * - openai.conversations.items.retrieve()
    */
-  listConversations: (params?: { limit?: number; after?: string; before?: string }) => Promise<api.ConversationsListResponse>;
+  listConversations: (params?: {
+    limit?: number;
+    after?: string;
+    before?: string;
+  }) => Promise<api.ConversationsListResponse>;
+
+  /**
+   * Deletes all conversations
+   * @returns A promise resolving to deletion confirmation
+   */
+  deleteConversations: typeof api.deleteConversations;
 
   /**
    * Creates a new instruction
@@ -898,6 +908,7 @@ export const OpenSecretContext = createContext<OpenSecretContextType>({
   deleteResponse: api.deleteResponse,
   createResponse: api.createResponse,
   listConversations: api.listConversations,
+  deleteConversations: api.deleteConversations,
   createInstruction: api.createInstruction,
   listInstructions: api.listInstructions,
   getInstruction: api.getInstruction,
@@ -1311,6 +1322,7 @@ export function OpenSecretProvider({
     deleteResponse: api.deleteResponse,
     createResponse: api.createResponse,
     listConversations: api.listConversations,
+    deleteConversations: api.deleteConversations,
     createInstruction: api.createInstruction,
     listInstructions: api.listInstructions,
     getInstruction: api.getInstruction,

--- a/src/lib/test/integration/api.test.ts
+++ b/src/lib/test/integration/api.test.ts
@@ -332,7 +332,9 @@ test("Instructions API - Create, List, Get, Update, Delete", async () => {
   });
   expect(updatedInstruction.id).toBe(instruction1.id);
   expect(updatedInstruction.name).toBe("Updated Test Instruction 1");
-  expect(updatedInstruction.prompt).toBe("You are a very helpful assistant that provides detailed explanations.");
+  expect(updatedInstruction.prompt).toBe(
+    "You are a very helpful assistant that provides detailed explanations."
+  );
   expect(updatedInstruction.prompt_tokens).toBeGreaterThan(0);
 
   // Set as default

--- a/src/lib/test/integration/apiKeys.test.ts
+++ b/src/lib/test/integration/apiKeys.test.ts
@@ -1,11 +1,5 @@
 import { expect, test, describe, beforeAll, afterAll } from "bun:test";
-import {
-  fetchLogin,
-  createApiKey,
-  listApiKeys,
-  deleteApiKey,
-  fetchModels
-} from "../../api";
+import { fetchLogin, createApiKey, listApiKeys, deleteApiKey, fetchModels } from "../../api";
 import { createCustomFetch } from "../../ai";
 import OpenAI from "openai";
 
@@ -37,41 +31,41 @@ describe("API Key Management", () => {
     // Create a new API key
     const keyName = `Test Key ${Date.now()}`;
     const createdKey = await createApiKey(keyName);
-    
+
     expect(createdKey.name).toBe(keyName);
     expect(createdKey.key).toBeDefined();
     expect(createdKey.created_at).toBeDefined();
-    
+
     // Verify the key format is a UUID with dashes
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     expect(createdKey.key).toMatch(uuidRegex);
-    
+
     // List API keys and verify the new key is present
     const response = await listApiKeys();
     console.log("Listed response:", response);
-    
+
     // Check if keys is an array
     expect(Array.isArray(response.keys)).toBe(true);
-    const foundKey = response.keys.find(k => k.name === createdKey.name);
-    
+    const foundKey = response.keys.find((k) => k.name === createdKey.name);
+
     expect(foundKey).toBeDefined();
     expect(foundKey!.name).toBe(keyName);
     expect(foundKey!.created_at).toBe(createdKey.created_at);
     // The key field should NOT be present in the list response
     expect((foundKey as any).key).toBeUndefined();
-    
+
     // Delete the API key
     await deleteApiKey(createdKey.name);
-    
+
     // Verify the key is deleted
     const responseAfterDelete = await listApiKeys();
-    const deletedKey = responseAfterDelete.keys.find(k => k.name === createdKey.name);
+    const deletedKey = responseAfterDelete.keys.find((k) => k.name === createdKey.name);
     expect(deletedKey).toBeUndefined();
   });
 
   test("Create multiple API keys", async () => {
     const keyNames: string[] = [];
-    
+
     try {
       // Create multiple keys
       for (let i = 0; i < 3; i++) {
@@ -79,11 +73,11 @@ describe("API Key Management", () => {
         const key = await createApiKey(keyName);
         keyNames.push(key.name);
       }
-      
+
       // List keys and verify all are present
       const response = await listApiKeys();
       for (const name of keyNames) {
-        expect(response.keys.some(k => k.name === name)).toBe(true);
+        expect(response.keys.some((k) => k.name === name)).toBe(true);
       }
     } finally {
       // Clean up: delete all created keys
@@ -104,7 +98,7 @@ describe("API Key Authentication with OpenAI", () => {
 
   beforeAll(async () => {
     await setupTestUser();
-    
+
     // Create an API key for testing
     testApiKeyName = `OpenAI Test Key ${Date.now()}`;
     const createdKey = await createApiKey(testApiKeyName);
@@ -149,10 +143,10 @@ describe("API Key Authentication with OpenAI", () => {
   test("Fetch models with API key authentication", async () => {
     // Test that fetchModels works with API key
     const models = await fetchModels(testApiKey);
-    
+
     expect(Array.isArray(models)).toBe(true);
     expect(models.length).toBeGreaterThan(0);
-    
+
     // Verify each model has required fields
     const firstModel = models[0];
     expect(firstModel.id).toBeDefined();
@@ -161,9 +155,9 @@ describe("API Key Authentication with OpenAI", () => {
 
   test("API key authentication fails with invalid key", async () => {
     const invalidApiKey = "550e8400-e29b-41d4-a716-000000000000"; // Invalid UUID
-    
+
     const customFetch = createCustomFetch({ apiKey: invalidApiKey });
-    
+
     try {
       const response = await customFetch(`${API_URL}/v1/models`, {
         method: "GET",
@@ -171,7 +165,7 @@ describe("API Key Authentication with OpenAI", () => {
           "Content-Type": "application/json"
         }
       });
-      
+
       // Should get 401 Unauthorized
       expect(response.status).toBe(401);
     } catch (error) {


### PR DESCRIPTION
This PR implements the `DELETE /v1/conversations` endpoint in both the Rust and TypeScript SDKs.

**Changes:**
- **Rust SDK:** Added `delete_conversations` method to `OpenSecretClient` and `ConversationsDeleteResponse` struct.
- **TypeScript SDK:** Added `deleteConversations` function and `ConversationsDeleteResponse` type.
- **Tests:** Added integration tests for both SDKs to verify the functionality.

Verified with:
- `cargo check`
- `bun run build`
- Integration tests (local verification passed for new features)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk conversation deletion added (new API and exposed via app context).

* **Refactor**
  * Response shape updated to allow string or array outputs.
  * Formatting and minor style cleanups across TypeScript code.

* **Tests**
  * Integration tests covering conversation creation, listing, bulk deletion, and improved test cleanup and assertions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->