### PR TITLE
feat: implement delete all KV endpoint

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -676,6 +676,13 @@ impl OpenSecretClient {
         Ok(())
     }
 
+    pub async fn kv_delete_all(&self) -> Result<()> {
+        let _: serde_json::Value = self
+            .encrypted_api_call("/protected/kv", "DELETE", None::<()>)
+            .await?;
+        Ok(())
+    }
+
     pub async fn kv_list(&self) -> Result<Vec<KVListItem>> {
         self.encrypted_api_call("/protected/kv", "GET", None::<()>)
             .await

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -158,6 +158,15 @@ export async function fetchDelete(key: string): Promise<void> {
   );
 }
 
+export async function fetchDeleteAllKV(): Promise<void> {
+  return authenticatedApiCall<void, void>(
+    `${apiUrl}/protected/kv`,
+    "DELETE",
+    undefined,
+    "Failed to delete all key-value pairs"
+  );
+}
+
 export async function fetchGet(key: string): Promise<string | undefined> {
   try {
     const data = await authenticatedApiCall<void, string>(

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -195,6 +195,13 @@ export type OpenSecretContextType = {
    */
   del: typeof api.fetchDelete;
 
+  /**
+   * Deletes all key-value pairs from the user's storage
+   * @returns A promise resolving when the deletion is complete
+   * @throws {Error} If the deletion fails
+   */
+  delAll: typeof api.fetchDeleteAllKV;
+
   verifyEmail: typeof api.verifyEmail;
   requestNewVerificationCode: typeof api.requestNewVerificationCode;
   requestNewVerificationEmail: typeof api.requestNewVerificationCode;
@@ -859,6 +866,7 @@ export const OpenSecretContext = createContext<OpenSecretContextType>({
   put: api.fetchPut,
   list: api.fetchList,
   del: api.fetchDelete,
+  delAll: api.fetchDeleteAllKV,
   verifyEmail: api.verifyEmail,
   requestNewVerificationCode: api.requestNewVerificationCode,
   requestNewVerificationEmail: api.requestNewVerificationCode,
@@ -1269,6 +1277,7 @@ export function OpenSecretProvider({
     put: api.fetchPut,
     list: api.fetchList,
     del: api.fetchDelete,
+    delAll: api.fetchDeleteAllKV,
     refetchUser: fetchUser,
     verifyEmail: api.verifyEmail,
     requestNewVerificationCode: api.requestNewVerificationCode,

--- a/src/lib/test/integration/ai.test.ts
+++ b/src/lib/test/integration/ai.test.ts
@@ -749,13 +749,13 @@ test("Integration test: Complete responses workflow", async () => {
   expect(retrievedResponse.status).toBe("completed");
   expect(Array.isArray(retrievedResponse.output)).toBe(true);
   expect(retrievedResponse.output?.length).toBeGreaterThan(0);
-  
+
   const firstItem = retrievedResponse.output![0];
   expect(firstItem.type).toBe("message");
   if (firstItem.type === "message") {
     const content = firstItem.content[0];
-    if ('text' in content) {
-        expect(content.text).toContain("workflow");
+    if ("text" in content) {
+      expect(content.text).toContain("workflow");
     }
   }
   expect(retrievedResponse.usage).toBeDefined();
@@ -816,7 +816,7 @@ test("Integration test: Direct API functions for responses", async () => {
   const firstItem = (retrievedResponse.output as any[])[0];
   expect(firstItem.type).toBe("message");
   expect(firstItem.content[0].text).toContain("apitest");
-  
+
   expect(retrievedResponse.usage).toBeDefined();
   expect(retrievedResponse.usage?.input_tokens).toBeGreaterThan(0);
   expect(retrievedResponse.usage?.output_tokens).toBeGreaterThan(0);

--- a/src/lib/test/integration/api.test.ts
+++ b/src/lib/test/integration/api.test.ts
@@ -17,7 +17,10 @@ import {
   getInstruction,
   updateInstruction,
   deleteInstruction,
-  setDefaultInstruction
+  setDefaultInstruction,
+  fetchPut,
+  fetchList,
+  fetchDeleteAllKV
 } from "../../api";
 
 const TEST_EMAIL = process.env.VITE_TEST_EMAIL;
@@ -444,4 +447,27 @@ test("Instructions API - Error cases", async () => {
   } catch (error: any) {
     expect(error.message).toBeDefined();
   }
+});
+
+test("KV Store - Delete All", async () => {
+  // Login first to get authenticated
+  const { access_token, refresh_token } = await tryEmailLogin();
+  window.localStorage.setItem("access_token", access_token);
+  window.localStorage.setItem("refresh_token", refresh_token);
+
+  // Add multiple keys
+  await fetchPut("key1", "value1");
+  await fetchPut("key2", "value2");
+  await fetchPut("key3", "value3");
+
+  // Verify they exist
+  const listBefore = await fetchList();
+  expect(listBefore.length).toBeGreaterThanOrEqual(3);
+
+  // Delete all keys
+  await fetchDeleteAllKV();
+
+  // Verify they are gone
+  const listAfter = await fetchList();
+  expect(listAfter.length).toBe(0);
 });


### PR DESCRIPTION
Implements the delete all KV endpoint in both Rust and TypeScript SDKs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a one-click bulk delete to remove all key-value pairs.
  * Exposed a public delete-all method in the app context/API for callers to trigger the bulk removal.

* **Tests**
  * Added integration tests covering insertion, listing, and the new delete-all flow to ensure correctness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->