### PR TITLE
feat: add batch delete conversations endpoint

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -950,6 +950,16 @@ impl OpenSecretClient {
             .await
     }
 
+    /// Batch deletes multiple conversations by their IDs
+    pub async fn batch_delete_conversations(
+        &self,
+        ids: Vec<String>,
+    ) -> Result<BatchDeleteConversationsResponse> {
+        let request = BatchDeleteConversationsRequest { ids };
+        self.encrypted_api_call("/v1/conversations/batch-delete", "POST", Some(request))
+            .await
+    }
+
     /// Fetches available AI models
     pub async fn get_models(&self) -> Result<ModelsResponse> {
         self.encrypted_openai_call("/v1/models", "GET", None::<()>)

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -304,6 +304,26 @@ pub struct ConversationsDeleteResponse {
     pub deleted: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchDeleteConversationsRequest {
+    pub ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchDeleteItemResult {
+    pub id: String,
+    pub object: String,
+    pub deleted: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchDeleteConversationsResponse {
+    pub object: String,
+    pub data: Vec<BatchDeleteItemResult>,
+}
+
 // AI/OpenAI API Types
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Model {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1653,6 +1653,22 @@ export type ConversationsDeleteResponse = {
   deleted: boolean;
 };
 
+export type BatchDeleteConversationsRequest = {
+  ids: string[];
+};
+
+export type BatchDeleteItemResult = {
+  id: string;
+  object: "conversation.deleted";
+  deleted: boolean;
+  error?: "not_found" | "delete_failed";
+};
+
+export type BatchDeleteConversationsResponse = {
+  object: "list";
+  data: BatchDeleteItemResult[];
+};
+
 /**
  * Lists user's conversation threads with pagination
  * @param params - Optional parameters for pagination and filtering
@@ -1956,6 +1972,44 @@ export async function deleteConversations(): Promise<ConversationsDeleteResponse
     "DELETE",
     undefined,
     "Failed to delete conversations"
+  );
+}
+
+/**
+ * Batch deletes multiple conversations by their IDs
+ * @param ids - Array of conversation UUIDs to delete
+ * @returns A promise resolving to per-item deletion results
+ * @throws {Error} If:
+ * - The user is not authenticated
+ * - The request fails
+ *
+ * @description
+ * This function deletes multiple conversations in a single request.
+ * Returns per-item results so callers can handle partial failures.
+ *
+ * @example
+ * ```typescript
+ * const result = await batchDeleteConversations([
+ *   "550e8400-e29b-41d4-a716-446655440000",
+ *   "550e8400-e29b-41d4-a716-446655440001"
+ * ]);
+ * for (const item of result.data) {
+ *   if (item.deleted) {
+ *     console.log(`Conversation ${item.id} deleted`);
+ *   } else {
+ *     console.log(`Failed to delete ${item.id}: ${item.error}`);
+ *   }
+ * }
+ * ```
+ */
+export async function batchDeleteConversations(
+  ids: string[]
+): Promise<BatchDeleteConversationsResponse> {
+  return authenticatedApiCall<BatchDeleteConversationsRequest, BatchDeleteConversationsResponse>(
+    `${apiUrl}/v1/conversations/batch-delete`,
+    "POST",
+    { ids },
+    "Failed to batch delete conversations"
   );
 }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -25,7 +25,10 @@ export type {
   ConversationItemsResponse,
   ConversationsListResponse,
   ConversationDeleteResponse,
-  ConversationsDeleteResponse
+  ConversationsDeleteResponse,
+  BatchDeleteConversationsRequest,
+  BatchDeleteItemResult,
+  BatchDeleteConversationsResponse
 } from "./api";
 
 // Export API key management functions

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -772,6 +772,13 @@ export type OpenSecretContextType = {
   deleteConversations: typeof api.deleteConversations;
 
   /**
+   * Batch deletes multiple conversations by their IDs
+   * @param ids - Array of conversation UUIDs to delete
+   * @returns A promise resolving to per-item deletion results
+   */
+  batchDeleteConversations: typeof api.batchDeleteConversations;
+
+  /**
    * Creates a new instruction
    * @param request - The instruction creation parameters
    * @returns A promise resolving to the created instruction
@@ -917,6 +924,7 @@ export const OpenSecretContext = createContext<OpenSecretContextType>({
   createResponse: api.createResponse,
   listConversations: api.listConversations,
   deleteConversations: api.deleteConversations,
+  batchDeleteConversations: api.batchDeleteConversations,
   createInstruction: api.createInstruction,
   listInstructions: api.listInstructions,
   getInstruction: api.getInstruction,
@@ -1332,6 +1340,7 @@ export function OpenSecretProvider({
     createResponse: api.createResponse,
     listConversations: api.listConversations,
     deleteConversations: api.deleteConversations,
+    batchDeleteConversations: api.batchDeleteConversations,
     createInstruction: api.createInstruction,
     listInstructions: api.listInstructions,
     getInstruction: api.getInstruction,


### PR DESCRIPTION
## Summary

Implements the batch delete conversations endpoint as specified in #57.

## Changes

### TypeScript SDK
- Added `BatchDeleteConversationsRequest`, `BatchDeleteItemResult`, and `BatchDeleteConversationsResponse` types
- Added `batchDeleteConversations(ids: string[])` function in `api.ts`
- Exported new types from `index.ts`
- Added to `OpenSecretContextType` and `OpenSecretProvider` in `main.tsx`

### Rust SDK
- Added corresponding structs in `types.rs`
- Added `batch_delete_conversations(ids: Vec<String>)` method in `client.rs`

### Tests
- Added integration test covering:
  - Successful batch deletion of multiple conversations
  - Partial failure handling (non-existent IDs return `not_found` error)

## API

```typescript
const result = await batchDeleteConversations([
  "550e8400-e29b-41d4-a716-446655440000",
  "550e8400-e29b-41d4-a716-446655440001"
]);
// Returns per-item results for partial failure handling
```

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Batch delete conversations: Users can now delete multiple conversations in a single API call, with per-item results showing success or error status.

* **Tests**
  * Added integration tests for batch deletion functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->