### PR TITLE
feat: add embeddings API support to Rust SDK

### DIFF
--- a/rust/src/attestation.rs
+++ b/rust/src/attestation.rs
@@ -26,6 +26,7 @@ pub struct AttestationVerifier {
     allow_debug: bool,
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for AttestationVerifier {
     fn default() -> Self {
         Self {

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -966,6 +966,24 @@ impl OpenSecretClient {
             .await
     }
 
+    /// Creates embeddings for the given input text(s)
+    ///
+    /// # Example
+    /// ```ignore
+    /// let request = EmbeddingRequest {
+    ///     input: "Hello, world!".into(),
+    ///     model: "nomic-embed-text".to_string(),
+    ///     encoding_format: None,
+    ///     dimensions: None,
+    ///     user: None,
+    /// };
+    /// let response = client.create_embeddings(request).await?;
+    /// ```
+    pub async fn create_embeddings(&self, request: EmbeddingRequest) -> Result<EmbeddingResponse> {
+        self.encrypted_openai_call("/v1/embeddings", "POST", Some(request))
+            .await
+    }
+
     /// Creates a chat completion (non-streaming)
     pub async fn create_chat_completion(
         &self,

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -463,3 +463,67 @@ pub struct ChatMessageDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCall>>,
 }
+
+// Embeddings Types
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingRequest {
+    pub input: EmbeddingInput,
+    #[serde(default = "default_embedding_model")]
+    pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding_format: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dimensions: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+}
+
+fn default_embedding_model() -> String {
+    "nomic-embed-text".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EmbeddingInput {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl From<String> for EmbeddingInput {
+    fn from(s: String) -> Self {
+        EmbeddingInput::Single(s)
+    }
+}
+
+impl From<&str> for EmbeddingInput {
+    fn from(s: &str) -> Self {
+        EmbeddingInput::Single(s.to_string())
+    }
+}
+
+impl From<Vec<String>> for EmbeddingInput {
+    fn from(v: Vec<String>) -> Self {
+        EmbeddingInput::Multiple(v)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingResponse {
+    pub object: String,
+    pub data: Vec<EmbeddingData>,
+    pub model: String,
+    pub usage: EmbeddingUsage,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingData {
+    pub object: String,
+    pub index: i32,
+    pub embedding: Vec<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingUsage {
+    pub prompt_tokens: i32,
+    pub total_tokens: i32,
+}


### PR DESCRIPTION
## Summary
Add embeddings API support to the Rust SDK.

## Changes
- Add `create_embeddings()` method to `OpenSecretClient`
- Add `EmbeddingRequest`, `EmbeddingResponse`, `EmbeddingInput`, `EmbeddingData`, and `EmbeddingUsage` types
- Add `From` trait implementations for convenient `EmbeddingInput` construction from strings
- Add comprehensive integration tests for single and multiple input embeddings
- Fix clippy warning on `AttestationVerifier::Default` impl

## Testing
All new embedding tests pass with the nomic-embed-text model (768 dimensions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embeddings support enabling generation of text vector representations; supports single and batch text inputs with configurable embedding model selection.

* **Tests**
  * Added comprehensive integration tests validating embeddings generation across different input types and response structure integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->