### PR TITLE
fix: add apiUrl option to createCustomFetch for standalone usage

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -4,6 +4,7 @@ import * as api from "./api";
 
 export interface CustomFetchOptions {
   apiKey?: string; // Optional API key to use instead of JWT token
+  apiUrl?: string; // Optional API URL for attestation (required when not using OpenSecretProvider)
 }
 
 export function createCustomFetch(
@@ -28,7 +29,7 @@ export function createCustomFetch(
       const headers = new Headers(init?.headers);
       headers.set("Authorization", getAuthHeader());
 
-      const { sessionKey, sessionId } = await getAttestation();
+      const { sessionKey, sessionId } = await getAttestation(false, options?.apiUrl);
       if (!sessionKey || !sessionId) {
         throw new Error("No session key or ID available");
       }

--- a/website/docs/maple-ai/index.md
+++ b/website/docs/maple-ai/index.md
@@ -66,7 +66,7 @@ async function chat(apiKey: string, message: string) {
     baseURL: `${MAPLE_API_URL}/v1/`,
     apiKey: apiKey,
     dangerouslyAllowBrowser: true,
-    fetch: createCustomFetch({ apiKey })
+    fetch: createCustomFetch({ apiKey, apiUrl: MAPLE_API_URL })
   });
 
   const stream = await openai.chat.completions.create({
@@ -91,7 +91,7 @@ chat("your-maple-api-key", "Hello, world!");
 
 ### How It Works
 
-The `createCustomFetch({ apiKey })` function from the SDK handles:
+The `createCustomFetch({ apiKey, apiUrl })` function from the SDK handles:
 
 1. **TEE Attestation** - Verifies you're talking to genuine secure hardware
 2. **End-to-End Encryption** - Encrypts your prompts before transmission
@@ -102,35 +102,18 @@ Your application just uses the standard OpenAI client interface.
 
 ### Fetching Available Models
 
-You can list available models before making completion requests:
+You can list available models using the OpenAI client:
 
 ```typescript
-import { createCustomFetch } from "@opensecret/react";
+const openai = new OpenAI({
+  baseURL: `${MAPLE_API_URL}/v1/`,
+  apiKey: apiKey,
+  dangerouslyAllowBrowser: true,
+  fetch: createCustomFetch({ apiKey, apiUrl: MAPLE_API_URL })
+});
 
-const MAPLE_API_URL = "https://enclave.trymaple.ai";
-
-async function listModels(apiKey: string) {
-  const customFetch = createCustomFetch({ apiKey });
-  
-  const response = await customFetch(`${MAPLE_API_URL}/v1/models`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json"
-    }
-  });
-  
-  const data = await response.json();
-  return data.data; // Array of model objects
-}
-```
-
-Or using the SDK's helper function:
-
-```typescript
-import { fetchModels } from "@opensecret/react";
-
-const models = await fetchModels(apiKey);
-console.log(models.map(m => m.id));
+const models = await openai.models.list();
+console.log(models.data.map(m => m.id));
 ```
 
 ### Available Models
@@ -186,7 +169,7 @@ export function MapleChat({ apiKey }: MapleChatProps) {
         baseURL: `${MAPLE_API_URL}/v1/`,
         apiKey: apiKey,
         dangerouslyAllowBrowser: true,
-        fetch: createCustomFetch({ apiKey })
+        fetch: createCustomFetch({ apiKey, apiUrl: MAPLE_API_URL })
       });
 
       const stream = await openai.chat.completions.create({
@@ -249,7 +232,7 @@ import { createCustomFetch } from "@opensecret/react";
 const MAPLE_API_URL = "https://enclave.trymaple.ai";
 
 async function completion(apiKey: string, prompt: string) {
-  const customFetch = createCustomFetch({ apiKey });
+  const customFetch = createCustomFetch({ apiKey, apiUrl: MAPLE_API_URL });
 
   const response = await customFetch(`${MAPLE_API_URL}/v1/chat/completions`, {
     method: "POST",


### PR DESCRIPTION
## Problem

When using `createCustomFetch` outside of `OpenSecretProvider` (e.g., for standalone Maple AI integration), attestation was incorrectly trying to reach localhost because the API URL wasn't set via the provider.

A hackathon participant ran into this issue when following the new Maple AI docs.

## Solution

Added optional `apiUrl` parameter to `CustomFetchOptions` that gets passed through to `getAttestation()`.

```typescript
// Before (broken for standalone usage)
createCustomFetch({ apiKey })

// After (works standalone)
createCustomFetch({ apiKey, apiUrl: 'https://enclave.trymaple.ai' })
```

## Backwards Compatible

- `apiUrl` is optional
- When not provided, falls back to existing behavior (uses URL from `OpenSecretProvider`)
- Existing code continues to work unchanged

## Changes

- `src/lib/ai.ts`: Added `apiUrl` option and pass it to `getAttestation()`
- `website/docs/maple-ai/index.md`: Updated all code examples to include `apiUrl`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for specifying a custom attestation API URL in SDK configuration, allowing requests to use a provided endpoint and ensuring API-key precedence for authorization.

* **Documentation**
  * Updated integration guides and code samples to show configuring the API URL.
  * Expanded “How It Works” with Secure Key Exchange and Response Decryption details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->