### PR TITLE
feat(rust): add reasoning_content field to ChatMessage types

### DIFF
--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -385,6 +385,8 @@ pub struct ChatMessage {
     pub content: Value, // Now accepts both string and array formats
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -462,6 +464,8 @@ pub struct ChatMessageDelta {
     pub content: Option<Value>, // Also update delta to accept flexible content
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
 }
 
 // Embeddings Types

--- a/rust/tests/api_keys.rs
+++ b/rust/tests/api_keys.rs
@@ -140,6 +140,7 @@ async fn test_streaming_chat_with_api_key() -> Result<()> {
             role: "user".to_string(),
             content: serde_json::json!("Please reply with exactly and only the word 'echo'"),
             tool_calls: None,
+            reasoning_content: None,
         }],
         temperature: Some(0.1),
         max_tokens: Some(10),


### PR DESCRIPTION
## Summary

Add optional `reasoning_content` field to `ChatMessage` and `ChatMessageDelta` structs in the Rust SDK.

## Motivation

Models like Kimi K2 (via vLLM/Tinfoil) can expose their reasoning/thinking process through a `reasoning_content` field in the response. Without this field in the SDK types, the reasoning content is silently dropped during deserialization.

## Changes

- Added `reasoning_content: Option<String>` to `ChatMessage` (for non-streaming responses)
- Added `reasoning_content: Option<String>` to `ChatMessageDelta` (for streaming responses)
- Both fields use `#[serde(skip_serializing_if = "Option::is_none")]` to avoid serializing when not present

## Testing

- `cargo check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat messages can now include an optional "reasoning content" field.

* **Tests**
  * Test fixtures updated to include the new optional field where applicable.
  * Added a streaming test that verifies reasoning content can be produced in deltas for the relevant model.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->