### PR TITLE
fix(rust): require message ids in agent SSE

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -2652,7 +2652,12 @@ mod tests {
             .unwrap();
 
         let sse_body = format!(
-            "{}{}{}data: [DONE]\n\n",
+            "{}{}{}{}data: [DONE]\n\n",
+            encrypted_sse_data(&session_key, &json!({})).replacen(
+                "data:",
+                "event: agent.typing\ndata:",
+                1
+            ),
             encrypted_sse_data(
                 &session_key,
                 &json!({
@@ -2665,19 +2670,15 @@ mod tests {
                 &session_key,
                 &json!({
                     "message_id": message_id,
-                    "messages": ["hello there"],
-                    "step": 0
+                    "message": "hello there"
                 })
             )
             .replacen("data:", "event: agent.message\ndata:", 1),
-            encrypted_sse_data(
-                &session_key,
-                &json!({
-                    "total_steps": 1,
-                    "total_messages": 1
-                })
-            )
-            .replacen("data:", "event: agent.done\ndata:", 1),
+            encrypted_sse_data(&session_key, &json!({})).replacen(
+                "data:",
+                "event: agent.done\ndata:",
+                1
+            ),
         );
 
         Mock::given(method("POST"))
@@ -2699,6 +2700,11 @@ mod tests {
         let mut stream = client.agent_chat("hey there").await.unwrap();
 
         match stream.next().await.unwrap().unwrap() {
+            AgentSseEvent::Typing(_) => {}
+            other => panic!("Expected typing event, got {:?}", other),
+        }
+
+        match stream.next().await.unwrap().unwrap() {
             AgentSseEvent::Reaction(event) => {
                 assert_eq!(event.item_id, reaction_item_id);
                 assert_eq!(event.emoji, "🫡");
@@ -2708,18 +2714,14 @@ mod tests {
 
         match stream.next().await.unwrap().unwrap() {
             AgentSseEvent::Message(event) => {
-                assert_eq!(event.message_id, Some(message_id));
-                assert_eq!(event.messages, vec!["hello there".to_string()]);
-                assert_eq!(event.step, 0);
+                assert_eq!(event.message_id, message_id);
+                assert_eq!(event.message, "hello there".to_string());
             }
             other => panic!("Expected message event, got {:?}", other),
         }
 
         match stream.next().await.unwrap().unwrap() {
-            AgentSseEvent::Done(event) => {
-                assert_eq!(event.total_steps, 1);
-                assert_eq!(event.total_messages, 1);
-            }
+            AgentSseEvent::Done(_) => {}
             other => panic!("Expected done event, got {:?}", other),
         }
 

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -864,10 +864,8 @@ pub struct DeletedObjectResponse {
 // Agent SSE event types
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentMessageEvent {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub message_id: Option<Uuid>,
-    pub messages: Vec<String>,
-    pub step: usize,
+    pub message_id: Uuid,
+    pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -877,15 +875,10 @@ pub struct AgentReactionEvent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentTypingEvent {
-    pub step: usize,
-}
+pub struct AgentTypingEvent {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentDoneEvent {
-    pub total_steps: usize,
-    pub total_messages: usize,
-}
+pub struct AgentDoneEvent {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentErrorEvent {

--- a/rust/tests/agent_integration.rs
+++ b/rust/tests/agent_integration.rs
@@ -224,8 +224,8 @@ async fn test_agent_chat_sse() {
             Ok(event) => match event {
                 AgentSseEvent::Message(msg) => {
                     got_message = true;
-                    all_messages.extend(msg.messages);
-                    println!("Agent message at step {}: {:?}", msg.step, all_messages);
+                    all_messages.push(msg.message.clone());
+                    println!("Agent message {}: {:?}", msg.message_id, all_messages);
                 }
                 AgentSseEvent::Reaction(reaction) => {
                     println!(
@@ -233,15 +233,12 @@ async fn test_agent_chat_sse() {
                         reaction.item_id, reaction.emoji
                     );
                 }
-                AgentSseEvent::Typing(typing) => {
-                    println!("Agent typing at step {}", typing.step);
+                AgentSseEvent::Typing(_) => {
+                    println!("Agent typing");
                 }
-                AgentSseEvent::Done(done) => {
+                AgentSseEvent::Done(_) => {
                     got_done = true;
-                    println!(
-                        "Agent done: {} steps, {} messages",
-                        done.total_steps, done.total_messages
-                    );
+                    println!("Agent done");
                 }
                 AgentSseEvent::Error(err) => {
                     panic!("Agent error: {}", err.error);
@@ -286,8 +283,8 @@ async fn test_subagent_chat_sse() {
             Ok(event) => match event {
                 AgentSseEvent::Message(msg) => {
                     got_message = true;
-                    all_messages.extend(msg.messages);
-                    println!("Subagent message at step {}: {:?}", msg.step, all_messages);
+                    all_messages.push(msg.message.clone());
+                    println!("Subagent message {}: {:?}", msg.message_id, all_messages);
                 }
                 AgentSseEvent::Reaction(reaction) => {
                     println!(
@@ -295,15 +292,12 @@ async fn test_subagent_chat_sse() {
                         reaction.item_id, reaction.emoji
                     );
                 }
-                AgentSseEvent::Typing(typing) => {
-                    println!("Subagent typing at step {}", typing.step);
+                AgentSseEvent::Typing(_) => {
+                    println!("Subagent typing");
                 }
-                AgentSseEvent::Done(done) => {
+                AgentSseEvent::Done(_) => {
                     got_done = true;
-                    println!(
-                        "Subagent done: {} steps, {} messages",
-                        done.total_steps, done.total_messages
-                    );
+                    println!("Subagent done");
                 }
                 AgentSseEvent::Error(err) => {
                     panic!("Subagent error: {}", err.error);


### PR DESCRIPTION
## Summary
- require  on  and expose a single  per SSE event
- treat  and  as marker events with empty payload structs
- update SDK tests to match the simplified agent SSE contract

## Validation
- OpenSecret SDK Development Environment
----------------------------------------
TypeScript/Bun tools available
Rust toolchain: rustc 1.89.0 (29483883e 2025-08-04)


running 20 tests
test crypto::tests::test_key_exchange ... ok
test crypto::tests::test_encrypt_decrypt ... ok
test client::tests::test_client_creation ... ok
test client::tests::test_set_main_agent_item_reaction_uses_authenticated_encrypted_v1_endpoint ... ok
test client::tests::test_clear_subagent_item_reaction_uses_authenticated_v1_endpoint ... ok
test client::tests::test_list_and_revoke_push_devices_use_v1_endpoints ... ok
test client::tests::test_corrupted_access_token_recovers_via_refresh_on_next_call ... ok
test client::tests::test_register_push_device_uses_v1_push_endpoint ... ok
test client::tests::test_init_main_agent_uses_authenticated_encrypted_v1_endpoint ... ok
test client::tests::test_refresh_reestablishes_attestation_without_sending_auth_headers ... ok
test client::tests::test_streaming_completion_preserves_reasoning_content ... ok
test push::tests::decrypt_preview_envelope_round_trips ... ok
test client::tests::test_logout_with_push_device_id_sends_cleanup_hint ... ok
test session::tests::test_session_management ... ok
test client::tests::test_agent_chat_stream_parses_reaction_and_message_ids ... ok
test client::tests::test_authenticated_calls_refresh_and_retry_seamlessly ... ok
test session::tests::test_token_management ... ok
test push::tests::push_keypair_pkcs8_round_trips ... ok
test push::tests::decrypt_preview_envelope_rejects_unknown_algorithm ... ok
test push::tests::decrypt_preview_envelope_rejects_unknown_payload_version ... ok

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s


running 8 tests
test test_account_deletion ... ignored, EXTREMELY DESTRUCTIVE - would permanently delete the account
test test_change_password ... ignored, Destructive operation - would change account password permanently
test test_convert_guest_to_email ... ignored, One-time operation - can only convert guest account once
test test_email_verification ... ignored, Requires email verification code from actual email
test test_password_reset_flow ... ignored, Requires email infrastructure and is destructive
test test_account_management_apis_exist ... ok
test test_verify_email_requires_no_auth ... ok
test test_password_reset_requires_no_auth ... ok

test result: ok. 3 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 0.05s


running 6 tests
test test_agent_chat_sse ... ignored, Requires agent API on server
test test_create_and_delete_subagent ... ignored, Requires agent API on server
test test_delete_main_agent_resets_agent_tree ... ignored, Requires agent API on server
test test_get_main_agent_and_items ... ignored, Requires agent API on server
test test_list_and_get_subagents ... ignored, Requires agent API on server
test test_subagent_chat_sse ... ignored, Requires agent API on server

test result: ok. 0 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 11 tests
test test_chat_completion_non_streaming ... ignored, Server currently only supports streaming completions
test test_guest_user_cannot_use_ai ... ignored, Paid guest users can access LLMs and models endpoint
test test_reasoning_content_with_kimi_k2 ... ignored, Known backend regression: kimi provider is not emitting reasoning_content; SDK passthrough is covered by unit tests
test test_get_models ... ok
test test_delete_conversations ... ok
test test_chat_completion_with_system_message ... ok
test test_create_embeddings_single_input ... ok
test test_chat_completion_streaming ... ok
test test_embeddings_from_string_conversion ... ok
test test_create_embeddings_multiple_inputs ... ok
test test_streaming_multi_tool_calls ... ok

test result: ok. 8 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 1.32s


running 9 tests
test test_user_profile_api ... ok
test test_third_party_token ... ok
test test_private_key_generation ... ok
test test_public_key_retrieval ... ok
test test_kv_delete_all ... ok
test test_kv_storage_apis ... ok
test test_message_signing ... ok
test test_encryption_decryption ... ok
test test_kv_storage_with_special_characters ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.89s


running 5 tests
test test_invalid_api_key_fails ... ok
test test_api_key_authentication ... ok
test test_create_list_delete_api_key ... ok
test test_multiple_api_keys ... ok
test test_streaming_chat_with_api_key ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.46s


running 4 tests
test test_attestation_handshake_production ... ok
test test_connection_health_check ... ok
test test_attestation_handshake_localhost ... ok
test test_attestation_nonce_verification ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 2 tests
test test_session_management ... ok
test test_login_signup_flow ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.38s


running 5 tests
test test_bip85_derive_child_mnemonic ... ok
test test_bip85_public_key_derivation ... ok
test test_bip85_message_signing ... ok
test test_bip85_private_key_bytes ... ok
test test_bip85_encryption_decryption ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.85s


running 8 tests
test test_invalid_base64_session_key ... ok
test test_encryption_decryption ... ok
test test_encryption_with_different_nonces ... ok
test test_decryption_with_wrong_key_fails ... ok
test test_session_key_decryption ... ok
test test_ecdh_key_exchange ... ok
test test_key_generation ... ok
test test_corrupted_ciphertext ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 3 tests
test test_client_initialization ... ok
test test_health_check_mock ... ok
test test_full_flow_with_real_server ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 2 tests
test test_session_key_derivation ... ok
test test_session_establishment ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 1 test
test src/client.rs - client::OpenSecretClient::create_embeddings (line 1299) ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret-sdk/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined server-sent event payloads for agent communication with simplified data structures
  * Message events now include required message ID with single message content
  * Typing and completion events refined by removing step and progress tracking fields

* **Tests**
  * Updated event handler tests to validate new payload structures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->