### PR TITLE
feat: add conversation project support across JS and Rust SDKs

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -102,6 +102,9 @@ fn build_conversations_endpoint(params: Option<&ConversationsListParams>) -> Str
         if let Some(project_id) = params.project_id {
             append_query_param(&mut query, "project_id", project_id);
         }
+        if let Some(unassigned_project) = params.unassigned_project {
+            append_query_param(&mut query, "unassigned_project", unassigned_project);
+        }
         if let Some(pinned) = params.pinned {
             append_query_param(&mut query, "pinned", pinned);
         }
@@ -2088,13 +2091,28 @@ mod tests {
             after: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
             order: Some("asc".to_string()),
             project_id: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap()),
+            unassigned_project: Some(false),
             pinned: Some(false),
         }));
 
         assert_eq!(
             endpoint,
-            "/v1/conversations?limit=25&after=550e8400%2De29b%2D41d4%2Da716%2D446655440000&order=asc&project_id=550e8400%2De29b%2D41d4%2Da716%2D446655440001&pinned=false"
+            "/v1/conversations?limit=25&after=550e8400%2De29b%2D41d4%2Da716%2D446655440000&order=asc&project_id=550e8400%2De29b%2D41d4%2Da716%2D446655440001&unassigned_project=false&pinned=false"
         );
+    }
+
+    #[test]
+    fn test_build_conversations_endpoint_supports_unassigned_project_filter() {
+        let endpoint = build_conversations_endpoint(Some(&ConversationsListParams {
+            limit: None,
+            after: None,
+            order: None,
+            project_id: None,
+            unassigned_project: Some(true),
+            pinned: None,
+        }));
+
+        assert_eq!(endpoint, "/v1/conversations?unassigned_project=true");
     }
 
     #[test]

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -102,9 +102,6 @@ fn build_conversations_endpoint(params: Option<&ConversationsListParams>) -> Str
         if let Some(project_id) = params.project_id {
             append_query_param(&mut query, "project_id", project_id);
         }
-        if let Some(has_project) = params.has_project {
-            append_query_param(&mut query, "has_project", has_project);
-        }
         if let Some(pinned) = params.pinned {
             append_query_param(&mut query, "pinned", pinned);
         }
@@ -2091,13 +2088,12 @@ mod tests {
             after: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
             order: Some("asc".to_string()),
             project_id: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap()),
-            has_project: Some(true),
             pinned: Some(false),
         }));
 
         assert_eq!(
             endpoint,
-            "/v1/conversations?limit=25&after=550e8400%2De29b%2D41d4%2Da716%2D446655440000&order=asc&project_id=550e8400%2De29b%2D41d4%2Da716%2D446655440001&has_project=true&pinned=false"
+            "/v1/conversations?limit=25&after=550e8400%2De29b%2D41d4%2Da716%2D446655440000&order=asc&project_id=550e8400%2De29b%2D41d4%2Da716%2D446655440001&pinned=false"
         );
     }
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -85,6 +85,63 @@ fn build_subagents_endpoint(params: Option<&ListSubagentsParams>) -> String {
     endpoint
 }
 
+fn build_conversations_endpoint(params: Option<&ConversationsListParams>) -> String {
+    let mut endpoint = "/v1/conversations".to_string();
+    let mut query = Vec::new();
+
+    if let Some(params) = params {
+        if let Some(limit) = params.limit {
+            append_query_param(&mut query, "limit", limit);
+        }
+        if let Some(after) = params.after {
+            append_query_param(&mut query, "after", after);
+        }
+        if let Some(order) = &params.order {
+            append_query_param(&mut query, "order", order);
+        }
+        if let Some(project_id) = params.project_id {
+            append_query_param(&mut query, "project_id", project_id);
+        }
+        if let Some(has_project) = params.has_project {
+            append_query_param(&mut query, "has_project", has_project);
+        }
+        if let Some(pinned) = params.pinned {
+            append_query_param(&mut query, "pinned", pinned);
+        }
+    }
+
+    if !query.is_empty() {
+        endpoint.push('?');
+        endpoint.push_str(&query.join("&"));
+    }
+
+    endpoint
+}
+
+fn build_conversation_projects_endpoint(params: Option<&ConversationProjectListParams>) -> String {
+    let mut endpoint = "/v1/conversation-projects".to_string();
+    let mut query = Vec::new();
+
+    if let Some(params) = params {
+        if let Some(limit) = params.limit {
+            append_query_param(&mut query, "limit", limit);
+        }
+        if let Some(after) = params.after {
+            append_query_param(&mut query, "after", after);
+        }
+        if let Some(order) = &params.order {
+            append_query_param(&mut query, "order", order);
+        }
+    }
+
+    if !query.is_empty() {
+        endpoint.push('?');
+        endpoint.push_str(&query.join("&"));
+    }
+
+    endpoint
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum AuthHeaderMode {
     None,
@@ -1271,6 +1328,96 @@ impl OpenSecretClient {
 
     // AI/OpenAI API Methods
 
+    /// Creates a new conversation.
+    pub async fn create_conversation(
+        &self,
+        request: ConversationCreateRequest,
+    ) -> Result<Conversation> {
+        self.authenticated_api_call("/v1/conversations", "POST", Some(request))
+            .await
+    }
+
+    /// Lists conversations with optional filters and pagination.
+    pub async fn list_conversations(
+        &self,
+        params: Option<ConversationsListParams>,
+    ) -> Result<ConversationsListResponse> {
+        let endpoint = build_conversations_endpoint(params.as_ref());
+        self.authenticated_api_call(&endpoint, "GET", None::<()>)
+            .await
+    }
+
+    /// Fetches a single conversation by UUID.
+    pub async fn get_conversation(&self, conversation_id: Uuid) -> Result<Conversation> {
+        self.authenticated_api_call(
+            &format!("/v1/conversations/{}", conversation_id),
+            "GET",
+            None::<()>,
+        )
+        .await
+    }
+
+    /// Partially updates a conversation.
+    pub async fn update_conversation(
+        &self,
+        conversation_id: Uuid,
+        request: ConversationUpdateRequest,
+    ) -> Result<Conversation> {
+        if request.is_empty() {
+            return Err(Error::Configuration(
+                "Conversation update request must include at least one field".to_string(),
+            ));
+        }
+
+        self.authenticated_api_call(
+            &format!("/v1/conversations/{}", conversation_id),
+            "POST",
+            Some(request),
+        )
+        .await
+    }
+
+    /// Deletes a single conversation by UUID.
+    pub async fn delete_conversation(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<DeletedObjectResponse> {
+        self.authenticated_api_call(
+            &format!("/v1/conversations/{}", conversation_id),
+            "DELETE",
+            None::<()>,
+        )
+        .await
+    }
+
+    /// Lists items in a conversation.
+    pub async fn list_conversation_items(
+        &self,
+        conversation_id: Uuid,
+        params: Option<AgentItemsListParams>,
+    ) -> Result<ConversationItemsResponse> {
+        let endpoint = build_agent_items_endpoint(
+            &format!("/v1/conversations/{}/items", conversation_id),
+            params.as_ref(),
+        );
+        self.authenticated_api_call(&endpoint, "GET", None::<()>)
+            .await
+    }
+
+    /// Fetches a single item from a conversation.
+    pub async fn get_conversation_item(
+        &self,
+        conversation_id: Uuid,
+        item_id: Uuid,
+    ) -> Result<ConversationItem> {
+        self.authenticated_api_call(
+            &format!("/v1/conversations/{}/items/{}", conversation_id, item_id),
+            "GET",
+            None::<()>,
+        )
+        .await
+    }
+
     /// Deletes all conversations
     pub async fn delete_conversations(&self) -> Result<ConversationsDeleteResponse> {
         self.authenticated_api_call("/v1/conversations", "DELETE", None::<()>)
@@ -1285,6 +1432,83 @@ impl OpenSecretClient {
         let request = BatchDeleteConversationsRequest { ids };
         self.authenticated_api_call("/v1/conversations/batch-delete", "POST", Some(request))
             .await
+    }
+
+    /// Batch updates conversation project assignments. Use `None` to clear the project.
+    pub async fn batch_update_conversation_project(
+        &self,
+        ids: Vec<Uuid>,
+        project_id: Option<Uuid>,
+    ) -> Result<BatchUpdateConversationProjectResponse> {
+        let request = BatchUpdateConversationProjectRequest { ids, project_id };
+        self.authenticated_api_call(
+            "/v1/conversations/batch-update-project",
+            "POST",
+            Some(request),
+        )
+        .await
+    }
+
+    /// Creates a new conversation project.
+    pub async fn create_conversation_project(
+        &self,
+        request: ConversationProjectCreateRequest,
+    ) -> Result<ConversationProject> {
+        self.authenticated_api_call("/v1/conversation-projects", "POST", Some(request))
+            .await
+    }
+
+    /// Lists conversation projects with pagination.
+    pub async fn list_conversation_projects(
+        &self,
+        params: Option<ConversationProjectListParams>,
+    ) -> Result<ConversationProjectsListResponse> {
+        let endpoint = build_conversation_projects_endpoint(params.as_ref());
+        self.authenticated_api_call(&endpoint, "GET", None::<()>)
+            .await
+    }
+
+    /// Fetches a single conversation project by UUID.
+    pub async fn get_conversation_project(&self, project_id: Uuid) -> Result<ConversationProject> {
+        self.authenticated_api_call(
+            &format!("/v1/conversation-projects/{}", project_id),
+            "GET",
+            None::<()>,
+        )
+        .await
+    }
+
+    /// Updates a conversation project and/or its project instructions.
+    pub async fn update_conversation_project(
+        &self,
+        project_id: Uuid,
+        request: ConversationProjectUpdateRequest,
+    ) -> Result<ConversationProject> {
+        if request.is_empty() {
+            return Err(Error::Configuration(
+                "Conversation project update request must include at least one field".to_string(),
+            ));
+        }
+
+        self.authenticated_api_call(
+            &format!("/v1/conversation-projects/{}", project_id),
+            "POST",
+            Some(request),
+        )
+        .await
+    }
+
+    /// Deletes a conversation project by UUID.
+    pub async fn delete_conversation_project(
+        &self,
+        project_id: Uuid,
+    ) -> Result<DeletedObjectResponse> {
+        self.authenticated_api_call(
+            &format!("/v1/conversation-projects/{}", project_id),
+            "DELETE",
+            None::<()>,
+        )
+        .await
     }
 
     /// Fetches available AI models
@@ -1858,6 +2082,70 @@ mod tests {
                 &json!({ "ok": true }),
             ))
         }
+    }
+
+    #[test]
+    fn test_build_conversations_endpoint_includes_filters() {
+        let endpoint = build_conversations_endpoint(Some(&ConversationsListParams {
+            limit: Some(25),
+            after: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
+            order: Some("asc".to_string()),
+            project_id: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap()),
+            has_project: Some(true),
+            pinned: Some(false),
+        }));
+
+        assert_eq!(
+            endpoint,
+            "/v1/conversations?limit=25&after=550e8400%2De29b%2D41d4%2Da716%2D446655440000&order=asc&project_id=550e8400%2De29b%2D41d4%2Da716%2D446655440001&has_project=true&pinned=false"
+        );
+    }
+
+    #[test]
+    fn test_build_conversation_projects_endpoint_includes_pagination() {
+        let endpoint = build_conversation_projects_endpoint(Some(&ConversationProjectListParams {
+            limit: Some(10),
+            after: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
+            order: Some("desc".to_string()),
+        }));
+
+        assert_eq!(
+            endpoint,
+            "/v1/conversation-projects?limit=10&after=550e8400%2De29b%2D41d4%2Da716%2D446655440000&order=desc"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_conversation_rejects_empty_request_locally() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+
+        let error = client
+            .update_conversation(Uuid::new_v4(), ConversationUpdateRequest::default())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, Error::Configuration(message) if message.contains("at least one field"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_conversation_project_rejects_empty_request_locally() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+
+        let error = client
+            .update_conversation_project(
+                Uuid::new_v4(),
+                ConversationProjectUpdateRequest::default(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, Error::Configuration(message) if message.contains("at least one field"))
+        );
     }
 
     #[tokio::test]

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -572,8 +572,6 @@ pub struct ConversationsListParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project_id: Option<Uuid>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub has_project: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub pinned: Option<bool>,
 }
 
@@ -651,7 +649,6 @@ pub struct ConversationProjectListItem {
     pub id: Uuid,
     pub object: String,
     pub name: String,
-    pub has_instructions: bool,
     pub created_at: i64,
     pub updated_at: i64,
 }

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -532,7 +532,7 @@ pub struct Conversation {
     pub project_id: Option<Uuid>,
     pub pinned: bool,
     pub created_at: i64,
-    pub updated_at: i64,
+    pub last_activity_at: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -617,20 +617,8 @@ pub struct BatchUpdateConversationProjectRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BatchUpdateConversationProjectItemResult {
-    pub id: Uuid,
-    pub object: String,
-    pub updated: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub project_id: Option<Uuid>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BatchUpdateConversationProjectResponse {
-    pub object: String,
-    pub data: Vec<BatchUpdateConversationProjectItemResult>,
+    pub success: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use uuid::Uuid;
 
@@ -96,6 +96,58 @@ pub struct EncryptedResponse<T> {
     pub encrypted: String,
     #[serde(skip)]
     _phantom: std::marker::PhantomData<T>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum NullableField<T> {
+    #[default]
+    Missing,
+    Null,
+    Value(T),
+}
+
+impl<T> NullableField<T> {
+    pub fn is_missing(&self) -> bool {
+        matches!(self, Self::Missing)
+    }
+
+    pub fn null() -> Self {
+        Self::Null
+    }
+
+    pub fn value(value: T) -> Self {
+        Self::Value(value)
+    }
+}
+
+impl<T> Serialize for NullableField<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Missing | Self::Null => serializer.serialize_none(),
+            Self::Value(value) => value.serialize(serializer),
+        }
+    }
+}
+
+impl<'de, T> Deserialize<'de> for NullableField<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(match Option::<T>::deserialize(deserializer)? {
+            Some(value) => Self::Value(value),
+            None => Self::Null,
+        })
+    }
 }
 
 // OAuth Types
@@ -471,6 +523,70 @@ pub struct ApiKeyCreateResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Conversation {
+    pub id: Uuid,
+    pub object: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<Uuid>,
+    pub pinned: bool,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ConversationCreateRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pinned: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ConversationUpdateRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub project_id: NullableField<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pinned: Option<bool>,
+}
+
+impl ConversationUpdateRequest {
+    pub fn is_empty(&self) -> bool {
+        self.metadata.is_none() && self.project_id.is_missing() && self.pinned.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ConversationsListParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_project: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pinned: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationsListResponse {
+    pub object: String,
+    pub data: Vec<Conversation>,
+    pub first_id: Option<Uuid>,
+    pub last_id: Option<Uuid>,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConversationsDeleteResponse {
     pub object: String,
     pub deleted: bool,
@@ -494,6 +610,88 @@ pub struct BatchDeleteItemResult {
 pub struct BatchDeleteConversationsResponse {
     pub object: String,
     pub data: Vec<BatchDeleteItemResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchUpdateConversationProjectRequest {
+    pub ids: Vec<Uuid>,
+    pub project_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchUpdateConversationProjectItemResult {
+    pub id: Uuid,
+    pub object: String,
+    pub updated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchUpdateConversationProjectResponse {
+    pub object: String,
+    pub data: Vec<BatchUpdateConversationProjectItemResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationProject {
+    pub id: Uuid,
+    pub object: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationProjectListItem {
+    pub id: Uuid,
+    pub object: String,
+    pub name: String,
+    pub has_instructions: bool,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationProjectsListResponse {
+    pub object: String,
+    pub data: Vec<ConversationProjectListItem>,
+    pub first_id: Option<Uuid>,
+    pub last_id: Option<Uuid>,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationProjectCreateRequest {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ConversationProjectUpdateRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub instructions: NullableField<String>,
+}
+
+impl ConversationProjectUpdateRequest {
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none() && self.instructions.is_missing()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ConversationProjectListParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order: Option<String>,
 }
 
 // AI/OpenAI API Types
@@ -845,6 +1043,8 @@ pub struct AgentItemsListResponse {
     pub has_more: bool,
 }
 
+pub type ConversationItemsResponse = AgentItemsListResponse;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubagentListResponse {
     pub object: String,
@@ -893,4 +1093,56 @@ pub enum AgentSseEvent {
     Typing(AgentTypingEvent),
     Done(AgentDoneEvent),
     Error(AgentErrorEvent),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn nullable_field_request_serialization_distinguishes_missing_and_null() {
+        let conversation_update = ConversationUpdateRequest::default();
+        assert!(conversation_update.is_empty());
+        assert_eq!(
+            serde_json::to_value(&conversation_update).unwrap(),
+            json!({})
+        );
+
+        let conversation_update = ConversationUpdateRequest {
+            project_id: NullableField::null(),
+            ..Default::default()
+        };
+        assert!(!conversation_update.is_empty());
+        assert_eq!(
+            serde_json::to_value(&conversation_update).unwrap(),
+            json!({ "project_id": null })
+        );
+
+        let project_update = ConversationProjectUpdateRequest {
+            instructions: NullableField::null(),
+            ..Default::default()
+        };
+        assert!(!project_update.is_empty());
+        assert_eq!(
+            serde_json::to_value(&project_update).unwrap(),
+            json!({ "instructions": null })
+        );
+    }
+
+    #[test]
+    fn batch_update_project_request_serializes_none_as_explicit_null() {
+        let request = BatchUpdateConversationProjectRequest {
+            ids: vec![Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()],
+            project_id: None,
+        };
+
+        assert_eq!(
+            serde_json::to_value(&request).unwrap(),
+            json!({
+                "ids": ["550e8400-e29b-41d4-a716-446655440000"],
+                "project_id": null
+            })
+        );
+    }
 }

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -572,6 +572,8 @@ pub struct ConversationsListParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project_id: Option<Uuid>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub unassigned_project: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pinned: Option<bool>,
 }
 

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -176,7 +176,7 @@ export function createCustomFetch(
                 statusText: response.statusText
               });
             }
-          } catch (jsonError) {
+          } catch {
             // Not JSON, continue with regular text response
           }
           // Return a new Response with the decrypted data
@@ -186,7 +186,7 @@ export function createCustomFetch(
             statusText: response.statusText
           });
         }
-      } catch (e) {
+      } catch {
         // If it's not JSON or doesn't have encrypted field, return original response
         console.log("Response is not encrypted JSON, returning as-is");
       }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1691,17 +1691,8 @@ export type BatchUpdateConversationProjectRequest = {
   project_id: string | null;
 };
 
-export type BatchUpdateConversationProjectItemResult = {
-  id: string;
-  object: "conversation";
-  updated: boolean;
-  project_id?: string | null;
-  error?: "not_found" | "update_failed";
-};
-
 export type BatchUpdateConversationProjectResponse = {
-  object: "list";
-  data: BatchUpdateConversationProjectItemResult[];
+  success: boolean;
 };
 
 export type ConversationsListParams = {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1616,14 +1616,31 @@ export type Conversation = {
   object: "conversation";
   created_at: number;
   metadata?: Record<string, unknown>;
+  project_id?: string | null;
+  pinned: boolean;
+  updated_at: number;
+};
+
+export type ConversationCreateOptions = {
+  project_id?: string;
+  pinned?: boolean;
 };
 
 export type ConversationCreateRequest = {
   metadata?: Record<string, unknown>;
+  project_id?: string;
+  pinned?: boolean;
+};
+
+export type ConversationUpdateOptions = {
+  project_id?: string | null;
+  pinned?: boolean;
 };
 
 export type ConversationUpdateRequest = {
   metadata?: Record<string, unknown>;
+  project_id?: string | null;
+  pinned?: boolean;
 };
 
 export type ConversationItemsResponse = {
@@ -1667,6 +1684,81 @@ export type BatchDeleteItemResult = {
 export type BatchDeleteConversationsResponse = {
   object: "list";
   data: BatchDeleteItemResult[];
+};
+
+export type BatchUpdateConversationProjectRequest = {
+  ids: string[];
+  project_id: string | null;
+};
+
+export type BatchUpdateConversationProjectItemResult = {
+  id: string;
+  object: "conversation";
+  updated: boolean;
+  project_id?: string | null;
+  error?: "not_found" | "update_failed";
+};
+
+export type BatchUpdateConversationProjectResponse = {
+  object: "list";
+  data: BatchUpdateConversationProjectItemResult[];
+};
+
+export type ConversationsListParams = {
+  limit?: number;
+  after?: string;
+  before?: string;
+  order?: "asc" | "desc";
+  project_id?: string;
+  has_project?: boolean;
+  pinned?: boolean;
+};
+
+export type ConversationProject = {
+  id: string;
+  object: "conversation.project";
+  name: string;
+  instructions: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
+export type ConversationProjectListItem = {
+  id: string;
+  object: "conversation.project";
+  name: string;
+  has_instructions: boolean;
+  created_at: number;
+  updated_at: number;
+};
+
+export type ConversationProjectsListResponse = {
+  object: "list";
+  data: ConversationProjectListItem[];
+  first_id?: string;
+  last_id?: string;
+  has_more: boolean;
+};
+
+export type ConversationProjectCreateRequest = {
+  name: string;
+};
+
+export type ConversationProjectUpdateRequest = {
+  name?: string;
+  instructions?: string | null;
+};
+
+export type ConversationProjectListParams = {
+  limit?: number;
+  after?: string;
+  order?: "asc" | "desc";
+};
+
+export type ConversationProjectDeleteResponse = {
+  id: string;
+  object: "conversation.project.deleted";
+  deleted: boolean;
 };
 
 /**
@@ -1847,9 +1939,14 @@ export type ResponsesCreateRequest = {
  * @deprecated Use openai.conversations.create() instead
  */
 export async function createConversation(
-  metadata?: Record<string, unknown>
+  metadata?: Record<string, unknown>,
+  options?: ConversationCreateOptions
 ): Promise<Conversation> {
-  const requestData: ConversationCreateRequest = metadata ? { metadata } : {};
+  const requestData: ConversationCreateRequest = {
+    ...(metadata !== undefined && { metadata }),
+    ...(options?.project_id !== undefined && { project_id: options.project_id }),
+    ...(options?.pinned !== undefined && { pinned: options.pinned })
+  };
 
   return authenticatedApiCall<ConversationCreateRequest, Conversation>(
     `${apiUrl}/v1/conversations`,
@@ -1904,9 +2001,30 @@ export async function getConversation(conversationId: string): Promise<Conversat
  */
 export async function updateConversation(
   conversationId: string,
-  metadata: Record<string, unknown>
+  metadata?: Record<string, unknown>,
+  options?: ConversationUpdateOptions
 ): Promise<Conversation> {
-  const requestData: ConversationUpdateRequest = { metadata };
+  const requestData: ConversationUpdateRequest = {};
+
+  if (metadata !== undefined) {
+    requestData.metadata = metadata;
+  }
+
+  if (options && Object.prototype.hasOwnProperty.call(options, "project_id")) {
+    requestData.project_id = options.project_id;
+  }
+
+  if (options?.pinned !== undefined) {
+    requestData.pinned = options.pinned;
+  }
+
+  if (
+    requestData.metadata === undefined &&
+    requestData.project_id === undefined &&
+    requestData.pinned === undefined
+  ) {
+    throw new Error("At least one conversation field must be provided");
+  }
 
   return authenticatedApiCall<ConversationUpdateRequest, Conversation>(
     `${apiUrl}/v1/conversations/${encodeURIComponent(conversationId)}`,
@@ -2015,6 +2133,24 @@ export async function batchDeleteConversations(
   );
 }
 
+export async function batchUpdateConversationProject(
+  ids: string[],
+  projectId: string | null
+): Promise<BatchUpdateConversationProjectResponse> {
+  return authenticatedApiCall<
+    BatchUpdateConversationProjectRequest,
+    BatchUpdateConversationProjectResponse
+  >(
+    `${apiUrl}/v1/conversations/batch-update-project`,
+    "POST",
+    {
+      ids,
+      project_id: projectId
+    },
+    "Failed to batch update conversation project"
+  );
+}
+
 /**
  * @deprecated Use openai.conversations.create() with items parameter instead
  * Adds items to a conversation
@@ -2104,6 +2240,24 @@ export async function listConversationItems(
 }
 
 /**
+ * Retrieves a single item from a conversation
+ * @param conversationId - The UUID of the conversation
+ * @param itemId - The UUID of the item to retrieve
+ * @returns A promise resolving to the conversation item
+ */
+export async function getConversationItem(
+  conversationId: string,
+  itemId: string
+): Promise<ConversationItem> {
+  return authenticatedApiCall<void, ConversationItem>(
+    `${apiUrl}/v1/conversations/${encodeURIComponent(conversationId)}/items/${encodeURIComponent(itemId)}`,
+    "GET",
+    undefined,
+    "Failed to retrieve conversation item"
+  );
+}
+
+/**
  * Lists all conversations with pagination (non-standard endpoint)
  * @param params - Optional pagination parameters
  * @returns A promise resolving to a paginated list of conversations
@@ -2124,11 +2278,9 @@ export async function listConversationItems(
  * }
  * ```
  */
-export async function listConversations(params?: {
-  limit?: number;
-  after?: string;
-  before?: string;
-}): Promise<ConversationsListResponse> {
+export async function listConversations(
+  params?: ConversationsListParams
+): Promise<ConversationsListResponse> {
   let url = `${apiUrl}/v1/conversations`;
   const queryParams = [];
 
@@ -2141,6 +2293,18 @@ export async function listConversations(params?: {
   if (params?.before) {
     queryParams.push(`before=${encodeURIComponent(params.before)}`);
   }
+  if (params?.order) {
+    queryParams.push(`order=${encodeURIComponent(params.order)}`);
+  }
+  if (params?.project_id) {
+    queryParams.push(`project_id=${encodeURIComponent(params.project_id)}`);
+  }
+  if (params?.has_project !== undefined) {
+    queryParams.push(`has_project=${params.has_project}`);
+  }
+  if (params?.pinned !== undefined) {
+    queryParams.push(`pinned=${params.pinned}`);
+  }
 
   if (queryParams.length > 0) {
     url += `?${queryParams.join("&")}`;
@@ -2151,6 +2315,81 @@ export async function listConversations(params?: {
     "GET",
     undefined,
     "Failed to list conversations"
+  );
+}
+
+export async function createConversationProject(
+  request: ConversationProjectCreateRequest
+): Promise<ConversationProject> {
+  return authenticatedApiCall<ConversationProjectCreateRequest, ConversationProject>(
+    `${apiUrl}/v1/conversation-projects`,
+    "POST",
+    request,
+    "Failed to create conversation project"
+  );
+}
+
+export async function listConversationProjects(
+  params?: ConversationProjectListParams
+): Promise<ConversationProjectsListResponse> {
+  let url = `${apiUrl}/v1/conversation-projects`;
+  const queryParams = [];
+
+  if (params?.limit !== undefined) {
+    queryParams.push(`limit=${params.limit}`);
+  }
+  if (params?.after) {
+    queryParams.push(`after=${encodeURIComponent(params.after)}`);
+  }
+  if (params?.order) {
+    queryParams.push(`order=${encodeURIComponent(params.order)}`);
+  }
+
+  if (queryParams.length > 0) {
+    url += `?${queryParams.join("&")}`;
+  }
+
+  return authenticatedApiCall<void, ConversationProjectsListResponse>(
+    url,
+    "GET",
+    undefined,
+    "Failed to list conversation projects"
+  );
+}
+
+export async function getConversationProject(projectId: string): Promise<ConversationProject> {
+  return authenticatedApiCall<void, ConversationProject>(
+    `${apiUrl}/v1/conversation-projects/${encodeURIComponent(projectId)}`,
+    "GET",
+    undefined,
+    "Failed to retrieve conversation project"
+  );
+}
+
+export async function updateConversationProject(
+  projectId: string,
+  request: ConversationProjectUpdateRequest
+): Promise<ConversationProject> {
+  if (request.name === undefined && request.instructions === undefined) {
+    throw new Error("At least one conversation project field must be provided");
+  }
+
+  return authenticatedApiCall<ConversationProjectUpdateRequest, ConversationProject>(
+    `${apiUrl}/v1/conversation-projects/${encodeURIComponent(projectId)}`,
+    "POST",
+    request,
+    "Failed to update conversation project"
+  );
+}
+
+export async function deleteConversationProject(
+  projectId: string
+): Promise<ConversationProjectDeleteResponse> {
+  return authenticatedApiCall<void, ConversationProjectDeleteResponse>(
+    `${apiUrl}/v1/conversation-projects/${encodeURIComponent(projectId)}`,
+    "DELETE",
+    undefined,
+    "Failed to delete conversation project"
   );
 }
 
@@ -2251,7 +2490,6 @@ export type InstructionUpdateRequest = {
 export type InstructionListParams = {
   limit?: number;
   after?: string;
-  before?: string;
   order?: string;
 };
 
@@ -2314,7 +2552,6 @@ export async function createInstruction(request: InstructionCreateRequest): Prom
  * Query Parameters:
  * - limit: Number of results per page (1-100, default: 20)
  * - after: UUID cursor for forward pagination
- * - before: UUID cursor for backward pagination
  * - order: Sort order ("asc" or "desc", default: "desc")
  *
  * @example
@@ -2339,9 +2576,6 @@ export async function listInstructions(
   }
   if (params?.after) {
     queryParams.push(`after=${encodeURIComponent(params.after)}`);
-  }
-  if (params?.before) {
-    queryParams.push(`before=${encodeURIComponent(params.before)}`);
   }
   if (params?.order) {
     queryParams.push(`order=${encodeURIComponent(params.order)}`);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1618,7 +1618,7 @@ export type Conversation = {
   metadata?: Record<string, unknown>;
   project_id?: string | null;
   pinned: boolean;
-  updated_at: number;
+  last_activity_at: number;
 };
 
 export type ConversationCreateOptions = {
@@ -2268,7 +2268,7 @@ export async function getConversationItem(
  * @description
  * This is a custom extension not part of the standard OpenAI Conversations API.
  * This function fetches a paginated list of the user's conversations.
- * Conversations are sorted by created_at (most recent first).
+ * Conversations are sorted by last_activity_at (most recent activity first).
  *
  * @example
  * ```typescript

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1710,7 +1710,6 @@ export type ConversationsListParams = {
   before?: string;
   order?: "asc" | "desc";
   project_id?: string;
-  has_project?: boolean;
   pinned?: boolean;
 };
 
@@ -1727,7 +1726,6 @@ export type ConversationProjectListItem = {
   id: string;
   object: "conversation.project";
   name: string;
-  has_instructions: boolean;
   created_at: number;
   updated_at: number;
 };
@@ -2298,9 +2296,6 @@ export async function listConversations(
   }
   if (params?.project_id) {
     queryParams.push(`project_id=${encodeURIComponent(params.project_id)}`);
-  }
-  if (params?.has_project !== undefined) {
-    queryParams.push(`has_project=${params.has_project}`);
   }
   if (params?.pinned !== undefined) {
     queryParams.push(`pinned=${params.pinned}`);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1701,6 +1701,7 @@ export type ConversationsListParams = {
   before?: string;
   order?: "asc" | "desc";
   project_id?: string;
+  unassigned_project?: boolean;
   pinned?: boolean;
 };
 
@@ -2287,6 +2288,9 @@ export async function listConversations(
   }
   if (params?.project_id) {
     queryParams.push(`project_id=${encodeURIComponent(params.project_id)}`);
+  }
+  if (params?.unassigned_project !== undefined) {
+    queryParams.push(`unassigned_project=${params.unassigned_project}`);
   }
   if (params?.pinned !== undefined) {
     queryParams.push(`pinned=${params.pinned}`);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -33,7 +33,6 @@ export type {
   BatchDeleteItemResult,
   BatchDeleteConversationsResponse,
   BatchUpdateConversationProjectRequest,
-  BatchUpdateConversationProjectItemResult,
   BatchUpdateConversationProjectResponse,
   ConversationProject,
   ConversationProjectListItem,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -20,15 +20,28 @@ export type {
   ResponsesCreateRequest,
   Conversation,
   ConversationItem,
+  ConversationCreateOptions,
   ConversationCreateRequest,
+  ConversationUpdateOptions,
   ConversationUpdateRequest,
   ConversationItemsResponse,
   ConversationsListResponse,
+  ConversationsListParams,
   ConversationDeleteResponse,
   ConversationsDeleteResponse,
   BatchDeleteConversationsRequest,
   BatchDeleteItemResult,
   BatchDeleteConversationsResponse,
+  BatchUpdateConversationProjectRequest,
+  BatchUpdateConversationProjectItemResult,
+  BatchUpdateConversationProjectResponse,
+  ConversationProject,
+  ConversationProjectListItem,
+  ConversationProjectsListResponse,
+  ConversationProjectCreateRequest,
+  ConversationProjectUpdateRequest,
+  ConversationProjectListParams,
+  ConversationProjectDeleteResponse,
   AgentCreatedBy,
   MainAgentResponse,
   CreateSubagentRequest,
@@ -44,6 +57,25 @@ export type {
 
 // Export API key management functions
 export { createApiKey, listApiKeys, deleteApiKey } from "./api";
+
+// Export conversation and conversation-project API functions
+export {
+  createConversation,
+  getConversation,
+  updateConversation,
+  deleteConversation,
+  listConversationItems,
+  getConversationItem,
+  listConversations,
+  deleteConversations,
+  batchDeleteConversations,
+  batchUpdateConversationProject,
+  createConversationProject,
+  listConversationProjects,
+  getConversationProject,
+  updateConversationProject,
+  deleteConversationProject
+} from "./api";
 
 // Export Agent API functions
 export {

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -743,7 +743,37 @@ export type OpenSecretContextType = {
    * @param request - The request parameters for creating a response
    * @returns A promise resolving to the created response or a stream
    */
-  createResponse: (request: api.ResponsesCreateRequest) => Promise<any>;
+  createResponse: typeof api.createResponse;
+
+  /**
+   * Creates a single conversation with optional metadata/project/pin state.
+   */
+  createConversation: typeof api.createConversation;
+
+  /**
+   * Retrieves a single conversation.
+   */
+  getConversation: typeof api.getConversation;
+
+  /**
+   * Updates a single conversation's metadata/project/pin state.
+   */
+  updateConversation: typeof api.updateConversation;
+
+  /**
+   * Deletes a single conversation.
+   */
+  deleteConversation: typeof api.deleteConversation;
+
+  /**
+   * Lists items in a single conversation.
+   */
+  listConversationItems: typeof api.listConversationItems;
+
+  /**
+   * Retrieves a single conversation item.
+   */
+  getConversationItem: typeof api.getConversationItem;
 
   /**
    * Lists all conversations with pagination (non-standard endpoint)
@@ -759,11 +789,7 @@ export type OpenSecretContextType = {
    * - openai.conversations.items.list()
    * - openai.conversations.items.retrieve()
    */
-  listConversations: (params?: {
-    limit?: number;
-    after?: string;
-    before?: string;
-  }) => Promise<api.ConversationsListResponse>;
+  listConversations: typeof api.listConversations;
 
   /**
    * Deletes all conversations
@@ -777,6 +803,36 @@ export type OpenSecretContextType = {
    * @returns A promise resolving to per-item deletion results
    */
   batchDeleteConversations: typeof api.batchDeleteConversations;
+
+  /**
+   * Batch moves conversations into a project or clears project assignment.
+   */
+  batchUpdateConversationProject: typeof api.batchUpdateConversationProject;
+
+  /**
+   * Creates a new conversation project.
+   */
+  createConversationProject: typeof api.createConversationProject;
+
+  /**
+   * Lists conversation projects with pagination.
+   */
+  listConversationProjects: typeof api.listConversationProjects;
+
+  /**
+   * Retrieves a single conversation project.
+   */
+  getConversationProject: typeof api.getConversationProject;
+
+  /**
+   * Updates a conversation project and/or its project-scoped instructions.
+   */
+  updateConversationProject: typeof api.updateConversationProject;
+
+  /**
+   * Deletes a conversation project.
+   */
+  deleteConversationProject: typeof api.deleteConversationProject;
 
   /**
    * Creates a new instruction
@@ -922,9 +978,21 @@ export const OpenSecretContext = createContext<OpenSecretContextType>({
   cancelResponse: api.cancelResponse,
   deleteResponse: api.deleteResponse,
   createResponse: api.createResponse,
+  createConversation: api.createConversation,
+  getConversation: api.getConversation,
+  updateConversation: api.updateConversation,
+  deleteConversation: api.deleteConversation,
+  listConversationItems: api.listConversationItems,
+  getConversationItem: api.getConversationItem,
   listConversations: api.listConversations,
   deleteConversations: api.deleteConversations,
   batchDeleteConversations: api.batchDeleteConversations,
+  batchUpdateConversationProject: api.batchUpdateConversationProject,
+  createConversationProject: api.createConversationProject,
+  listConversationProjects: api.listConversationProjects,
+  getConversationProject: api.getConversationProject,
+  updateConversationProject: api.updateConversationProject,
+  deleteConversationProject: api.deleteConversationProject,
   createInstruction: api.createInstruction,
   listInstructions: api.listInstructions,
   getInstruction: api.getInstruction,
@@ -1338,9 +1406,21 @@ export function OpenSecretProvider({
     cancelResponse: api.cancelResponse,
     deleteResponse: api.deleteResponse,
     createResponse: api.createResponse,
+    createConversation: api.createConversation,
+    getConversation: api.getConversation,
+    updateConversation: api.updateConversation,
+    deleteConversation: api.deleteConversation,
+    listConversationItems: api.listConversationItems,
+    getConversationItem: api.getConversationItem,
     listConversations: api.listConversations,
     deleteConversations: api.deleteConversations,
     batchDeleteConversations: api.batchDeleteConversations,
+    batchUpdateConversationProject: api.batchUpdateConversationProject,
+    createConversationProject: api.createConversationProject,
+    listConversationProjects: api.listConversationProjects,
+    getConversationProject: api.getConversationProject,
+    updateConversationProject: api.updateConversationProject,
+    deleteConversationProject: api.deleteConversationProject,
     createInstruction: api.createInstruction,
     listInstructions: api.listInstructions,
     getInstruction: api.getInstruction,


### PR DESCRIPTION
## Summary
- add conversation project request/response types and client methods in the TypeScript and Rust SDKs
- expose conversation CRUD, item retrieval, batch project updates, and conversation-project APIs through the React SDK exports and context
- add Rust coverage for endpoint query building plus nullable and empty update handling
- tighten the React context typing for `createResponse`

## Validation
- TypeScript: prettier check, eslint, and `bun run build`
- Rust: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --lib --all-features`, and `cargo check --all-features`
- Full `bun test --env-file .env.local` and `cargo test --all-features` were attempted separately and are environment-dependent / not fully green in this session


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation management: create, view, edit, delete conversations
  * Conversation items: list and retrieve individual items
  * Conversation projects: create, view, edit, delete, and list projects
  * Batch update: assign multiple conversations to a project at once
  * Enhanced filtering & sorting: filter by project/unassigned, pinned; sort by last activity

* **Bug Fixes / Validation**
  * Update calls now reject empty update requests to prevent no-op submissions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->