### PR TITLE
fix: align third-party audience handling with platform

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,10 +26,10 @@ function TokenGenerator() {
     <div>
       <div className="auth-form">
         <input
-          type="url"
+          type="text"
           value={audience}
           onChange={(e) => setAudience(e.target.value)}
-          placeholder="Enter audience URL"
+          placeholder="Enter audience"
         />
         <button onClick={generateToken}>Generate Token</button>
       </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -924,11 +924,11 @@ export type ThirdPartyTokenResponse = {
 
 /**
  * Generates a JWT token for use with third-party services
- * @param audience - Optional URL of the service
+ * @param audience - Optional audience value for the target service
  * @returns A promise resolving to the token response containing the JWT
  *
  * @description
- * - If audience is provided, it can be any valid URL
+ * - If audience is provided, it can be a valid URL or another accepted audience string
  * - If audience is omitted, a token with no audience restriction will be generated
  */
 export async function generateThirdPartyToken(audience?: string): Promise<ThirdPartyTokenResponse> {

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -421,15 +421,15 @@ export type OpenSecretContextType = {
 
   /**
    * Generates a JWT token for use with third-party services
-   * @param audience - Optional URL of the service (e.g. "https://billing.opensecret.cloud")
+   * @param audience - Optional audience value for the target service
    * @returns A promise resolving to the token response
    * @throws {Error} If:
    * - The user is not authenticated
-   * - The audience URL is invalid (if provided)
+   * - The audience value is invalid (if provided)
    *
    *
    * - Generates a signed JWT token for use with third-party services
-   * - If audience is provided, it can be any valid URL
+   * - If audience is provided, it can be a valid URL or another accepted audience string
    * - If audience is omitted, a token with no audience restriction will be generated
    * - Requires an active authentication session
    * - Token can be used to authenticate with the specified service

--- a/src/lib/test/integration/api.test.ts
+++ b/src/lib/test/integration/api.test.ts
@@ -178,12 +178,19 @@ test("Third party token generation", async () => {
   expect(typeof opensSecretResponse.token).toBe("string");
   expect(opensSecretResponse.token.length).toBeGreaterThan(0);
 
-  // Test with any valid URL (now allowed)
+  // Test with any valid URL
   const anyValidUrl = "https://google.com";
   const googleResponse = await generateThirdPartyToken(anyValidUrl);
   expect(googleResponse.token).toBeDefined();
   expect(typeof googleResponse.token).toBe("string");
   expect(googleResponse.token.length).toBeGreaterThan(0);
+
+  // Test with a non-URL audience identifier
+  const stringAudience = "authenticated";
+  const stringAudienceResponse = await generateThirdPartyToken(stringAudience);
+  expect(stringAudienceResponse.token).toBeDefined();
+  expect(typeof stringAudienceResponse.token).toBe("string");
+  expect(stringAudienceResponse.token.length).toBeGreaterThan(0);
 
   // Test with no audience (should work)
   const noAudienceResponse = await generateThirdPartyToken();
@@ -191,10 +198,10 @@ test("Third party token generation", async () => {
   expect(typeof noAudienceResponse.token).toBe("string");
   expect(noAudienceResponse.token.length).toBeGreaterThan(0);
 
-  // Test invalid audience URL (this should still fail)
+  // Test reserved internal audience (this should still fail)
   try {
-    await generateThirdPartyToken("not-a-url");
-    throw new Error("Should not accept invalid URL");
+    await generateThirdPartyToken("access");
+    throw new Error("Should not accept reserved internal audience");
   } catch (error: any) {
     expect(error.message).toBe("Bad Request");
   }


### PR DESCRIPTION
## Summary
- align the SDK third-party token contract with platform support for non-URL audience strings
- add an integration test for a colonless audience and keep the reserved internal audience rejection check
- relax the sample token generator input and API comments from URL-only wording to generic audience wording

## Validation
- npx eslint src/App.tsx src/lib/api.ts src/lib/main.tsx src/lib/test/integration/api.test.ts
- npm run build
- nix develop -c sh -c "set -a && . ./.env.local && set +a && bun test src/lib/test/integration/api.test.ts" *(fails in this environment before the changed path because the suite expects a local API at http://localhost:3000 and errors during attestation)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret-sdk/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * The audience input field now flexibly accepts audience values in addition to URLs, enabling broader integration scenarios.

* **Documentation**
  * Updated audience parameter documentation to clarify accepted input types beyond URLs.

* **Tests**
  * Expanded integration test coverage to validate audience value handling for both URL and non-URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->