### PR TITLE
fix: replace unmaintained Rust CBOR dependency

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1"
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_cbor = "0.11"
+ciborium = "0.2"
 percent-encoding = "2.3"
 
 # Cryptography
@@ -29,8 +29,6 @@ chacha20poly1305 = "0.10"
 x25519-dalek = { version = "2.0", features = ["static_secrets"] }
 hkdf = "0.12"
 p256 = { version = "0.13", features = ["ecdh", "pkcs8"] }
-getrandom = "0.2"
-rand = "0.8"
 sha2 = "0.10"
 base64 = "0.22"
 ring = "0.17"  # For certificate validation

--- a/rust/src/attestation.rs
+++ b/rust/src/attestation.rs
@@ -1,8 +1,8 @@
+use crate::cbor::{self, Value as CborValue};
 use crate::error::{Error, Result};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use ring::signature;
 use serde::{Deserialize, Serialize};
-use serde_cbor::Value as CborValue;
 use x509_parser::prelude::*;
 
 // AWS Nitro Root Certificate (production)
@@ -54,7 +54,7 @@ impl AttestationVerifier {
         let document_bytes = BASE64.decode(document_b64)?;
 
         // Parse COSE_Sign1 structure
-        let cbor_value: CborValue = serde_cbor::from_slice(&document_bytes).map_err(Error::Cbor)?;
+        let cbor_value: CborValue = cbor::from_slice(&document_bytes)?;
 
         let cose_sign1 = match &cbor_value {
             CborValue::Array(arr) => arr,
@@ -100,7 +100,7 @@ impl AttestationVerifier {
         };
 
         // Parse attestation document from payload
-        let doc_cbor: CborValue = serde_cbor::from_slice(payload).map_err(Error::Cbor)?;
+        let doc_cbor: CborValue = cbor::from_slice(payload)?;
 
         let doc = self.parse_attestation_document(&doc_cbor)?;
 
@@ -180,12 +180,7 @@ impl AttestationVerifier {
                 }
                 "timestamp" => {
                     doc.timestamp = match value {
-                        CborValue::Integer(i) if *i >= 0 => *i as u64,
-                        CborValue::Integer(_) => {
-                            return Err(Error::AttestationVerificationFailed(
-                                "Invalid timestamp: negative value".to_string(),
-                            ))
-                        }
+                        CborValue::Integer(i) => cbor_integer_to_u64(*i, "timestamp")?,
                         _ => {
                             return Err(Error::AttestationVerificationFailed(
                                 "Invalid timestamp: not an integer".to_string(),
@@ -215,12 +210,7 @@ impl AttestationVerifier {
 
                     for (pcr_key, pcr_value) in pcrs_map {
                         let index = match pcr_key {
-                            CborValue::Integer(i) if *i >= 0 => *i as usize,
-                            CborValue::Integer(_) => {
-                                return Err(Error::AttestationVerificationFailed(
-                                    "Invalid PCR index: negative value".to_string(),
-                                ))
-                            }
+                            CborValue::Integer(i) => cbor_integer_to_usize(*i, "PCR index")?,
                             _ => {
                                 return Err(Error::AttestationVerificationFailed(
                                     "Invalid PCR index: not an integer".to_string(),
@@ -603,6 +593,24 @@ fn extract_ec_point(pubkey_bytes: &[u8], expected_size: usize) -> Result<&[u8]> 
     )))
 }
 
+fn cbor_integer_to_u64(value: ciborium::value::Integer, field_name: &str) -> Result<u64> {
+    u64::try_from(value).map_err(|_| {
+        Error::AttestationVerificationFailed(format!(
+            "Invalid {}: negative or out of range value",
+            field_name
+        ))
+    })
+}
+
+fn cbor_integer_to_usize(value: ciborium::value::Integer, field_name: &str) -> Result<usize> {
+    usize::try_from(value).map_err(|_| {
+        Error::AttestationVerificationFailed(format!(
+            "Invalid {}: negative or out of range value",
+            field_name
+        ))
+    })
+}
+
 fn create_sig_structure(protected: &[u8], payload: &[u8]) -> Result<Vec<u8>> {
     // Create the COSE_Sign1 signature structure as a CBOR array
     // ["Signature1", protected, external_aad, payload]
@@ -614,12 +622,11 @@ fn create_sig_structure(protected: &[u8], payload: &[u8]) -> Result<Vec<u8>> {
     ]);
 
     // Encode to CBOR bytes
-    serde_cbor::to_vec(&sig_structure).map_err(Error::Cbor)
+    cbor::to_vec(&sig_structure)
 }
 
 #[cfg(feature = "mock-attestation")]
 pub fn create_mock_attestation_document(nonce: &str) -> Result<String> {
-    use serde_cbor::to_vec;
     use std::collections::HashMap;
 
     let mut pcrs = HashMap::new();
@@ -638,17 +645,17 @@ pub fn create_mock_attestation_document(nonce: &str) -> Result<String> {
     };
 
     // Create a mock COSE_Sign1 structure
-    let payload = to_vec(&doc).map_err(Error::Cbor)?;
+    let payload = cbor::to_vec(&doc)?;
     let protected = vec![0u8; 32]; // Mock protected header
     let signature = vec![0u8; 64]; // Mock signature
 
     let cose_sign1 = vec![
         CborValue::Bytes(protected),
-        CborValue::Map(std::collections::BTreeMap::new()), // Empty unprotected headers
+        CborValue::Map(Vec::new()), // Empty unprotected headers
         CborValue::Bytes(payload),
         CborValue::Bytes(signature),
     ];
 
-    let cose_bytes = to_vec(&CborValue::Array(cose_sign1)).map_err(Error::Cbor)?;
+    let cose_bytes = cbor::to_vec(&CborValue::Array(cose_sign1))?;
     Ok(BASE64.encode(cose_bytes))
 }

--- a/rust/src/cbor.rs
+++ b/rust/src/cbor.rs
@@ -1,0 +1,15 @@
+use crate::error::{Error, Result};
+use serde::{de::DeserializeOwned, Serialize};
+use std::io::Cursor;
+
+pub(crate) type Value = ciborium::value::Value;
+
+pub(crate) fn from_slice<T: DeserializeOwned>(bytes: &[u8]) -> Result<T> {
+    ciborium::de::from_reader(Cursor::new(bytes)).map_err(|e| Error::Cbor(e.to_string()))
+}
+
+pub(crate) fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(value, &mut bytes).map_err(|e| Error::Cbor(e.to_string()))?;
+    Ok(bytes)
+}

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,5 +1,6 @@
 use crate::{
     attestation::{AttestationDocument, AttestationVerifier},
+    cbor::{self, Value as CborValue},
     crypto::{self},
     error::{Error, Result},
     session::SessionManager,
@@ -12,7 +13,6 @@ use reqwest::{
     Client,
 };
 use serde::{de::DeserializeOwned, Serialize};
-use serde_cbor::Value as CborValue;
 use std::sync::{Arc, RwLock};
 use uuid::Uuid;
 
@@ -321,7 +321,7 @@ impl OpenSecretClient {
     fn parse_mock_attestation(&self, document_b64: &str) -> Result<AttestationDocument> {
         // For mock/dev mode, just extract the essential fields without full verification
         let document_bytes = BASE64.decode(document_b64)?;
-        let cbor_value: CborValue = serde_cbor::from_slice(&document_bytes)?;
+        let cbor_value: CborValue = cbor::from_slice(&document_bytes)?;
 
         // Parse COSE_Sign1 structure
         let cose_sign1 = match &cbor_value {
@@ -344,7 +344,7 @@ impl OpenSecretClient {
         };
 
         // Parse attestation document from payload
-        let doc_cbor: CborValue = serde_cbor::from_slice(payload)?;
+        let doc_cbor: CborValue = cbor::from_slice(payload)?;
         let map = match &doc_cbor {
             CborValue::Map(m) => m,
             _ => {
@@ -1942,9 +1942,7 @@ mod tests {
     use super::*;
     use crate::PushNotificationKeyPair;
     use futures::StreamExt;
-    use serde_cbor::Value as CborValue;
     use serde_json::json;
-    use std::collections::BTreeMap;
     use wiremock::{
         matchers::{header, method, path},
         Match, Mock, MockServer, Request, Respond, ResponseTemplate,
@@ -2008,25 +2006,26 @@ mod tests {
     }
 
     fn build_mock_attestation_document(nonce: &str, server_public_key: &[u8; 32]) -> String {
-        let mut payload = BTreeMap::new();
-        payload.insert(
-            CborValue::Text("public_key".to_string()),
-            CborValue::Bytes(server_public_key.to_vec()),
-        );
-        payload.insert(
-            CborValue::Text("nonce".to_string()),
-            CborValue::Bytes(nonce.as_bytes().to_vec()),
-        );
+        let payload = CborValue::Map(vec![
+            (
+                CborValue::Text("public_key".to_string()),
+                CborValue::Bytes(server_public_key.to_vec()),
+            ),
+            (
+                CborValue::Text("nonce".to_string()),
+                CborValue::Bytes(nonce.as_bytes().to_vec()),
+            ),
+        ]);
 
-        let payload = serde_cbor::to_vec(&CborValue::Map(payload)).unwrap();
+        let payload = cbor::to_vec(&payload).unwrap();
         let cose_sign1 = CborValue::Array(vec![
             CborValue::Bytes(vec![]),
-            CborValue::Map(BTreeMap::new()),
+            CborValue::Map(Vec::new()),
             CborValue::Bytes(payload),
             CborValue::Bytes(vec![]),
         ]);
 
-        BASE64.encode(serde_cbor::to_vec(&cose_sign1).unwrap())
+        BASE64.encode(cbor::to_vec(&cose_sign1).unwrap())
     }
 
     fn encrypted_response<T: Serialize>(session_key: &[u8; 32], payload: &T) -> serde_json::Value {

--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -4,6 +4,7 @@ use chacha20poly1305::{
     aead::{Aead, KeyInit, Nonce},
     ChaCha20Poly1305,
 };
+use p256::elliptic_curve::rand_core::{OsRng, RngCore};
 use x25519_dalek::{EphemeralSecret, PublicKey as X25519PublicKey, SharedSecret, StaticSecret};
 
 // Re-export for tests
@@ -16,7 +17,7 @@ pub struct KeyPair {
 }
 
 pub fn generate_key_pair() -> KeyPair {
-    let secret = StaticSecret::random_from_rng(rand::thread_rng());
+    let secret = StaticSecret::random_from_rng(OsRng);
     let public = X25519PublicKey::from(&secret);
     KeyPair { secret, public }
 }
@@ -35,18 +36,18 @@ pub fn decrypt_message(ciphertext: &[u8], key: &[u8; 32]) -> Result<Vec<u8>> {
 
 pub fn generate_random_bytes<const N: usize>() -> [u8; N] {
     let mut bytes = [0u8; N];
-    getrandom::getrandom(&mut bytes).expect("Failed to generate random bytes");
+    OsRng.fill_bytes(&mut bytes);
     bytes
 }
 
 pub fn generate_ephemeral_keypair() -> (EphemeralSecret, PublicKey) {
-    let secret = EphemeralSecret::random_from_rng(rand::thread_rng());
+    let secret = EphemeralSecret::random_from_rng(OsRng);
     let public = PublicKey::from(&secret);
     (secret, public)
 }
 
 pub fn generate_static_keypair() -> (StaticSecret, PublicKey) {
-    let secret = StaticSecret::random_from_rng(rand::thread_rng());
+    let secret = StaticSecret::random_from_rng(OsRng);
     let public = PublicKey::from(&secret);
     (secret, public)
 }

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -9,7 +9,7 @@ pub enum Error {
     Serialization(#[from] serde_json::Error),
 
     #[error("CBOR error: {0}")]
-    Cbor(#[from] serde_cbor::Error),
+    Cbor(String),
 
     #[error("Cryptographic error: {0}")]
     Crypto(String),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod attestation;
+mod cbor;
 pub mod client;
 pub mod crypto;
 pub mod error;


### PR DESCRIPTION
## Summary
- Replace unmaintained serde_cbor usage in the Rust SDK with ciborium-backed helpers.
- Remove direct rand 0.8 and getrandom dependencies; use the crypto stack's rand_core OsRng path for X25519 keys and random bytes.
- Preserve Nitro attestation parsing and COSE signature-structure encoding through the new internal CBOR module.

## Validation
- cargo fmt --manifest-path rust/Cargo.toml -- --check
- cargo check --manifest-path rust/Cargo.toml --locked
- cargo check --manifest-path rust/Cargo.toml --locked --features mock-attestation
- cargo clippy --manifest-path rust/Cargo.toml --locked --all-targets --all-features -- -D warnings
- cargo test --manifest-path rust/Cargo.toml --locked --lib
- cargo test --manifest-path rust/Cargo.toml --locked --lib --features mock-attestation
- cargo test --manifest-path rust/Cargo.toml --locked --test crypto --test attestation --test session

Note: full cargo test reaches live API integration tests locally; one API-key streaming test returned 403 Usage limit reached, which is an account quota issue rather than a code failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret-sdk/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CBOR serialization library dependencies for improved compatibility.
  * Removed unnecessary direct randomness utility dependencies.
  * Updated random number generation to use OS-backed RNG for enhanced security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->