### PR TITLE
Allow dev fake attestation on loopback ports

### DIFF
--- a/src/lib/attestation.ts
+++ b/src/lib/attestation.ts
@@ -246,6 +246,17 @@ const FakeAttestationDocumentSchema = z.object({
 
 type FakeAttestationDocument = z.infer<typeof FakeAttestationDocumentSchema>;
 
+const LOCAL_DEVELOPMENT_API_HOSTS = new Set(["127.0.0.1", "localhost", "0.0.0.0", "[::1]"]);
+
+export function isLocalDevelopmentApiUrl(apiUrl: string): boolean {
+  try {
+    const url = new URL(apiUrl);
+    return url.protocol === "http:" && LOCAL_DEVELOPMENT_API_HOSTS.has(url.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
 async function fakeAuthenticate(
   attestationDocumentBase64: string
 ): Promise<FakeAttestationDocument> {
@@ -269,12 +280,7 @@ export async function verifyAttestation(
     const apiUrl = explicitApiUrl || getApiUrl();
 
     // With a local backend we get a fake attestation document, so we'll just pretend to authenticate it
-    if (
-      apiUrl &&
-      (apiUrl === "http://127.0.0.1:3000" ||
-        apiUrl === "http://localhost:3000" ||
-        apiUrl === "http://0.0.0.0:3000")
-    ) {
+    if (apiUrl && isLocalDevelopmentApiUrl(apiUrl)) {
       console.log("DEV MODE: Using fake attestation document");
       const fakeDocument = await fakeAuthenticate(attestationDocumentBase64);
       return fakeDocument as AttestationDocument;

--- a/src/lib/test/integration/attestation.test.ts
+++ b/src/lib/test/integration/attestation.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "bun:test";
-import { createSigStructure, parseDocumentData, parseDocumentPayload } from "../../attestation";
+import {
+  createSigStructure,
+  isLocalDevelopmentApiUrl,
+  parseDocumentData,
+  parseDocumentPayload
+} from "../../attestation";
 import { encode } from "@stablelib/base64";
 
 const HARDCODED_TEST_ATTESTATION_DOCUMENT =
@@ -26,4 +31,31 @@ test("Makes CoseSign1 bytes correctly", async () => {
   const hash = await crypto.subtle.digest("SHA-384", coseSign1);
 
   expect(encode(new Uint8Array(hash))).toBe(EXPECTED_SIGNATURE_STRUCTURE_DIGEST);
+});
+
+test("Recognizes local development API URLs independent of port", () => {
+  const localApiUrls = [
+    "http://127.0.0.1:31110",
+    "http://localhost:31110/",
+    "http://0.0.0.0:31110",
+    "http://[::1]:31110"
+  ];
+
+  for (const apiUrl of localApiUrls) {
+    expect(isLocalDevelopmentApiUrl(apiUrl)).toBe(true);
+  }
+});
+
+test("Does not recognize production or invalid API URLs as local development URLs", () => {
+  const nonLocalApiUrls = [
+    "https://api.opensecret.cloud",
+    "https://localhost:31110",
+    "http://api.opensecret.cloud",
+    "localhost:31110",
+    "not a url"
+  ];
+
+  for (const apiUrl of nonLocalApiUrls) {
+    expect(isLocalDevelopmentApiUrl(apiUrl)).toBe(false);
+  }
 });


### PR DESCRIPTION
## Summary
- Replace the exact port-3000 dev attestation URL check with a URL parser for local HTTP API hosts
- Allow 127.0.0.1, localhost, 0.0.0.0, and [::1] on any port, including trailing slashes
- Add Bun coverage for local, production, HTTPS localhost, and invalid URL cases

Fixes #83

## Verification
- VITE_OPEN_SECRET_API_URL=http://127.0.0.1:31110 nix develop -c bun test src/lib/test/integration/attestation.test.ts --timeout 30000
- nix develop -c ./node_modules/.bin/prettier --check src/lib/attestation.ts src/lib/test/integration/attestation.test.ts
- nix develop -c bun run build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret-sdk/pull/85" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for local development API detection across various hostname and protocol configurations.

* **Improvements**
  * Enhanced attestation verification to support a broader range of local development environments, including different hostnames and IPv6 addresses, beyond specific port configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->