### PR TITLE
Support base64 embedding responses in the Rust SDK

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensecret"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2021"
 authors = ["OpenSecret"]
 description = "Rust SDK for OpenSecret - secure AI API interactions with nitro attestation"

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -853,11 +853,35 @@ pub struct EmbeddingResponse {
     pub usage: EmbeddingUsage,
 }
 
+/// An embedding vector in the representation requested by `encoding_format`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EmbeddingVector {
+    Float(Vec<f64>),
+    Base64(String),
+}
+
+impl EmbeddingVector {
+    pub fn as_floats(&self) -> Option<&[f64]> {
+        match self {
+            Self::Float(values) => Some(values),
+            Self::Base64(_) => None,
+        }
+    }
+
+    pub fn as_base64(&self) -> Option<&str> {
+        match self {
+            Self::Float(_) => None,
+            Self::Base64(value) => Some(value),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddingData {
     pub object: String,
     pub index: i32,
-    pub embedding: Vec<f64>,
+    pub embedding: EmbeddingVector,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1142,5 +1166,76 @@ mod tests {
         assert_eq!(response.message, "");
         assert_eq!(response.access_token.as_deref(), Some("new-access"));
         assert_eq!(response.refresh_token, None);
+    }
+
+    #[test]
+    fn embedding_response_deserializes_float_vectors() {
+        let response: EmbeddingResponse = serde_json::from_value(json!({
+            "object": "list",
+            "data": [{
+                "object": "embedding",
+                "index": 0,
+                "embedding": [0.1, 0.2, 0.3]
+            }],
+            "model": "nomic-embed-text",
+            "usage": { "prompt_tokens": 4, "total_tokens": 4 }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            response.data[0].embedding,
+            EmbeddingVector::Float(vec![0.1, 0.2, 0.3])
+        );
+        assert_eq!(
+            response.data[0].embedding.as_floats(),
+            Some([0.1, 0.2, 0.3].as_slice())
+        );
+        assert_eq!(response.data[0].embedding.as_base64(), None);
+        assert_eq!(
+            serde_json::to_value(&response).unwrap()["data"][0]["embedding"],
+            json!([0.1, 0.2, 0.3])
+        );
+    }
+
+    #[test]
+    fn embedding_response_deserializes_base64_vectors() {
+        let response: EmbeddingResponse = serde_json::from_value(json!({
+            "object": "list",
+            "data": [{
+                "object": "embedding",
+                "index": 0,
+                "embedding": "AQIDBA=="
+            }],
+            "model": "nomic-embed-text",
+            "usage": { "prompt_tokens": 4, "total_tokens": 4 }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            response.data[0].embedding,
+            EmbeddingVector::Base64("AQIDBA==".to_string())
+        );
+        assert_eq!(response.data[0].embedding.as_floats(), None);
+        assert_eq!(response.data[0].embedding.as_base64(), Some("AQIDBA=="));
+        assert_eq!(
+            serde_json::to_value(&response).unwrap()["data"][0]["embedding"],
+            json!("AQIDBA==")
+        );
+    }
+
+    #[test]
+    fn embedding_response_rejects_unknown_vector_representations() {
+        let response = serde_json::from_value::<EmbeddingResponse>(json!({
+            "object": "list",
+            "data": [{
+                "object": "embedding",
+                "index": 0,
+                "embedding": { "values": [0.1, 0.2, 0.3] }
+            }],
+            "model": "nomic-embed-text",
+            "usage": { "prompt_tokens": 4, "total_tokens": 4 }
+        }));
+
+        assert!(response.is_err());
     }
 }

--- a/rust/tests/ai_integration.rs
+++ b/rust/tests/ai_integration.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine as _};
 use futures::StreamExt;
 use opensecret::{
     ChatCompletionRequest, ChatMessage, EmbeddingInput, EmbeddingRequest, Error, Function,
@@ -401,7 +402,7 @@ async fn test_guest_user_cannot_use_ai() {
 }
 
 #[tokio::test]
-async fn test_create_embeddings_single_input() {
+async fn test_create_embeddings_float_encoding() {
     let client = setup_authenticated_client()
         .await
         .expect("Failed to setup client");
@@ -409,7 +410,7 @@ async fn test_create_embeddings_single_input() {
     let request = EmbeddingRequest {
         input: EmbeddingInput::Single("Hello, world!".to_string()),
         model: embedding_model(),
-        encoding_format: None,
+        encoding_format: Some("float".to_string()),
         dimensions: None,
         user: None,
     };
@@ -425,12 +426,12 @@ async fn test_create_embeddings_single_input() {
     assert_eq!(response.data[0].object, "embedding");
     assert_eq!(response.data[0].index, 0);
 
-    let expected_dimensions = embedding_dimensions();
-    assert_eq!(
-        response.data[0].embedding.len(),
-        expected_dimensions,
-        "Unexpected embedding dimensions"
-    );
+    let embedding = response.data[0]
+        .embedding
+        .as_floats()
+        .expect("Expected float embedding response");
+    assert_eq!(embedding.len(), embedding_dimensions());
+    assert!(embedding.iter().all(|value| value.is_finite()));
 
     // Verify usage
     assert!(response.usage.prompt_tokens > 0);
@@ -438,9 +439,49 @@ async fn test_create_embeddings_single_input() {
 
     println!(
         "Embedding created with {} dimensions, {} tokens used",
-        response.data[0].embedding.len(),
+        embedding.len(),
         response.usage.total_tokens
     );
+}
+
+#[tokio::test]
+async fn test_create_embeddings_base64_encoding() {
+    let client = setup_authenticated_client()
+        .await
+        .expect("Failed to setup client");
+
+    let request = EmbeddingRequest {
+        input: EmbeddingInput::Single("Hello, world!".to_string()),
+        model: embedding_model(),
+        encoding_format: Some("base64".to_string()),
+        dimensions: None,
+        user: None,
+    };
+
+    let response = client
+        .create_embeddings(request)
+        .await
+        .expect("Failed to create base64 embeddings");
+
+    assert_eq!(response.object, "list");
+    assert_eq!(response.data.len(), 1);
+    assert_eq!(response.data[0].object, "embedding");
+    assert_eq!(response.data[0].index, 0);
+
+    let embedding = response.data[0]
+        .embedding
+        .as_base64()
+        .expect("Expected base64 embedding response");
+    let decoded = general_purpose::STANDARD
+        .decode(embedding)
+        .expect("Embedding should contain valid base64");
+    assert_eq!(
+        decoded.len(),
+        embedding_dimensions() * std::mem::size_of::<f32>()
+    );
+
+    assert!(response.usage.prompt_tokens > 0);
+    assert!(response.usage.total_tokens > 0);
 }
 
 #[tokio::test]
@@ -474,11 +515,11 @@ async fn test_create_embeddings_multiple_inputs() {
     for (i, embedding_data) in response.data.iter().enumerate() {
         assert_eq!(embedding_data.object, "embedding");
         assert_eq!(embedding_data.index as usize, i);
-        assert_eq!(
-            embedding_data.embedding.len(),
-            embedding_dimensions(),
-            "Unexpected embedding dimensions"
-        );
+        let embedding = embedding_data
+            .embedding
+            .as_floats()
+            .expect("Expected default float embedding response");
+        assert_eq!(embedding.len(), embedding_dimensions());
     }
 
     // Verify usage accounts for all inputs
@@ -512,7 +553,14 @@ async fn test_embeddings_from_string_conversion() {
         .expect("Failed to create embeddings");
 
     assert_eq!(response.data.len(), 1);
-    assert_eq!(response.data[0].embedding.len(), embedding_dimensions());
+    assert_eq!(
+        response.data[0]
+            .embedding
+            .as_floats()
+            .expect("Expected default float embedding response")
+            .len(),
+        embedding_dimensions()
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- model embedding response values as either float vectors or base64 strings
- preserve the requested representation through SDK deserialization and serialization
- add ergonomic accessors for both representations
- add SDK contract and encrypted live integration coverage for both `float` and `base64`

## Why

Tinfoil already supports `encoding_format: "base64"`, and OpenSecret already preserves that provider response through its encrypted embeddings endpoint. The Rust SDK currently requires every embedding value to deserialize as `Vec<f64>`, causing otherwise valid base64 responses to fail before Maple Proxy can return them.

This fixes the response model at the SDK layer. No OpenSecret backend or Maple Proxy behavior change is needed.

## Compatibility

This changes the Rust representation of `EmbeddingData.embedding` from `Vec<f64>` to `EmbeddingVector`. Consumers upgrading the SDK and directly reading that field can match the enum or use `as_floats()` / `as_base64()`. The HTTP API and wire format are unchanged.

## Testing

- `cargo test --lib --all-features` — 32 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- encrypted live SDK test with `encoding_format: "float"` — 768 finite values
- encrypted live SDK test with `encoding_format: "base64"` — valid base64 decoding to 768 float32 values

Related to OpenSecretCloud/maple-proxy#40.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret-sdk/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding responses can now be returned as either float arrays or base64-encoded values.
  * Added helpers to read embeddings in the requested representation.
  * Clients can request explicit `float` or `base64` embedding encoding modes.
* **Bug Fixes**
  * Improved handling by rejecting unsupported/unknown embedding response shapes during parsing.
* **Tests**
  * Expanded integration coverage for both encoding formats, including dimensionality, decoding, and usage metadata.
* **Chores**
  * Bumped the Rust crate version to **3.3.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->