### PR TITLE
feat: add encrypted Voxtral speech synthesis APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,19 @@ You can now use the OpenAI client as normal. (Right now only streaming responses
 
 For an alternative approach using custom fetch directly, see the implementation in `src/lib/ai.test.ts` in the SDK source code.
 
+For non-streaming text-to-speech, the context provides a typed Voxtral helper.
+It defaults to the `voxtral-tts` model and `neutral_female` voice, returns WAV
+audio as a standard `Response`, and accepts an `AbortSignal` for cancellation:
+
+```typescript
+const controller = new AbortController();
+const response = await os.synthesizeSpeech(
+  { input: "Read this response aloud." },
+  { signal: controller.signal }
+);
+const wavAudio = await response.arrayBuffer();
+```
+
 ### Library development
 
 This library uses [Bun](https://bun.sh/) for development.

--- a/rust/README.md
+++ b/rust/README.md
@@ -109,6 +109,24 @@ it cannot be used to bypass JWT-only account or conversation APIs. The existing
 typed model, embedding, and chat-completion helpers remain available as
 compatibility wrappers over the same transport.
 
+### Speech synthesis
+
+The typed speech helper defaults to the `voxtral-tts` model and its
+`neutral_female` voice, then returns decoded audio bytes and their MIME type:
+
+```rust
+use opensecret::SpeechSynthesisRequest;
+
+let response = client
+    .synthesize_speech(SpeechSynthesisRequest::new(
+        "Your audio never leaves the enclave.",
+    ))
+    .await?;
+
+assert_eq!(response.content_type, "audio/wav");
+std::fs::write("speech.wav", response.audio.as_ref())?;
+```
+
 The SDK manages transport credentials and framing. Caller-provided `Host`,
 `Authorization`, `x-session-id`, `Content-Length`, `Content-Type`,
 `Content-Encoding`, `Accept-Encoding`, `Content-MD5`, `Digest`, hop-by-hop, and

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -40,6 +40,12 @@ struct EncryptedBody {
     encrypted: String,
 }
 
+#[derive(Deserialize)]
+struct SpeechSynthesisCarrier {
+    content_base64: String,
+    content_type: String,
+}
+
 const MAX_INFERENCE_SSE_LINE_BYTES: usize = 16 * 1024 * 1024;
 
 pub struct OpenSecretClient {
@@ -2076,6 +2082,72 @@ impl OpenSecretClient {
             .await
     }
 
+    /// Synthesizes speech with OpenSecret's OpenAI-compatible audio endpoint.
+    ///
+    /// [`SpeechSynthesisRequest::new`] selects the `voxtral-tts` model and
+    /// `neutral_female` voice. The encrypted backend carrier is decoded into
+    /// the original audio bytes and MIME type.
+    pub async fn synthesize_speech(
+        &self,
+        request: SpeechSynthesisRequest,
+    ) -> Result<SpeechSynthesisResponse> {
+        let request = HttpRequest::builder()
+            .method(http::Method::POST)
+            .uri("/v1/audio/speech")
+            .body(Bytes::from(serde_json::to_vec(&request)?))
+            .map_err(|error| {
+                Error::Configuration(format!("Failed to build speech synthesis request: {error}"))
+            })?;
+        let response = self.send_inference_request(request).await?;
+        let status = response.status();
+        let body = collect_response_body(response.into_body()).await?;
+
+        if !status.is_success() {
+            return Err(Error::Api {
+                status: status.as_u16(),
+                message: String::from_utf8_lossy(&body).into_owned(),
+            });
+        }
+
+        let carrier: SpeechSynthesisCarrier = serde_json::from_slice(&body).map_err(|error| {
+            Error::InvalidResponse(format!(
+                "Speech synthesis response was not a valid audio carrier: {error}"
+            ))
+        })?;
+        let content_type = carrier.content_type.trim().to_string();
+        let media_type = content_type
+            .split(';')
+            .next()
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase();
+        if media_type.strip_prefix("audio/").is_none_or(|subtype| {
+            subtype.is_empty()
+                || subtype
+                    .chars()
+                    .any(|character| character.is_whitespace() || matches!(character, '/' | ';'))
+        }) {
+            return Err(Error::InvalidResponse(
+                "Speech synthesis response did not contain an audio content type".to_string(),
+            ));
+        }
+        let audio = BASE64.decode(carrier.content_base64).map_err(|error| {
+            Error::InvalidResponse(format!(
+                "Speech synthesis response contained invalid base64 audio: {error}"
+            ))
+        })?;
+        if audio.is_empty() {
+            return Err(Error::InvalidResponse(
+                "Speech synthesis response contained empty audio".to_string(),
+            ));
+        }
+
+        Ok(SpeechSynthesisResponse {
+            audio: Bytes::from(audio),
+            content_type,
+        })
+    }
+
     /// Creates embeddings for the given input text(s)
     ///
     /// # Example
@@ -3596,6 +3668,249 @@ mod tests {
             Some("2 + 2 = 4")
         );
         assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_decodes_voxtral_wav_bytes_and_content_type() {
+        let mock_server = MockServer::start().await;
+        let client =
+            OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                .unwrap();
+        let session_id = Uuid::new_v4();
+        let session_key = [49u8; 32];
+        client
+            .session_manager
+            .set_session(session_id, session_key)
+            .unwrap();
+
+        let wav_bytes = Bytes::from_static(
+            b"RIFF\xff\x00\x80\x7f\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00",
+        );
+        let carrier = json!({
+            "content_base64": BASE64.encode(wav_bytes.as_ref()),
+            "content_type": "audio/wav"
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .and(header("authorization", "Bearer speech_api_key"))
+            .and(header("x-session-id", session_id.to_string()))
+            .and(header("content-type", "application/json"))
+            .and(EncryptedJsonBodyMatcher {
+                session_key,
+                expected: json!({
+                    "input": "The assistant can speak this response.",
+                    "model": "voxtral-tts",
+                    "voice": "neutral_female"
+                }),
+            })
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &carrier)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = client
+            .synthesize_speech(SpeechSynthesisRequest::new(
+                "The assistant can speak this response.",
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.audio, wav_bytes);
+        assert_eq!(response.content_type, "audio/wav");
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_rejects_malformed_audio_carrier() {
+        let mock_server = MockServer::start().await;
+        let client =
+            OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                .unwrap();
+        let session_key = [50u8; 32];
+        client
+            .session_manager
+            .set_session(Uuid::new_v4(), session_key)
+            .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(encrypted_response(
+                &session_key,
+                &json!({ "content_base64": "UklGRg==" }),
+            )))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let error = client
+            .synthesize_speech(SpeechSynthesisRequest::new("Malformed carrier"))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::InvalidResponse(message) if message.contains("valid audio carrier")
+        ));
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_rejects_invalid_base64_audio() {
+        let mock_server = MockServer::start().await;
+        let client =
+            OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                .unwrap();
+        let session_key = [51u8; 32];
+        client
+            .session_manager
+            .set_session(Uuid::new_v4(), session_key)
+            .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(encrypted_response(
+                &session_key,
+                &json!({
+                    "content_base64": "%%%not-base64%%%",
+                    "content_type": "audio/wav"
+                }),
+            )))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let error = client
+            .synthesize_speech(SpeechSynthesisRequest::new("Invalid base64"))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::InvalidResponse(message) if message.contains("invalid base64 audio")
+        ));
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_rejects_empty_audio_and_non_audio_content_type() {
+        for (carrier, expected_message) in [
+            (
+                json!({
+                    "content_base64": "",
+                    "content_type": "audio/wav"
+                }),
+                "empty audio",
+            ),
+            (
+                json!({
+                    "content_base64": "UklGRg==",
+                    "content_type": "text/plain"
+                }),
+                "audio content type",
+            ),
+            (
+                json!({
+                    "content_base64": "UklGRg==",
+                    "content_type": ""
+                }),
+                "audio content type",
+            ),
+            (
+                json!({
+                    "content_base64": "UklGRg==",
+                    "content_type": "audio/"
+                }),
+                "audio content type",
+            ),
+            (
+                json!({
+                    "content_base64": "UklGRg==",
+                    "content_type": "audio//"
+                }),
+                "audio content type",
+            ),
+            (
+                json!({
+                    "content_base64": "UklGRg==",
+                    "content_type": "audio/wav extra"
+                }),
+                "audio content type",
+            ),
+            (
+                json!({
+                    "content_base64": "UklGRg==",
+                    "content_type": "audio/wav/extra"
+                }),
+                "audio content type",
+            ),
+        ] {
+            let mock_server = MockServer::start().await;
+            let client =
+                OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                    .unwrap();
+            let session_key = [52u8; 32];
+            client
+                .session_manager
+                .set_session(Uuid::new_v4(), session_key)
+                .unwrap();
+
+            Mock::given(method("POST"))
+                .and(path("/v1/audio/speech"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(encrypted_response(&session_key, &carrier)),
+                )
+                .expect(1)
+                .mount(&mock_server)
+                .await;
+
+            let error = client
+                .synthesize_speech(SpeechSynthesisRequest::new("Invalid audio carrier"))
+                .await
+                .unwrap_err();
+
+            assert!(
+                matches!(error, Error::InvalidResponse(message) if message.contains(expected_message))
+            );
+            mock_server.verify().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_preserves_non_success_api_error() {
+        let mock_server = MockServer::start().await;
+        let client =
+            OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                .unwrap();
+        client
+            .session_manager
+            .set_session(Uuid::new_v4(), [53u8; 32])
+            .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(
+                ResponseTemplate::new(422).set_body_string("voxtral request was rejected"),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let error = client
+            .synthesize_speech(SpeechSynthesisRequest::new("Rejected request"))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::Api { status: 422, message }
+                if message == "voxtral request was rejected"
+        ));
+        mock_server.verify().await;
     }
 
     #[tokio::test]

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -683,6 +683,40 @@ pub struct ConversationProjectListParams {
 }
 
 // AI/OpenAI API Types
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SpeechSynthesisRequest {
+    pub input: String,
+    #[serde(default = "default_speech_synthesis_model")]
+    pub model: String,
+    #[serde(default = "default_speech_synthesis_voice")]
+    pub voice: String,
+}
+
+impl SpeechSynthesisRequest {
+    /// Creates a Voxtral TTS request with the default neutral female voice.
+    pub fn new(input: impl Into<String>) -> Self {
+        Self {
+            input: input.into(),
+            model: default_speech_synthesis_model(),
+            voice: default_speech_synthesis_voice(),
+        }
+    }
+}
+
+fn default_speech_synthesis_model() -> String {
+    "voxtral-tts".to_string()
+}
+
+fn default_speech_synthesis_voice() -> String {
+    "neutral_female".to_string()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpeechSynthesisResponse {
+    pub audio: bytes::Bytes,
+    pub content_type: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Model {
     pub id: String,
@@ -1264,6 +1298,27 @@ pub enum AgentSseEvent {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn speech_synthesis_request_defaults_to_exact_voxtral_contract() {
+        let request = SpeechSynthesisRequest::new("The assistant can speak this response.");
+
+        assert_eq!(request.model, "voxtral-tts");
+        assert_eq!(request.voice, "neutral_female");
+        assert_eq!(
+            serde_json::to_value(&request).unwrap(),
+            json!({
+                "input": "The assistant can speak this response.",
+                "model": "voxtral-tts",
+                "voice": "neutral_female"
+            })
+        );
+
+        let deserialized: SpeechSynthesisRequest =
+            serde_json::from_value(json!({ "input": "Use the defaults." })).unwrap();
+        assert_eq!(deserialized.model, "voxtral-tts");
+        assert_eq!(deserialized.voice, "neutral_female");
+    }
 
     #[test]
     fn nullable_field_request_serialization_distinguishes_missing_and_null() {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -7,6 +7,82 @@ export interface CustomFetchOptions {
   apiUrl?: string; // Optional API URL for attestation (required when not using OpenSecretProvider)
 }
 
+export const VOXTRAL_TTS_VOICES = [
+  "neutral_female",
+  "neutral_male",
+  "casual_female",
+  "casual_male",
+  "cheerful_female",
+  "ar_male",
+  "de_female",
+  "de_male",
+  "es_female",
+  "es_male",
+  "fr_female",
+  "fr_male",
+  "hi_female",
+  "hi_male",
+  "it_female",
+  "it_male",
+  "nl_female",
+  "nl_male",
+  "pt_female",
+  "pt_male"
+] as const;
+
+export type VoxtralTtsVoice = (typeof VOXTRAL_TTS_VOICES)[number];
+export type SpeechSynthesisVoice = VoxtralTtsVoice;
+
+export type SpeechSynthesisRequest = {
+  input: string;
+  model?: "voxtral-tts";
+  voice?: SpeechSynthesisVoice;
+};
+
+export interface SpeechSynthesisOptions extends CustomFetchOptions {
+  signal?: AbortSignal;
+}
+
+type AudioResponseCarrier = {
+  content_base64: string;
+  content_type: string;
+};
+
+const DEFAULT_SPEECH_MODEL = "voxtral-tts";
+const DEFAULT_SPEECH_VOICE: SpeechSynthesisVoice = "neutral_female";
+
+export async function synthesizeSpeech(
+  request: SpeechSynthesisRequest,
+  options?: SpeechSynthesisOptions
+): Promise<Response> {
+  const requestApiUrl = options?.apiUrl || api.getApiUrl();
+  if (!requestApiUrl) {
+    throw new Error(
+      "No API URL configured. Pass apiUrl or call synthesizeSpeech within OpenSecretProvider."
+    );
+  }
+
+  const apiUrl = requestApiUrl.replace(/\/+$/, "");
+  const customFetch = createCustomFetch({
+    apiKey: options?.apiKey,
+    apiUrl
+  });
+
+  return customFetch(`${apiUrl}/v1/audio/speech`, {
+    method: "POST",
+    headers: {
+      Accept: "audio/wav",
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      input: request.input,
+      model: request.model ?? DEFAULT_SPEECH_MODEL,
+      voice: request.voice ?? DEFAULT_SPEECH_VOICE
+    }),
+    signal: options?.signal
+  });
+}
+
 export function createCustomFetch(
   options?: CustomFetchOptions
 ): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
@@ -29,7 +105,11 @@ export function createCustomFetch(
       const headers = new Headers(init?.headers);
       headers.set("Authorization", getAuthHeader());
 
-      const { sessionKey, sessionId } = await getAttestation(false, options?.apiUrl);
+      const { sessionKey, sessionId } = await getAttestation(
+        false,
+        options?.apiUrl,
+        init?.signal ?? undefined
+      );
       if (!sessionKey || !sessionId) {
         throw new Error("No session key or ID available");
       }
@@ -132,63 +212,39 @@ export function createCustomFetch(
 
       // Decrypt regular JSON responses
       const responseText = await response.text();
+      let responseData: unknown;
       try {
-        const responseData = JSON.parse(responseText);
+        responseData = JSON.parse(responseText);
+      } catch {
+        // If it's not JSON or doesn't have encrypted field, return original response
+        console.log("Response is not encrypted JSON, returning as-is");
+      }
 
-        // Check if the response has an encrypted field
-        if (responseData.encrypted) {
-          const decrypted = decryptMessage(sessionKey, responseData.encrypted);
+      if (isRecord(responseData) && typeof responseData.encrypted === "string") {
+        const decrypted = decryptMessage(sessionKey, responseData.encrypted);
+        const audioCarrier = parseAudioResponseCarrier(decrypted);
 
-          // Try to parse as JSON to check for TTS response format
-          try {
-            const decryptedData = JSON.parse(decrypted);
+        if (audioCarrier) {
+          const bytes = decodeAudioResponseCarrier(audioCarrier);
+          const headersOut = new Headers(response.headers);
+          headersOut.set("content-type", audioCarrier.content_type);
+          // These describe the encrypted carrier rather than the decoded audio.
+          headersOut.delete("content-encoding");
+          headersOut.delete("content-length");
+          headersOut.delete("transfer-encoding");
 
-            // Check if this is a TTS response with content_base64 and content_type
-            if (decryptedData.content_base64 && decryptedData.content_type) {
-              console.log("TTS response detected with content_type:", decryptedData.content_type);
-
-              // Decode base64 audio data to binary
-              let bytes: Uint8Array;
-              try {
-                const binaryString = atob(decryptedData.content_base64);
-                bytes = new Uint8Array(binaryString.length);
-                for (let i = 0; i < binaryString.length; i++) {
-                  bytes[i] = binaryString.charCodeAt(i);
-                }
-              } catch (e) {
-                console.error("Failed to decode base64 audio data:", e);
-                throw new Error("Invalid base64 audio data in TTS response");
-              }
-
-              console.log("Decoded audio bytes length:", bytes.length);
-
-              // Return as a binary response with the proper content type
-              const headersOut = new Headers(response.headers);
-              headersOut.set("content-type", decryptedData.content_type);
-              // Remove headers that are no longer valid for the decoded response
-              headersOut.delete("content-encoding");
-              headersOut.delete("content-length");
-              headersOut.delete("transfer-encoding");
-
-              return new Response(bytes, {
-                headers: headersOut,
-                status: response.status,
-                statusText: response.statusText
-              });
-            }
-          } catch {
-            // Not JSON, continue with regular text response
-          }
-          // Return a new Response with the decrypted data
-          return new Response(decrypted, {
-            headers: response.headers,
+          return new Response(bytes, {
+            headers: headersOut,
             status: response.status,
             statusText: response.statusText
           });
         }
-      } catch {
-        // If it's not JSON or doesn't have encrypted field, return original response
-        console.log("Response is not encrypted JSON, returning as-is");
+
+        return new Response(decrypted, {
+          headers: response.headers,
+          status: response.status,
+          statusText: response.statusText
+        });
       }
 
       // Return the original response text as a new Response
@@ -202,6 +258,68 @@ export function createCustomFetch(
       throw error;
     }
   };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseAudioResponseCarrier(decrypted: string): AudioResponseCarrier | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(decrypted);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const hasContent = Object.prototype.hasOwnProperty.call(value, "content_base64");
+  const hasContentType = Object.prototype.hasOwnProperty.call(value, "content_type");
+  if (!hasContent && !hasContentType) {
+    return null;
+  }
+
+  if (typeof value.content_base64 !== "string" || value.content_base64.length === 0) {
+    throw new Error("Invalid audio response carrier");
+  }
+
+  if (typeof value.content_type !== "string") {
+    throw new Error("Invalid audio response carrier");
+  }
+
+  const contentType = value.content_type.trim();
+  const mediaType = contentType.split(";", 1)[0].trim().toLowerCase();
+  if (!/^audio\/[^\s/;]+$/.test(mediaType)) {
+    throw new Error("Invalid audio response carrier");
+  }
+
+  return {
+    content_base64: value.content_base64,
+    content_type: contentType
+  };
+}
+
+function decodeAudioResponseCarrier(carrier: AudioResponseCarrier): Uint8Array {
+  let binaryString: string;
+  try {
+    binaryString = atob(carrier.content_base64);
+  } catch (error) {
+    console.error("Failed to decode base64 audio data:", error);
+    throw new Error("Invalid base64 audio data in response");
+  }
+
+  if (binaryString.length === 0) {
+    throw new Error("Audio response carrier contained no audio data");
+  }
+
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
 }
 
 function extractEvent(buffer: string): string | null {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -232,10 +232,11 @@ export async function requestNewVerificationCode(): Promise<void> {
 
 export async function fetchAttestationDocument(
   nonce: string,
-  explicitApiUrl?: string
+  explicitApiUrl?: string,
+  signal?: AbortSignal
 ): Promise<string> {
   const url = explicitApiUrl || apiUrl;
-  const response = await fetch(`${url}/attestation/${nonce}`);
+  const response = await fetch(`${url}/attestation/${nonce}`, { signal });
   if (!response.ok) {
     throw new Error(`Request failed with status ${response.status}`);
   }
@@ -246,7 +247,8 @@ export async function fetchAttestationDocument(
 export async function keyExchange(
   clientPublicKey: string,
   nonce: string,
-  explicitApiUrl?: string
+  explicitApiUrl?: string,
+  signal?: AbortSignal
 ): Promise<{ encrypted_session_key: string; session_id: string }> {
   const url = explicitApiUrl || apiUrl;
   const response = await fetch(`${url}/key_exchange`, {
@@ -254,7 +256,8 @@ export async function keyExchange(
     headers: {
       "Content-Type": "application/json"
     },
-    body: JSON.stringify({ client_public_key: clientPublicKey, nonce })
+    body: JSON.stringify({ client_public_key: clientPublicKey, nonce }),
+    signal
   });
 
   if (!response.ok) {

--- a/src/lib/attestation.ts
+++ b/src/lib/attestation.ts
@@ -270,10 +270,11 @@ async function fakeAuthenticate(
 
 export async function verifyAttestation(
   nonce: string,
-  explicitApiUrl?: string
+  explicitApiUrl?: string,
+  signal?: AbortSignal
 ): Promise<AttestationDocument> {
   try {
-    const attestationDocumentBase64 = await fetchAttestationDocument(nonce, explicitApiUrl);
+    const attestationDocumentBase64 = await fetchAttestationDocument(nonce, explicitApiUrl, signal);
 
     // Get the API URL from the API layer where it's already set
     // First check explicit URL, then check both possible APIs
@@ -290,6 +291,15 @@ export async function verifyAttestation(
     const verifiedDocument = await authenticate(attestationDocumentBase64, awsRootCertDer, nonce);
     return verifiedDocument;
   } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "name" in error &&
+      error.name === "AbortError"
+    ) {
+      throw error;
+    }
+
     if (error instanceof Error) {
       console.error("Error verifying attestation document:", error);
       throw new Error(`Couldn't process attestation document: ${error.message}`);

--- a/src/lib/getAttestation.ts
+++ b/src/lib/getAttestation.ts
@@ -27,7 +27,8 @@ function generateNaclKeyPair(): { publicKey: Uint8Array; secretKey: Uint8Array }
 
 export async function getAttestation(
   forceRefresh?: boolean,
-  explicitApiUrl?: string
+  explicitApiUrl?: string,
+  signal?: AbortSignal
 ): Promise<Attestation> {
   // Check if we already have a sessionKey and sessionId in sessionstorage
   const sessionKey = sessionStorage.getItem("sessionKey");
@@ -48,7 +49,7 @@ export async function getAttestation(
     const attestationNonce = window.crypto.randomUUID();
 
     console.log("Generated attestation nonce:", attestationNonce);
-    const document = await verifyAttestation(attestationNonce, explicitApiUrl);
+    const document = await verifyAttestation(attestationNonce, explicitApiUrl, signal);
 
     if (document && document.public_key) {
       console.log("Attestation document verification succeeded");
@@ -59,7 +60,8 @@ export async function getAttestation(
       const { encrypted_session_key, session_id } = await keyExchange(
         encode(clientKeyPair.publicKey),
         attestationNonce,
-        explicitApiUrl
+        explicitApiUrl,
+        signal
       );
       console.log("Key exchange completed.");
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -113,8 +113,17 @@ export {
   getSubagentItem
 } from "./api";
 
-// Export AI customization options
-export { createCustomFetch, type CustomFetchOptions } from "./ai";
+// Export AI customization options and speech synthesis
+export {
+  VOXTRAL_TTS_VOICES,
+  createCustomFetch,
+  synthesizeSpeech,
+  type CustomFetchOptions,
+  type SpeechSynthesisOptions,
+  type SpeechSynthesisRequest,
+  type SpeechSynthesisVoice,
+  type VoxtralTtsVoice
+} from "./ai";
 
 // Re-export Model type from OpenAI for convenience
 export type { Model } from "openai/resources/models.js";

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -1,6 +1,11 @@
 import React, { createContext, useState, useEffect } from "react";
 import * as api from "./api";
-import { createCustomFetch } from "./ai";
+import {
+  createCustomFetch,
+  synthesizeSpeech as synthesizeSpeechRequest,
+  type SpeechSynthesisOptions,
+  type SpeechSynthesisRequest
+} from "./ai";
 import { getAttestation } from "./getAttestation";
 import type { Model } from "openai/resources/models.js";
 import { authenticate } from "./attestation";
@@ -342,6 +347,17 @@ export type OpenSecretContextType = {
    * ```
    */
   aiCustomFetch: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+  /**
+   * Synthesizes WAV speech with Tinfoil's Voxtral TTS model.
+   *
+   * The provider supplies the configured OpenSecret URL and current API key.
+   * Pass an AbortSignal to cancel an in-flight synthesis request.
+   */
+  synthesizeSpeech: (
+    request: SpeechSynthesisRequest,
+    options?: Pick<SpeechSynthesisOptions, "signal">
+  ) => Promise<Response>;
 
   /**
    * Returns the current OpenSecret enclave API URL being used
@@ -939,6 +955,7 @@ export const OpenSecretContext = createContext<OpenSecretContextType>({
   getPublicKey: api.fetchPublicKey,
   signMessage: api.signMessage,
   aiCustomFetch: async () => new Response(),
+  synthesizeSpeech: async () => new Response(),
   apiUrl: "",
   pcrConfig: {},
   getAttestation,
@@ -1361,6 +1378,12 @@ export function OpenSecretProvider({
     getPublicKey: api.fetchPublicKey,
     signMessage: api.signMessage,
     aiCustomFetch: aiCustomFetch || (async () => new Response()),
+    synthesizeSpeech: (request, options) =>
+      synthesizeSpeechRequest(request, {
+        apiUrl,
+        apiKey,
+        signal: options?.signal
+      }),
     apiUrl,
     pcrConfig,
     getAttestation,

--- a/src/lib/test/integration/ai.test.ts
+++ b/src/lib/test/integration/ai.test.ts
@@ -7,7 +7,7 @@ import {
   batchDeleteConversations,
   listConversations
 } from "../../api";
-import { createCustomFetch } from "../../ai";
+import { createCustomFetch, synthesizeSpeech } from "../../ai";
 import OpenAI from "openai";
 
 const TEST_EMAIL = process.env.VITE_TEST_EMAIL;
@@ -15,7 +15,6 @@ const TEST_PASSWORD = process.env.VITE_TEST_PASSWORD;
 const TEST_CLIENT_ID = process.env.VITE_TEST_CLIENT_ID;
 const API_URL = process.env.VITE_OPEN_SECRET_API_URL;
 const CHAT_MODEL = process.env.VITE_TEST_CHAT_MODEL ?? "llama3-3-70b";
-const TTS_MODEL = process.env.VITE_TEST_TTS_MODEL ?? "qwen3-tts";
 
 if (!TEST_EMAIL || !TEST_PASSWORD || !TEST_CLIENT_ID || !API_URL) {
   throw new Error("Test credentials must be set in .env.local");
@@ -198,53 +197,27 @@ liveAiTest("streams chat completion", async () => {
   expect(response?.trim()).toBe("echo");
 });
 
-test.skip("text-to-speech with configured TTS model", async () => {
+test.skip("Voxtral text-to-speech returns WAV audio", async () => {
   await setupTestUser();
 
-  const client = new OpenAI({
-    baseURL: `${API_URL}/v1/`,
-    dangerouslyAllowBrowser: true,
-    apiKey: "api-key-doesnt-matter",
-    defaultHeaders: {
-      "Accept-Encoding": "identity"
-    },
-    fetch: createCustomFetch()
-  });
-
   const textToSpeak = "Hello, this is a test of the text-to-speech system.";
-
-  const response = await client.audio.speech.create({
-    model: TTS_MODEL,
-    voice: "af_sky" as any,
-    input: textToSpeak,
-    response_format: "mp3"
-  });
+  const response = await synthesizeSpeech(
+    {
+      input: textToSpeak,
+      model: "voxtral-tts",
+      voice: "neutral_female"
+    },
+    { apiUrl: API_URL }
+  );
 
   const buffer = Buffer.from(await response.arrayBuffer());
 
-  // Verify we got back audio data
-  expect(buffer.length).toBeGreaterThan(0);
+  expect(response.headers.get("content-type")).toContain("audio/wav");
+  expect(buffer.length).toBeGreaterThan(44);
+  expect(buffer.subarray(0, 4).toString("ascii")).toBe("RIFF");
+  expect(buffer.subarray(8, 12).toString("ascii")).toBe("WAVE");
 
   console.log(`TTS response size: ${buffer.length} bytes`);
-
-  // Log the first 20 bytes to understand the format
-  const first20Bytes = buffer.slice(0, 20).toString("hex");
-  console.log(`First 20 bytes (hex): ${first20Bytes}`);
-
-  // Also log as string to see if it's JSON or text
-  const first100Chars = buffer.slice(0, 100).toString("utf-8");
-  console.log(`First 100 chars (string): ${first100Chars}`);
-
-  // MP3 files typically start with an ID3 tag or FF FB/FF FA (MPEG audio sync)
-  const firstBytes = buffer.slice(0, 3).toString("hex");
-  const isID3 = firstBytes === "494433"; // "ID3" in hex
-  const isMPEGSync = firstBytes.startsWith("fff") || firstBytes.startsWith("ffe");
-
-  // For now, just verify we got data back
-  // The format check might need adjustment based on what the server returns
-  if (!isID3 && !isMPEGSync) {
-    console.warn("Response doesn't appear to be MP3 format, but got data back");
-  }
 });
 
 // To run this test manually:
@@ -276,34 +249,26 @@ test.skip("Whisper transcription with real MP3 file", async () => {
 test.skip("TTS → Whisper transcription chain", async () => {
   await setupTestUser();
 
-  const client = new OpenAI({
-    baseURL: `${API_URL}/v1/`,
-    dangerouslyAllowBrowser: true,
-    apiKey: "api-key-doesnt-matter",
-    defaultHeaders: {
-      "Accept-Encoding": "identity"
-    },
-    fetch: createCustomFetch()
-  });
-
   // Step 1: Generate speech from simple text
   const originalText = "Hello";
 
   console.log("Generating speech from text:", originalText);
 
-  const ttsResponse = await client.audio.speech.create({
-    model: TTS_MODEL,
-    voice: "af_sky" as any,
-    input: originalText,
-    response_format: "mp3"
-  });
+  const ttsResponse = await synthesizeSpeech(
+    {
+      input: originalText,
+      model: "voxtral-tts",
+      voice: "neutral_female"
+    },
+    { apiUrl: API_URL }
+  );
 
   const audioBuffer = Buffer.from(await ttsResponse.arrayBuffer());
   console.log(`Generated audio size: ${audioBuffer.length} bytes`);
 
   // Step 2: Create a Blob from the audio buffer
-  const audioBlob = new Blob([audioBuffer], { type: "audio/mpeg" });
-  const audioFile = new File([audioBlob], "tts_output.mp3", { type: "audio/mpeg" });
+  const audioBlob = new Blob([audioBuffer], { type: "audio/wav" });
+  const audioFile = new File([audioBlob], "tts_output.wav", { type: "audio/wav" });
 
   // Step 3: Transcribe the audio back to text using Whisper
   console.log("Transcribing audio back to text...");

--- a/src/lib/test/integration/speech.test.ts
+++ b/src/lib/test/integration/speech.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { decode, encode } from "@stablelib/base64";
+import { ChaCha20Poly1305 } from "@stablelib/chacha20poly1305";
+import * as cbor from "cbor2";
+import nacl from "tweetnacl";
+import { synthesizeSpeech } from "../../ai";
+import { getApiUrl, setApiUrl } from "../../api";
+import { decryptMessage, encryptMessage } from "../../encryption";
+
+const apiUrl = "https://api.example.com";
+const apiKey = "speech-api-key";
+const sessionId = "speech-session-id";
+const sessionKey = new Uint8Array(32).fill(23);
+const originalFetch = globalThis.fetch;
+const originalApiUrl = getApiUrl();
+
+const wavBytes = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20,
+  0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x80, 0xbb, 0x00, 0x00, 0x00, 0x77, 0x01, 0x00,
+  0x02, 0x00, 0x10, 0x00, 0x64, 0x61, 0x74, 0x61, 0x00, 0x00, 0x00, 0x00
+]);
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  window.sessionStorage.setItem("sessionKey", encode(sessionKey));
+  window.sessionStorage.setItem("sessionId", sessionId);
+  setApiUrl(apiUrl);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  setApiUrl(originalApiUrl);
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+function encryptedResponse(carrier: unknown, headers?: HeadersInit): Response {
+  return new Response(
+    JSON.stringify({
+      encrypted: encryptMessage(sessionKey, JSON.stringify(carrier))
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        ...headers
+      }
+    }
+  );
+}
+
+test("synthesizeSpeech sends the Voxtral request and returns decoded WAV bytes", async () => {
+  globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    expect(input.toString()).toBe(`${apiUrl}/v1/audio/speech`);
+    expect(init?.method).toBe("POST");
+
+    const headers = new Headers(init?.headers);
+    expect(headers.get("authorization")).toBe(`Bearer ${apiKey}`);
+    expect(headers.get("x-session-id")).toBe(sessionId);
+    expect(headers.get("accept")).toBe("audio/wav");
+    expect(headers.get("content-type")).toBe("application/json");
+
+    const encryptedRequest = JSON.parse(String(init?.body)) as { encrypted: string };
+    expect(JSON.parse(decryptMessage(sessionKey, encryptedRequest.encrypted))).toEqual({
+      input: "Read this aloud.",
+      model: "voxtral-tts",
+      voice: "neutral_female"
+    });
+
+    return encryptedResponse(
+      {
+        content_base64: encode(wavBytes),
+        content_type: " audio/wav; codecs=1 "
+      },
+      {
+        "Content-Encoding": "identity",
+        "Content-Length": "999",
+        "Transfer-Encoding": "chunked",
+        "X-Preserved": "yes"
+      }
+    );
+  }) as typeof fetch;
+
+  const response = await synthesizeSpeech(
+    { input: "Read this aloud." },
+    { apiKey, apiUrl: `${apiUrl}/` }
+  );
+
+  expect(response.headers.get("content-type")).toBe("audio/wav; codecs=1");
+  expect(response.headers.get("content-encoding")).toBeNull();
+  expect(response.headers.get("content-length")).toBeNull();
+  expect(response.headers.get("transfer-encoding")).toBeNull();
+  expect(response.headers.get("x-preserved")).toBe("yes");
+  expect(new Uint8Array(await response.arrayBuffer())).toEqual(wavBytes);
+});
+
+test("synthesizeSpeech normalizes trailing-slash URLs for a fresh attestation session", async () => {
+  window.sessionStorage.clear();
+
+  const localApiUrl = "http://127.0.0.1:31587";
+  const serverKeyPair = nacl.box.keyPair();
+  const attestationPayload = cbor.encode({ public_key: serverKeyPair.publicKey });
+  const fakeAttestationDocument = encode(
+    cbor.encode([new Uint8Array(), new Map(), attestationPayload, new Uint8Array()])
+  );
+  const controller = new AbortController();
+  const requestedUrls: string[] = [];
+  let attestationNonce: string | undefined;
+
+  globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    const requestUrl = input.toString();
+    requestedUrls.push(requestUrl);
+
+    if (requestUrl.startsWith(`${localApiUrl}/attestation/`)) {
+      expect(init?.signal).toBe(controller.signal);
+      expect(requestUrl).toMatch(
+        /^http:\/\/127\.0\.0\.1:31587\/attestation\/[0-9a-f]{8}-[0-9a-f-]+$/i
+      );
+      attestationNonce = requestUrl.slice(`${localApiUrl}/attestation/`.length);
+      return Response.json({ attestation_document: fakeAttestationDocument });
+    }
+
+    if (requestUrl === `${localApiUrl}/key_exchange`) {
+      expect(init?.signal).toBe(controller.signal);
+      const body = JSON.parse(String(init?.body)) as {
+        client_public_key: string;
+        nonce: string;
+      };
+      expect(body.nonce).toBe(attestationNonce);
+
+      const clientPublicKey = decode(body.client_public_key);
+      const sharedSecret = nacl.scalarMult(serverKeyPair.secretKey, clientPublicKey);
+      const nonce = new Uint8Array(12).fill(31);
+      const ciphertext = new ChaCha20Poly1305(sharedSecret).seal(nonce, sessionKey);
+      const encryptedSessionKey = new Uint8Array(nonce.length + ciphertext.length);
+      encryptedSessionKey.set(nonce);
+      encryptedSessionKey.set(ciphertext, nonce.length);
+
+      return Response.json({
+        encrypted_session_key: encode(encryptedSessionKey),
+        session_id: sessionId
+      });
+    }
+
+    if (requestUrl === `${localApiUrl}/v1/audio/speech`) {
+      expect(init?.signal).toBe(controller.signal);
+      const encryptedRequest = JSON.parse(String(init?.body)) as { encrypted: string };
+      expect(JSON.parse(decryptMessage(sessionKey, encryptedRequest.encrypted))).toEqual({
+        input: "Cold session.",
+        model: "voxtral-tts",
+        voice: "neutral_female"
+      });
+      return encryptedResponse({
+        content_base64: encode(wavBytes),
+        content_type: "audio/wav"
+      });
+    }
+
+    throw new Error(`Unexpected request URL: ${requestUrl}`);
+  }) as typeof fetch;
+
+  const response = await synthesizeSpeech(
+    { input: "Cold session." },
+    { apiKey, apiUrl: `${localApiUrl}/`, signal: controller.signal }
+  );
+
+  expect(requestedUrls).toHaveLength(3);
+  expect(requestedUrls[0]).toStartWith(`${localApiUrl}/attestation/`);
+  expect(requestedUrls[1]).toBe(`${localApiUrl}/key_exchange`);
+  expect(requestedUrls[2]).toBe(`${localApiUrl}/v1/audio/speech`);
+  expect(requestedUrls.every((url) => !url.includes(`${localApiUrl}//`))).toBe(true);
+  expect(new Uint8Array(await response.arrayBuffer())).toEqual(wavBytes);
+});
+
+test("synthesizeSpeech preserves AbortError when cancelled during attestation", async () => {
+  window.sessionStorage.clear();
+
+  const localApiUrl = "http://127.0.0.1:31587";
+  const controller = new AbortController();
+  const abortError = new DOMException("Speech synthesis cancelled", "AbortError");
+  const requestedUrls: string[] = [];
+  let markAttestationStarted!: () => void;
+  const attestationStarted = new Promise<void>((resolve) => {
+    markAttestationStarted = resolve;
+  });
+
+  globalThis.fetch = mock(
+    async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const requestUrl = input.toString();
+      requestedUrls.push(requestUrl);
+
+      if (!requestUrl.startsWith(`${localApiUrl}/attestation/`)) {
+        throw new Error(`Unexpected request after attestation abort: ${requestUrl}`);
+      }
+
+      expect(init?.signal).toBe(controller.signal);
+      markAttestationStarted();
+
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          reject(new Error("Attestation request did not receive the AbortSignal"));
+          return;
+        }
+
+        const rejectWithAbortReason = () => reject(signal.reason);
+        if (signal.aborted) {
+          rejectWithAbortReason();
+        } else {
+          signal.addEventListener("abort", rejectWithAbortReason, { once: true });
+        }
+      });
+    }
+  ) as typeof fetch;
+
+  const synthesis = synthesizeSpeech(
+    { input: "Cancel before key exchange." },
+    {
+      apiKey,
+      apiUrl: `${localApiUrl}/`,
+      signal: controller.signal
+    }
+  );
+
+  await attestationStarted;
+  controller.abort(abortError);
+
+  let rejection: unknown;
+  try {
+    await synthesis;
+  } catch (error) {
+    rejection = error;
+  }
+
+  expect(rejection).toBe(abortError);
+  expect(requestedUrls).toHaveLength(1);
+  expect(requestedUrls[0]).toStartWith(`${localApiUrl}/attestation/`);
+  expect(requestedUrls.some((url) => url.endsWith("/key_exchange"))).toBe(false);
+  expect(requestedUrls.some((url) => url.endsWith("/v1/audio/speech"))).toBe(false);
+});
+
+test("synthesizeSpeech rejects malformed base64 audio", async () => {
+  globalThis.fetch = mock(async () =>
+    encryptedResponse({
+      content_base64: "%%%not-base64%%%",
+      content_type: "audio/wav"
+    })
+  ) as typeof fetch;
+
+  await expect(synthesizeSpeech({ input: "Hello" }, { apiKey })).rejects.toThrow(
+    "Invalid base64 audio data in response"
+  );
+});
+
+test("synthesizeSpeech rejects malformed and non-audio carriers", async () => {
+  const invalidCarriers = [
+    { content_base64: encode(wavBytes) },
+    { content_base64: encode(wavBytes), content_type: "audio/" },
+    { content_base64: encode(wavBytes), content_type: "application/octet-stream" }
+  ];
+  let responseIndex = 0;
+
+  globalThis.fetch = mock(async () =>
+    encryptedResponse(invalidCarriers[responseIndex++])
+  ) as typeof fetch;
+
+  for (const input of ["Missing type", "Empty subtype", "Wrong type"]) {
+    await expect(synthesizeSpeech({ input }, { apiKey })).rejects.toThrow(
+      "Invalid audio response carrier"
+    );
+  }
+});
+
+test("synthesizeSpeech forwards the caller's AbortSignal", async () => {
+  const controller = new AbortController();
+
+  globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+    expect(init?.signal).toBe(controller.signal);
+    return encryptedResponse({
+      content_base64: encode(wavBytes),
+      content_type: "audio/wav"
+    });
+  }) as typeof fetch;
+
+  await synthesizeSpeech({ input: "Cancelable speech." }, { apiKey, signal: controller.signal });
+});


### PR DESCRIPTION
## Summary

- add first-class Voxtral speech synthesis APIs to the TypeScript/React and Rust SDKs
- send `/v1/audio/speech` through the existing attested, end-to-end encrypted transport and decode the encrypted audio carrier into standard response bytes
- default to `voxtral-tts` with `neutral_female`, export the supported typed voice set, and document both client APIs
- thread `AbortSignal` through TypeScript attestation, key exchange, and synthesis while preserving cancellation errors and normalizing trailing-slash API URLs
- reject malformed, empty, or non-audio carriers in both SDKs

## API surface

TypeScript:

- `synthesizeSpeech(request, options?)`
- `useOpenSecret().synthesizeSpeech(request, options?)`
- exported request, options, voice types, and `VOXTRAL_TTS_VOICES`
- returns a standard `Response` whose body can be read with `arrayBuffer()`

Rust:

- `OpenSecretClient::synthesize_speech`
- `SpeechSynthesisRequest::new`
- `SpeechSynthesisResponse` with decoded bytes and MIME type

## Validation

- TypeScript speech tests: 6 passed / 36 assertions
- TypeScript formatting and production build
- Rust speech tests: 6 passed
- Rust library suite: 76 passed
- Rust formatting and Clippy with warnings denied
- local encrypted Free/Pro smoke through OpenSecret and Tinfoil:
  - Free rejected with HTTP 403
  - Pro returned a valid 272,684-byte WAV
- `git diff --check`

The live account integration suite was not run successfully in this checkout because its client ID and localhost service were unavailable.

## Rollout dependency

This PR intentionally does not bump or publish either package version. Maple was smoke-tested against this checkout through a local filesystem link. After merge, publish new TypeScript and Rust SDK versions and update Maple to those released versions.

Companion PRs:

- OpenSecret backend: https://github.com/OpenSecretCloud/opensecret/pull/241
- Maple: https://github.com/OpenSecretCloud/Maple/pull/694

Open PR #89 overlaps the attestation and Rust-client paths used here. If it lands first, preserve this PR's cancellation propagation and speech API behavior while reconciling the shared files.
