### PR TITLE
feat: add encrypted Voxtral speech synthesis APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,26 @@ You can now use the OpenAI client as normal. (Right now only streaming responses
 
 For an alternative approach using custom fetch directly, see the implementation in `src/lib/ai.test.ts` in the SDK source code.
 
+For non-streaming text-to-speech, the context provides a typed speech helper.
+Request fields are forwarded without SDK defaults, binary and HTTP-200 provider
+error bodies are returned as a standard `Response`, and an `AbortSignal` can
+cancel the request. The current speech proxy buffers the complete response;
+streaming request fields are forwarded but do not make this helper incremental:
+
+```typescript
+const controller = new AbortController();
+const response = await os.synthesizeSpeech(
+  {
+    input: "Read this response aloud.",
+    model: "voxtral-tts",
+    voice: "neutral_female",
+    speed: 1.2
+  },
+  { signal: controller.signal }
+);
+const audio = await response.arrayBuffer();
+```
+
 ### Library development
 
 This library uses [Bun](https://bun.sh/) for development.

--- a/rust/README.md
+++ b/rust/README.md
@@ -109,6 +109,42 @@ it cannot be used to bypass JWT-only account or conversation APIs. The existing
 typed model, embedding, and chat-completion helpers remain available as
 compatibility wrappers over the same transport.
 
+### Speech synthesis
+
+The typed speech helper forwards only the parameters selected by the caller.
+It returns decoded audio bytes and their MIME type, while preserving successful
+JSON provider errors as a distinct response-body variant. It buffers the full
+response even when provider streaming request fields are forwarded:
+
+```rust
+use opensecret::{
+    NullableField, SpeechSynthesisRequest, SpeechSynthesisResponseFormat,
+    SpeechSynthesisResponseBody,
+};
+
+let mut request = SpeechSynthesisRequest::new(
+    "Your audio never leaves the enclave.",
+);
+request.model = NullableField::value("voxtral-tts".to_string());
+request.voice = NullableField::value("neutral_female".to_string());
+request.response_format = Some(SpeechSynthesisResponseFormat::Wav);
+request.speed = NullableField::value(1.2);
+
+let response = client
+    .synthesize_speech(request)
+    .await?;
+
+assert_eq!(response.content_type, "audio/wav");
+match response.body {
+    SpeechSynthesisResponseBody::Binary(audio) => {
+        std::fs::write("speech.wav", audio.as_ref())?;
+    }
+    SpeechSynthesisResponseBody::Json(error) => {
+        eprintln!("Provider error: {}", String::from_utf8_lossy(&error));
+    }
+}
+```
+
 The SDK manages transport credentials and framing. Caller-provided `Host`,
 `Authorization`, `x-session-id`, `Content-Length`, `Content-Type`,
 `Content-Encoding`, `Accept-Encoding`, `Content-MD5`, `Digest`, hop-by-hop, and

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -40,6 +40,12 @@ struct EncryptedBody {
     encrypted: String,
 }
 
+#[derive(Deserialize)]
+struct SpeechSynthesisCarrier {
+    content_base64: String,
+    content_type: String,
+}
+
 const MAX_INFERENCE_SSE_LINE_BYTES: usize = 16 * 1024 * 1024;
 
 pub struct OpenSecretClient {
@@ -2076,6 +2082,105 @@ impl OpenSecretClient {
             .await
     }
 
+    /// Synthesizes speech with OpenSecret's OpenAI-compatible audio endpoint.
+    ///
+    /// The SDK forwards every field supplied by the caller without selecting
+    /// provider defaults. Binary carriers are decoded into their original bytes;
+    /// successful JSON provider responses are returned as JSON bytes for the
+    /// caller to interpret. This typed helper collects the complete response body
+    /// before returning, including when provider streaming fields are requested.
+    pub async fn synthesize_speech(
+        &self,
+        request: SpeechSynthesisRequest,
+    ) -> Result<SpeechSynthesisResponse> {
+        let request = HttpRequest::builder()
+            .method(http::Method::POST)
+            .uri("/v1/audio/speech")
+            .body(Bytes::from(serde_json::to_vec(&request)?))
+            .map_err(|error| {
+                Error::Configuration(format!("Failed to build speech synthesis request: {error}"))
+            })?;
+        let response = self.send_inference_request(request).await?;
+        let status = response.status();
+        let response_content_type = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let body = collect_response_body(response.into_body()).await?;
+
+        if !status.is_success() {
+            return Err(Error::Api {
+                status: status.as_u16(),
+                message: String::from_utf8_lossy(&body).into_owned(),
+            });
+        }
+
+        let response_json: serde_json::Value = serde_json::from_slice(&body).map_err(|error| {
+            Error::InvalidResponse(format!(
+                "Speech synthesis response was neither a valid response carrier nor JSON: {error}"
+            ))
+        })?;
+        let is_carrier = response_json.as_object().is_some_and(|object| {
+            object.contains_key("content_base64") && object.contains_key("content_type")
+        });
+        if !is_carrier {
+            return Ok(SpeechSynthesisResponse {
+                body: SpeechSynthesisResponseBody::Json(body),
+                content_type: response_content_type
+                    .unwrap_or_else(|| "application/json".to_string()),
+            });
+        }
+
+        let carrier: SpeechSynthesisCarrier =
+            serde_json::from_value(response_json).map_err(|error| {
+                Error::InvalidResponse(format!(
+                    "Speech synthesis response was not a valid response carrier: {error}"
+                ))
+            })?;
+        let content_type = carrier.content_type.trim().to_string();
+        let media_type = content_type
+            .split(';')
+            .next()
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase();
+        let is_valid_media_type = media_type.split_once('/').is_some_and(|(top, subtype)| {
+            !top.is_empty()
+                && !subtype.is_empty()
+                && !top
+                    .chars()
+                    .chain(subtype.chars())
+                    .any(|character| character.is_whitespace() || matches!(character, '/' | ';'))
+        });
+        if !is_valid_media_type {
+            return Err(Error::InvalidResponse(
+                "Speech synthesis response did not contain a valid content type".to_string(),
+            ));
+        }
+        let is_json = media_type == "application/json" || media_type.ends_with("+json");
+        let payload = BASE64.decode(carrier.content_base64).map_err(|error| {
+            Error::InvalidResponse(format!(
+                "Speech synthesis response contained invalid base64 data: {error}"
+            ))
+        })?;
+        if !is_json && payload.is_empty() {
+            return Err(Error::InvalidResponse(
+                "Speech synthesis response contained an empty binary body".to_string(),
+            ));
+        }
+
+        let body = if is_json {
+            SpeechSynthesisResponseBody::Json(Bytes::from(payload))
+        } else {
+            SpeechSynthesisResponseBody::Binary(Bytes::from(payload))
+        };
+
+        Ok(SpeechSynthesisResponse { body, content_type })
+    }
+
     /// Creates embeddings for the given input text(s)
     ///
     /// # Example
@@ -3596,6 +3701,375 @@ mod tests {
             Some("2 + 2 = 4")
         );
         assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_decodes_voxtral_wav_bytes_and_content_type() {
+        let mock_server = MockServer::start().await;
+        let client =
+            OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                .unwrap();
+        let session_id = Uuid::new_v4();
+        let session_key = [49u8; 32];
+        client
+            .session_manager
+            .set_session(session_id, session_key)
+            .unwrap();
+
+        let wav_bytes = Bytes::from_static(
+            b"RIFF\xff\x00\x80\x7f\x24\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00",
+        );
+        let carrier = json!({
+            "content_base64": BASE64.encode(wav_bytes.as_ref()),
+            "content_type": "audio/wav"
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .and(header("authorization", "Bearer speech_api_key"))
+            .and(header("x-session-id", session_id.to_string()))
+            .and(header("content-type", "application/json"))
+            .and(EncryptedJsonBodyMatcher {
+                session_key,
+                expected: json!({
+                    "input": "The assistant can speak this response.",
+                    "model": "voxtral-tts",
+                    "voice": "neutral_female"
+                }),
+            })
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &carrier)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let mut request = SpeechSynthesisRequest::new("The assistant can speak this response.");
+        request.model = NullableField::value("voxtral-tts".to_string());
+        request.voice = NullableField::value("neutral_female".to_string());
+        let response = client.synthesize_speech(request).await.unwrap();
+
+        assert_eq!(
+            response.body,
+            SpeechSynthesisResponseBody::Binary(wav_bytes)
+        );
+        assert_eq!(response.content_type, "audio/wav");
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_preserves_successful_json_provider_error() {
+        let mock_server = MockServer::start().await;
+        let client =
+            OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                .unwrap();
+        let session_key = [54u8; 32];
+        client
+            .session_manager
+            .set_session(Uuid::new_v4(), session_key)
+            .unwrap();
+
+        let provider_error = json!({
+            "error": {
+                "message": "Unknown voice",
+                "type": "BadRequestError"
+            }
+        });
+        let expected = Bytes::from(serde_json::to_vec(&provider_error).unwrap());
+        let carrier = json!({
+            "content_base64": BASE64.encode(expected.as_ref()),
+            "content_type": "application/json"
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &carrier)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = client
+            .synthesize_speech(SpeechSynthesisRequest::new("Invalid voice"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.body, SpeechSynthesisResponseBody::Json(expected));
+        assert_eq!(response.content_type, "application/json");
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_decodes_json_response_carrier_without_reformatting() {
+        let mock_server = MockServer::start().await;
+        let client =
+            OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                .unwrap();
+        let session_key = [55u8; 32];
+        client
+            .session_manager
+            .set_session(Uuid::new_v4(), session_key)
+            .unwrap();
+
+        let provider_error = Bytes::from_static(
+            br#"{ "error": { "message": "Unknown voice" }, "request_id": "tts-7" }"#,
+        );
+        let carrier = json!({
+            "content_base64": BASE64.encode(provider_error.as_ref()),
+            "content_type": "application/problem+json; charset=utf-8"
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &carrier)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = client
+            .synthesize_speech(SpeechSynthesisRequest::new("Invalid voice"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.body,
+            SpeechSynthesisResponseBody::Json(provider_error)
+        );
+        assert_eq!(
+            response.content_type,
+            "application/problem+json; charset=utf-8"
+        );
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_accepts_binary_content_type_fallback() {
+        let mock_server = MockServer::start().await;
+        let client =
+            OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                .unwrap();
+        let session_key = [56u8; 32];
+        client
+            .session_manager
+            .set_session(Uuid::new_v4(), session_key)
+            .unwrap();
+
+        let binary = Bytes::from_static(b"provider-binary-audio");
+        let carrier = json!({
+            "content_base64": BASE64.encode(binary.as_ref()),
+            "content_type": "application/octet-stream"
+        });
+
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &carrier)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = client
+            .synthesize_speech(SpeechSynthesisRequest::new("Binary fallback"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.body, SpeechSynthesisResponseBody::Binary(binary));
+        assert_eq!(response.content_type, "application/octet-stream");
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_preserves_json_with_one_carrier_named_field() {
+        let mock_server = MockServer::start().await;
+        let client =
+            OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                .unwrap();
+        let session_key = [50u8; 32];
+        client
+            .session_manager
+            .set_session(Uuid::new_v4(), session_key)
+            .unwrap();
+
+        let provider_error = json!({
+            "error": { "message": "Provider metadata collision" },
+            "content_base64": "this field alone is not a carrier"
+        });
+        let expected = Bytes::from(serde_json::to_vec(&provider_error).unwrap());
+
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &provider_error)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = client
+            .synthesize_speech(SpeechSynthesisRequest::new("Provider JSON"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.body, SpeechSynthesisResponseBody::Json(expected));
+        assert_eq!(response.content_type, "application/json");
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_rejects_invalid_base64_audio() {
+        let mock_server = MockServer::start().await;
+        let client =
+            OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                .unwrap();
+        let session_key = [51u8; 32];
+        client
+            .session_manager
+            .set_session(Uuid::new_v4(), session_key)
+            .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(encrypted_response(
+                &session_key,
+                &json!({
+                    "content_base64": "%%%not-base64%%%",
+                    "content_type": "audio/wav"
+                }),
+            )))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let error = client
+            .synthesize_speech(SpeechSynthesisRequest::new("Invalid base64"))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::InvalidResponse(message) if message.contains("invalid base64 data")
+        ));
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_rejects_empty_binary_and_malformed_content_type() {
+        for (carrier, expected_message) in [
+            (
+                json!({
+                    "content_base64": "",
+                    "content_type": "audio/wav"
+                }),
+                "empty binary body",
+            ),
+            (
+                json!({
+                    "content_base64": "UklGRg==",
+                    "content_type": ""
+                }),
+                "valid content type",
+            ),
+            (
+                json!({
+                    "content_base64": "UklGRg==",
+                    "content_type": "audio/"
+                }),
+                "valid content type",
+            ),
+            (
+                json!({
+                    "content_base64": "UklGRg==",
+                    "content_type": "audio//"
+                }),
+                "valid content type",
+            ),
+            (
+                json!({
+                    "content_base64": "UklGRg==",
+                    "content_type": "audio/wav extra"
+                }),
+                "valid content type",
+            ),
+            (
+                json!({
+                    "content_base64": "UklGRg==",
+                    "content_type": "audio/wav/extra"
+                }),
+                "valid content type",
+            ),
+        ] {
+            let mock_server = MockServer::start().await;
+            let client =
+                OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                    .unwrap();
+            let session_key = [52u8; 32];
+            client
+                .session_manager
+                .set_session(Uuid::new_v4(), session_key)
+                .unwrap();
+
+            Mock::given(method("POST"))
+                .and(path("/v1/audio/speech"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(encrypted_response(&session_key, &carrier)),
+                )
+                .expect(1)
+                .mount(&mock_server)
+                .await;
+
+            let error = client
+                .synthesize_speech(SpeechSynthesisRequest::new("Invalid audio carrier"))
+                .await
+                .unwrap_err();
+
+            assert!(
+                matches!(error, Error::InvalidResponse(message) if message.contains(expected_message))
+            );
+            mock_server.verify().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn synthesize_speech_preserves_non_success_api_error() {
+        let mock_server = MockServer::start().await;
+        let client =
+            OpenSecretClient::new_with_api_key(mock_server.uri(), "speech_api_key".to_string())
+                .unwrap();
+        client
+            .session_manager
+            .set_session(Uuid::new_v4(), [53u8; 32])
+            .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/audio/speech"))
+            .respond_with(
+                ResponseTemplate::new(422).set_body_string("voxtral request was rejected"),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let error = client
+            .synthesize_speech(SpeechSynthesisRequest::new("Rejected request"))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::Api { status: 422, message }
+                if message == "voxtral request was rejected"
+        ));
+        mock_server.verify().await;
     }
 
     #[tokio::test]

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -683,6 +683,231 @@ pub struct ConversationProjectListParams {
 }
 
 // AI/OpenAI API Types
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SpeechSynthesisResponseFormat {
+    Wav,
+    Pcm,
+    Flac,
+    Mp3,
+    Aac,
+    Opus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SpeechSynthesisStreamFormat {
+    Sse,
+    Audio,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SpeechSynthesisTaskType {
+    CustomVoice,
+    VoiceDesign,
+    Base,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SpeechReferenceAudio {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SpeechSpeakerEmbedding {
+    Single(Vec<f64>),
+    Multiple(Vec<Vec<f64>>),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SpeechReference {
+    pub audio_path: String,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub text: NullableField<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("additional speech parameter conflicts with typed field: {parameter}")]
+pub struct SpeechAdditionalParameterError {
+    pub parameter: String,
+}
+
+const SPEECH_SYNTHESIS_TYPED_PARAMETERS: [&str; 26] = [
+    "input",
+    "model",
+    "voice",
+    "speaker",
+    "instructions",
+    "response_format",
+    "speed",
+    "stream_format",
+    "stream",
+    "task_type",
+    "language",
+    "ref_audio",
+    "ref_text",
+    "ref_audio_2",
+    "ambient_sound",
+    "duration_seconds",
+    "x_vector_only_mode",
+    "speaker_embedding",
+    "max_new_tokens",
+    "seed",
+    "initial_codec_chunk_frames",
+    "non_streaming_mode",
+    "extra_params",
+    "word_timestamps",
+    "references",
+    "additional_parameters",
+];
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SpeechSynthesisRequest {
+    pub input: String,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub model: NullableField<String>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub voice: NullableField<String>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub speaker: NullableField<String>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub instructions: NullableField<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<SpeechSynthesisResponseFormat>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub speed: NullableField<f64>,
+    /// Provider streaming format. The typed speech helper still buffers the
+    /// complete response before returning it.
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub stream_format: NullableField<SpeechSynthesisStreamFormat>,
+    /// Provider streaming switch. This is forwarded unchanged, while the typed
+    /// speech helper remains a buffered response API.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub task_type: NullableField<SpeechSynthesisTaskType>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub language: NullableField<String>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub ref_audio: NullableField<SpeechReferenceAudio>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub ref_text: NullableField<String>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub ref_audio_2: NullableField<String>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub ambient_sound: NullableField<String>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub duration_seconds: NullableField<f64>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub x_vector_only_mode: NullableField<bool>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub speaker_embedding: NullableField<SpeechSpeakerEmbedding>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub max_new_tokens: NullableField<i64>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub seed: NullableField<u64>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub initial_codec_chunk_frames: NullableField<u64>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub non_streaming_mode: NullableField<bool>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub extra_params: NullableField<serde_json::Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub word_timestamps: Option<bool>,
+    #[serde(default, skip_serializing_if = "NullableField::is_missing")]
+    pub references: NullableField<Vec<SpeechReference>>,
+    /// Provider fields not yet modeled by this SDK version.
+    ///
+    /// Values are flattened into the request body. Use [`Value::Null`] to
+    /// explicitly send JSON `null`; absent entries are omitted.
+    #[serde(default, flatten)]
+    additional_parameters: serde_json::Map<String, Value>,
+}
+
+impl SpeechSynthesisRequest {
+    /// Creates a speech request without selecting any provider defaults.
+    pub fn new(input: impl Into<String>) -> Self {
+        Self {
+            input: input.into(),
+            model: NullableField::Missing,
+            voice: NullableField::Missing,
+            speaker: NullableField::Missing,
+            instructions: NullableField::Missing,
+            response_format: None,
+            speed: NullableField::Missing,
+            stream_format: NullableField::Missing,
+            stream: None,
+            task_type: NullableField::Missing,
+            language: NullableField::Missing,
+            ref_audio: NullableField::Missing,
+            ref_text: NullableField::Missing,
+            ref_audio_2: NullableField::Missing,
+            ambient_sound: NullableField::Missing,
+            duration_seconds: NullableField::Missing,
+            x_vector_only_mode: NullableField::Missing,
+            speaker_embedding: NullableField::Missing,
+            max_new_tokens: NullableField::Missing,
+            seed: NullableField::Missing,
+            initial_codec_chunk_frames: NullableField::Missing,
+            non_streaming_mode: NullableField::Missing,
+            extra_params: NullableField::Missing,
+            word_timestamps: None,
+            references: NullableField::Missing,
+            additional_parameters: serde_json::Map::new(),
+        }
+    }
+
+    /// Returns forward-compatible provider parameters not modeled by this SDK.
+    pub fn additional_parameters(&self) -> &serde_json::Map<String, Value> {
+        &self.additional_parameters
+    }
+
+    /// Adds a forward-compatible provider parameter to the flattened request.
+    ///
+    /// Typed field names are rejected to prevent duplicate JSON keys. Set those
+    /// fields directly instead.
+    pub fn insert_additional_parameter(
+        &mut self,
+        parameter: impl Into<String>,
+        value: Value,
+    ) -> std::result::Result<Option<Value>, SpeechAdditionalParameterError> {
+        let parameter = parameter.into();
+        if SPEECH_SYNTHESIS_TYPED_PARAMETERS.contains(&parameter.as_str()) {
+            return Err(SpeechAdditionalParameterError { parameter });
+        }
+        Ok(self.additional_parameters.insert(parameter, value))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpeechSynthesisResponseBody {
+    Binary(bytes::Bytes),
+    Json(bytes::Bytes),
+}
+
+impl SpeechSynthesisResponseBody {
+    pub fn as_bytes(&self) -> &bytes::Bytes {
+        match self {
+            Self::Binary(bytes) | Self::Json(bytes) => bytes,
+        }
+    }
+
+    pub fn into_bytes(self) -> bytes::Bytes {
+        match self {
+            Self::Binary(bytes) | Self::Json(bytes) => bytes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpeechSynthesisResponse {
+    pub body: SpeechSynthesisResponseBody,
+    pub content_type: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Model {
     pub id: String,
@@ -1264,6 +1489,168 @@ pub enum AgentSseEvent {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn speech_synthesis_request_has_no_sdk_defaults() {
+        let request = SpeechSynthesisRequest::new("The assistant can speak this response.");
+
+        assert_eq!(
+            serde_json::to_value(&request).unwrap(),
+            json!({
+                "input": "The assistant can speak this response."
+            })
+        );
+
+        let deserialized: SpeechSynthesisRequest =
+            serde_json::from_value(json!({ "input": "No defaults." })).unwrap();
+        assert_eq!(deserialized, SpeechSynthesisRequest::new("No defaults."));
+    }
+
+    #[test]
+    fn speech_synthesis_request_preserves_explicit_nulls() {
+        let mut request = SpeechSynthesisRequest::new("Preserve nulls.");
+        request.model = NullableField::null();
+        request.voice = NullableField::null();
+        request.speed = NullableField::null();
+        request.ref_audio = NullableField::null();
+        request.extra_params = NullableField::null();
+        request.references = NullableField::value(vec![SpeechReference {
+            audio_path: "https://example.com/reference.wav".to_string(),
+            text: NullableField::null(),
+        }]);
+
+        let serialized = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            serialized,
+            json!({
+                "input": "Preserve nulls.",
+                "model": null,
+                "voice": null,
+                "speed": null,
+                "ref_audio": null,
+                "extra_params": null,
+                "references": [{
+                    "audio_path": "https://example.com/reference.wav",
+                    "text": null
+                }]
+            })
+        );
+
+        let round_tripped: SpeechSynthesisRequest = serde_json::from_value(serialized).unwrap();
+        assert_eq!(round_tripped, request);
+    }
+
+    #[test]
+    fn speech_synthesis_request_serializes_current_and_future_provider_parameters() {
+        let mut request = SpeechSynthesisRequest::new("Create configurable speech.");
+        request.model = NullableField::value("voxtral-tts".to_string());
+        request.voice = NullableField::value("neutral_female".to_string());
+        request.speaker = NullableField::value("speaker-alias".to_string());
+        request.instructions = NullableField::value("Sound cheerful".to_string());
+        request.response_format = Some(SpeechSynthesisResponseFormat::Flac);
+        request.speed = NullableField::value(1.2);
+        request.stream_format = NullableField::value(SpeechSynthesisStreamFormat::Audio);
+        request.stream = Some(false);
+        request.task_type = NullableField::value(SpeechSynthesisTaskType::CustomVoice);
+        request.language = NullableField::value("Auto".to_string());
+        request.ref_audio = NullableField::value(SpeechReferenceAudio::Multiple(vec![
+            "data:audio/wav;base64,AAAA".to_string(),
+            "https://example.com/reference.wav".to_string(),
+        ]));
+        request.ref_text = NullableField::value("Reference transcript".to_string());
+        request.ref_audio_2 = NullableField::value("https://example.com/second.wav".to_string());
+        request.ambient_sound = NullableField::value("ocean waves".to_string());
+        request.duration_seconds = NullableField::value(4.5);
+        request.x_vector_only_mode = NullableField::value(true);
+        request.speaker_embedding = NullableField::value(SpeechSpeakerEmbedding::Multiple(vec![
+            vec![0.1, 0.2],
+            vec![0.3, 0.4],
+        ]));
+        request.max_new_tokens = NullableField::value(2048);
+        request.seed = NullableField::value(42);
+        request.initial_codec_chunk_frames = NullableField::value(8);
+        request.non_streaming_mode = NullableField::value(true);
+        request.extra_params = NullableField::value(serde_json::Map::from_iter([(
+            "cfg_alpha".to_string(),
+            json!(0.7),
+        )]));
+        request.word_timestamps = Some(true);
+        request.references = NullableField::value(vec![SpeechReference {
+            audio_path: "https://example.com/voice.wav".to_string(),
+            text: NullableField::value("Hello".to_string()),
+        }]);
+        request
+            .insert_additional_parameter("future_control", Value::Null)
+            .unwrap();
+
+        let serialized = serde_json::to_value(&request).unwrap();
+        assert_eq!(
+            serialized,
+            json!({
+                "input": "Create configurable speech.",
+                "model": "voxtral-tts",
+                "voice": "neutral_female",
+                "speaker": "speaker-alias",
+                "instructions": "Sound cheerful",
+                "response_format": "flac",
+                "speed": 1.2,
+                "stream_format": "audio",
+                "stream": false,
+                "task_type": "CustomVoice",
+                "language": "Auto",
+                "ref_audio": [
+                    "data:audio/wav;base64,AAAA",
+                    "https://example.com/reference.wav"
+                ],
+                "ref_text": "Reference transcript",
+                "ref_audio_2": "https://example.com/second.wav",
+                "ambient_sound": "ocean waves",
+                "duration_seconds": 4.5,
+                "x_vector_only_mode": true,
+                "speaker_embedding": [[0.1, 0.2], [0.3, 0.4]],
+                "max_new_tokens": 2048,
+                "seed": 42,
+                "initial_codec_chunk_frames": 8,
+                "non_streaming_mode": true,
+                "extra_params": { "cfg_alpha": 0.7 },
+                "word_timestamps": true,
+                "references": [{
+                    "audio_path": "https://example.com/voice.wav",
+                    "text": "Hello"
+                }],
+                "future_control": null
+            })
+        );
+
+        let round_tripped: SpeechSynthesisRequest = serde_json::from_value(serialized).unwrap();
+        assert_eq!(round_tripped, request);
+    }
+
+    #[test]
+    fn speech_synthesis_additional_parameters_reject_typed_field_collisions() {
+        let mut request = SpeechSynthesisRequest::new("No duplicate keys.");
+
+        let error = request
+            .insert_additional_parameter("speed", json!(1.5))
+            .unwrap_err();
+        assert_eq!(error.parameter, "speed");
+        assert!(request.additional_parameters().is_empty());
+
+        request
+            .insert_additional_parameter("future_nullable_control", Value::Null)
+            .unwrap();
+        assert_eq!(
+            request.additional_parameters()["future_nullable_control"],
+            Value::Null
+        );
+        assert_eq!(
+            serde_json::to_value(request).unwrap(),
+            json!({
+                "input": "No duplicate keys.",
+                "future_nullable_control": null
+            })
+        );
+    }
 
     #[test]
     fn nullable_field_request_serialization_distinguishes_missing_and_null() {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -7,6 +7,131 @@ export interface CustomFetchOptions {
   apiUrl?: string; // Optional API URL for attestation (required when not using OpenSecretProvider)
 }
 
+export const VOXTRAL_TTS_VOICES = [
+  "neutral_female",
+  "neutral_male",
+  "casual_female",
+  "casual_male",
+  "cheerful_female",
+  "ar_male",
+  "de_female",
+  "de_male",
+  "es_female",
+  "es_male",
+  "fr_female",
+  "fr_male",
+  "hi_female",
+  "hi_male",
+  "it_female",
+  "it_male",
+  "nl_female",
+  "nl_male",
+  "pt_female",
+  "pt_male"
+] as const;
+
+export type VoxtralTtsVoice = (typeof VOXTRAL_TTS_VOICES)[number];
+/**
+ * A provider voice identifier. `VoxtralTtsVoice` enumerates the presets known
+ * to this SDK version, while `string` keeps the request forward-compatible
+ * with voices added by the provider later.
+ */
+export type SpeechSynthesisVoice = VoxtralTtsVoice | (string & Record<never, never>);
+
+export type SpeechSynthesisResponseFormat = "wav" | "pcm" | "flac" | "mp3" | "aac" | "opus";
+export type SpeechSynthesisStreamFormat = "sse" | "audio";
+export type SpeechSynthesisTaskType = "CustomVoice" | "VoiceDesign" | "Base";
+
+export type SpeechSynthesisJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | SpeechSynthesisJsonValue[]
+  | { [key: string]: SpeechSynthesisJsonValue | undefined };
+
+export type SpeechSynthesisReference = {
+  audio_path: string;
+  text?: string | null;
+  [key: string]: SpeechSynthesisJsonValue | undefined;
+};
+
+export type SpeechSynthesisRequest = {
+  input: string;
+  model?: string | null;
+  voice?: SpeechSynthesisVoice | null;
+  /** Alias accepted by vLLM for `voice`. */
+  speaker?: SpeechSynthesisVoice | null;
+  instructions?: string | null;
+  response_format?: SpeechSynthesisResponseFormat;
+  /** Supported range is 0.25 through 4.0 for non-streaming requests. */
+  speed?: number | null;
+  /**
+   * Provider streaming format. The current OpenSecret speech proxy buffers the
+   * complete encrypted response before this helper returns it.
+   */
+  stream_format?: SpeechSynthesisStreamFormat | null;
+  /**
+   * Provider streaming switch. The current OpenSecret speech proxy remains a
+   * buffered HTTP transport even when this field is forwarded as `true`.
+   */
+  stream?: boolean;
+  task_type?: SpeechSynthesisTaskType | null;
+  language?: string | null;
+  ref_audio?: string | string[] | null;
+  ref_text?: string | null;
+  ref_audio_2?: string | null;
+  ambient_sound?: string | null;
+  duration_seconds?: number | null;
+  x_vector_only_mode?: boolean | null;
+  speaker_embedding?: number[] | number[][] | null;
+  max_new_tokens?: number | null;
+  seed?: number | null;
+  initial_codec_chunk_frames?: number | null;
+  non_streaming_mode?: boolean | null;
+  extra_params?: { [key: string]: SpeechSynthesisJsonValue | undefined } | null;
+  word_timestamps?: boolean;
+  references?: SpeechSynthesisReference[] | null;
+  /** Future provider fields are forwarded unchanged. */
+  [key: string]: SpeechSynthesisJsonValue | undefined;
+};
+
+export interface SpeechSynthesisOptions extends CustomFetchOptions {
+  signal?: AbortSignal;
+}
+
+type BinaryResponseCarrier = {
+  content_base64: string;
+  content_type: string;
+};
+
+export async function synthesizeSpeech(
+  request: SpeechSynthesisRequest,
+  options?: SpeechSynthesisOptions
+): Promise<Response> {
+  const requestApiUrl = options?.apiUrl || api.getApiUrl();
+  if (!requestApiUrl) {
+    throw new Error(
+      "No API URL configured. Pass apiUrl or call synthesizeSpeech within OpenSecretProvider."
+    );
+  }
+
+  const apiUrl = requestApiUrl.replace(/\/+$/, "");
+  const customFetch = createCustomFetch({
+    apiKey: options?.apiKey,
+    apiUrl
+  });
+
+  return customFetch(`${apiUrl}/v1/audio/speech`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(request),
+    signal: options?.signal
+  });
+}
+
 export function createCustomFetch(
   options?: CustomFetchOptions
 ): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
@@ -29,7 +154,11 @@ export function createCustomFetch(
       const headers = new Headers(init?.headers);
       headers.set("Authorization", getAuthHeader());
 
-      const { sessionKey, sessionId } = await getAttestation(false, options?.apiUrl);
+      const { sessionKey, sessionId } = await getAttestation(
+        false,
+        options?.apiUrl,
+        init?.signal ?? undefined
+      );
       if (!sessionKey || !sessionId) {
         throw new Error("No session key or ID available");
       }
@@ -132,63 +261,39 @@ export function createCustomFetch(
 
       // Decrypt regular JSON responses
       const responseText = await response.text();
+      let responseData: unknown;
       try {
-        const responseData = JSON.parse(responseText);
+        responseData = JSON.parse(responseText);
+      } catch {
+        // If it's not JSON or doesn't have encrypted field, return original response
+        console.log("Response is not encrypted JSON, returning as-is");
+      }
 
-        // Check if the response has an encrypted field
-        if (responseData.encrypted) {
-          const decrypted = decryptMessage(sessionKey, responseData.encrypted);
+      if (isRecord(responseData) && typeof responseData.encrypted === "string") {
+        const decrypted = decryptMessage(sessionKey, responseData.encrypted);
+        const binaryCarrier = parseBinaryResponseCarrier(decrypted);
 
-          // Try to parse as JSON to check for TTS response format
-          try {
-            const decryptedData = JSON.parse(decrypted);
+        if (binaryCarrier) {
+          const bytes = decodeBinaryResponseCarrier(binaryCarrier);
+          const headersOut = new Headers(response.headers);
+          headersOut.set("content-type", binaryCarrier.content_type);
+          // These describe the encrypted carrier rather than the decoded body.
+          headersOut.delete("content-encoding");
+          headersOut.delete("content-length");
+          headersOut.delete("transfer-encoding");
 
-            // Check if this is a TTS response with content_base64 and content_type
-            if (decryptedData.content_base64 && decryptedData.content_type) {
-              console.log("TTS response detected with content_type:", decryptedData.content_type);
-
-              // Decode base64 audio data to binary
-              let bytes: Uint8Array;
-              try {
-                const binaryString = atob(decryptedData.content_base64);
-                bytes = new Uint8Array(binaryString.length);
-                for (let i = 0; i < binaryString.length; i++) {
-                  bytes[i] = binaryString.charCodeAt(i);
-                }
-              } catch (e) {
-                console.error("Failed to decode base64 audio data:", e);
-                throw new Error("Invalid base64 audio data in TTS response");
-              }
-
-              console.log("Decoded audio bytes length:", bytes.length);
-
-              // Return as a binary response with the proper content type
-              const headersOut = new Headers(response.headers);
-              headersOut.set("content-type", decryptedData.content_type);
-              // Remove headers that are no longer valid for the decoded response
-              headersOut.delete("content-encoding");
-              headersOut.delete("content-length");
-              headersOut.delete("transfer-encoding");
-
-              return new Response(bytes, {
-                headers: headersOut,
-                status: response.status,
-                statusText: response.statusText
-              });
-            }
-          } catch {
-            // Not JSON, continue with regular text response
-          }
-          // Return a new Response with the decrypted data
-          return new Response(decrypted, {
-            headers: response.headers,
+          return new Response(bytes, {
+            headers: headersOut,
             status: response.status,
             statusText: response.statusText
           });
         }
-      } catch {
-        // If it's not JSON or doesn't have encrypted field, return original response
-        console.log("Response is not encrypted JSON, returning as-is");
+
+        return new Response(decrypted, {
+          headers: response.headers,
+          status: response.status,
+          statusText: response.statusText
+        });
       }
 
       // Return the original response text as a new Response
@@ -202,6 +307,68 @@ export function createCustomFetch(
       throw error;
     }
   };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseBinaryResponseCarrier(decrypted: string): BinaryResponseCarrier | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(decrypted);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const hasContent = Object.prototype.hasOwnProperty.call(value, "content_base64");
+  const hasContentType = Object.prototype.hasOwnProperty.call(value, "content_type");
+  if (!hasContent || !hasContentType) {
+    return null;
+  }
+
+  if (typeof value.content_base64 !== "string" || value.content_base64.length === 0) {
+    throw new Error("Invalid binary response carrier");
+  }
+
+  if (typeof value.content_type !== "string") {
+    throw new Error("Invalid binary response carrier");
+  }
+
+  const contentType = value.content_type.trim();
+  const mediaType = contentType.split(";", 1)[0].trim().toLowerCase();
+  if (!/^[^\s/;]+\/[^\s/;]+$/.test(mediaType)) {
+    throw new Error("Invalid binary response carrier");
+  }
+
+  return {
+    content_base64: value.content_base64,
+    content_type: contentType
+  };
+}
+
+function decodeBinaryResponseCarrier(carrier: BinaryResponseCarrier): Uint8Array {
+  let binaryString: string;
+  try {
+    binaryString = atob(carrier.content_base64);
+  } catch (error) {
+    console.error("Failed to decode base64 binary data:", error);
+    throw new Error("Invalid base64 data in binary response");
+  }
+
+  if (binaryString.length === 0) {
+    throw new Error("Binary response carrier contained no data");
+  }
+
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
 }
 
 function extractEvent(buffer: string): string | null {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -232,10 +232,11 @@ export async function requestNewVerificationCode(): Promise<void> {
 
 export async function fetchAttestationDocument(
   nonce: string,
-  explicitApiUrl?: string
+  explicitApiUrl?: string,
+  signal?: AbortSignal
 ): Promise<string> {
   const url = explicitApiUrl || apiUrl;
-  const response = await fetch(`${url}/attestation/${nonce}`);
+  const response = await fetch(`${url}/attestation/${nonce}`, { signal });
   if (!response.ok) {
     throw new Error(`Request failed with status ${response.status}`);
   }
@@ -246,7 +247,8 @@ export async function fetchAttestationDocument(
 export async function keyExchange(
   clientPublicKey: string,
   nonce: string,
-  explicitApiUrl?: string
+  explicitApiUrl?: string,
+  signal?: AbortSignal
 ): Promise<{ encrypted_session_key: string; session_id: string }> {
   const url = explicitApiUrl || apiUrl;
   const response = await fetch(`${url}/key_exchange`, {
@@ -254,7 +256,8 @@ export async function keyExchange(
     headers: {
       "Content-Type": "application/json"
     },
-    body: JSON.stringify({ client_public_key: clientPublicKey, nonce })
+    body: JSON.stringify({ client_public_key: clientPublicKey, nonce }),
+    signal
   });
 
   if (!response.ok) {

--- a/src/lib/attestation.ts
+++ b/src/lib/attestation.ts
@@ -270,10 +270,11 @@ async function fakeAuthenticate(
 
 export async function verifyAttestation(
   nonce: string,
-  explicitApiUrl?: string
+  explicitApiUrl?: string,
+  signal?: AbortSignal
 ): Promise<AttestationDocument> {
   try {
-    const attestationDocumentBase64 = await fetchAttestationDocument(nonce, explicitApiUrl);
+    const attestationDocumentBase64 = await fetchAttestationDocument(nonce, explicitApiUrl, signal);
 
     // Get the API URL from the API layer where it's already set
     // First check explicit URL, then check both possible APIs
@@ -290,6 +291,15 @@ export async function verifyAttestation(
     const verifiedDocument = await authenticate(attestationDocumentBase64, awsRootCertDer, nonce);
     return verifiedDocument;
   } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "name" in error &&
+      error.name === "AbortError"
+    ) {
+      throw error;
+    }
+
     if (error instanceof Error) {
       console.error("Error verifying attestation document:", error);
       throw new Error(`Couldn't process attestation document: ${error.message}`);

--- a/src/lib/getAttestation.ts
+++ b/src/lib/getAttestation.ts
@@ -27,7 +27,8 @@ function generateNaclKeyPair(): { publicKey: Uint8Array; secretKey: Uint8Array }
 
 export async function getAttestation(
   forceRefresh?: boolean,
-  explicitApiUrl?: string
+  explicitApiUrl?: string,
+  signal?: AbortSignal
 ): Promise<Attestation> {
   // Check if we already have a sessionKey and sessionId in sessionstorage
   const sessionKey = sessionStorage.getItem("sessionKey");
@@ -48,7 +49,7 @@ export async function getAttestation(
     const attestationNonce = window.crypto.randomUUID();
 
     console.log("Generated attestation nonce:", attestationNonce);
-    const document = await verifyAttestation(attestationNonce, explicitApiUrl);
+    const document = await verifyAttestation(attestationNonce, explicitApiUrl, signal);
 
     if (document && document.public_key) {
       console.log("Attestation document verification succeeded");
@@ -59,7 +60,8 @@ export async function getAttestation(
       const { encrypted_session_key, session_id } = await keyExchange(
         encode(clientKeyPair.publicKey),
         attestationNonce,
-        explicitApiUrl
+        explicitApiUrl,
+        signal
       );
       console.log("Key exchange completed.");
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -113,8 +113,22 @@ export {
   getSubagentItem
 } from "./api";
 
-// Export AI customization options
-export { createCustomFetch, type CustomFetchOptions } from "./ai";
+// Export AI customization options and speech synthesis
+export {
+  VOXTRAL_TTS_VOICES,
+  createCustomFetch,
+  synthesizeSpeech,
+  type CustomFetchOptions,
+  type SpeechSynthesisOptions,
+  type SpeechSynthesisJsonValue,
+  type SpeechSynthesisReference,
+  type SpeechSynthesisRequest,
+  type SpeechSynthesisResponseFormat,
+  type SpeechSynthesisStreamFormat,
+  type SpeechSynthesisTaskType,
+  type SpeechSynthesisVoice,
+  type VoxtralTtsVoice
+} from "./ai";
 
 // Re-export Model type from OpenAI for convenience
 export type { Model } from "openai/resources/models.js";

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -1,6 +1,11 @@
 import React, { createContext, useState, useEffect } from "react";
 import * as api from "./api";
-import { createCustomFetch } from "./ai";
+import {
+  createCustomFetch,
+  synthesizeSpeech as synthesizeSpeechRequest,
+  type SpeechSynthesisOptions,
+  type SpeechSynthesisRequest
+} from "./ai";
 import { getAttestation } from "./getAttestation";
 import type { Model } from "openai/resources/models.js";
 import { authenticate } from "./attestation";
@@ -342,6 +347,18 @@ export type OpenSecretContextType = {
    * ```
    */
   aiCustomFetch: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+  /**
+   * Synthesizes speech through OpenSecret's Tinfoil speech endpoint.
+   *
+   * Request fields are forwarded without SDK-provided model, voice, format, or
+   * speed defaults. The provider supplies the configured OpenSecret URL and
+   * current API key. Pass an AbortSignal to cancel an in-flight request.
+   */
+  synthesizeSpeech: (
+    request: SpeechSynthesisRequest,
+    options?: Pick<SpeechSynthesisOptions, "signal">
+  ) => Promise<Response>;
 
   /**
    * Returns the current OpenSecret enclave API URL being used
@@ -939,6 +956,7 @@ export const OpenSecretContext = createContext<OpenSecretContextType>({
   getPublicKey: api.fetchPublicKey,
   signMessage: api.signMessage,
   aiCustomFetch: async () => new Response(),
+  synthesizeSpeech: async () => new Response(),
   apiUrl: "",
   pcrConfig: {},
   getAttestation,
@@ -1361,6 +1379,12 @@ export function OpenSecretProvider({
     getPublicKey: api.fetchPublicKey,
     signMessage: api.signMessage,
     aiCustomFetch: aiCustomFetch || (async () => new Response()),
+    synthesizeSpeech: (request, options) =>
+      synthesizeSpeechRequest(request, {
+        apiUrl,
+        apiKey,
+        signal: options?.signal
+      }),
     apiUrl,
     pcrConfig,
     getAttestation,

--- a/src/lib/test/integration/ai.test.ts
+++ b/src/lib/test/integration/ai.test.ts
@@ -7,7 +7,7 @@ import {
   batchDeleteConversations,
   listConversations
 } from "../../api";
-import { createCustomFetch } from "../../ai";
+import { createCustomFetch, synthesizeSpeech } from "../../ai";
 import OpenAI from "openai";
 
 const TEST_EMAIL = process.env.VITE_TEST_EMAIL;
@@ -15,7 +15,6 @@ const TEST_PASSWORD = process.env.VITE_TEST_PASSWORD;
 const TEST_CLIENT_ID = process.env.VITE_TEST_CLIENT_ID;
 const API_URL = process.env.VITE_OPEN_SECRET_API_URL;
 const CHAT_MODEL = process.env.VITE_TEST_CHAT_MODEL ?? "llama3-3-70b";
-const TTS_MODEL = process.env.VITE_TEST_TTS_MODEL ?? "qwen3-tts";
 
 if (!TEST_EMAIL || !TEST_PASSWORD || !TEST_CLIENT_ID || !API_URL) {
   throw new Error("Test credentials must be set in .env.local");
@@ -198,53 +197,27 @@ liveAiTest("streams chat completion", async () => {
   expect(response?.trim()).toBe("echo");
 });
 
-test.skip("text-to-speech with configured TTS model", async () => {
+test.skip("Voxtral text-to-speech returns WAV audio", async () => {
   await setupTestUser();
 
-  const client = new OpenAI({
-    baseURL: `${API_URL}/v1/`,
-    dangerouslyAllowBrowser: true,
-    apiKey: "api-key-doesnt-matter",
-    defaultHeaders: {
-      "Accept-Encoding": "identity"
-    },
-    fetch: createCustomFetch()
-  });
-
   const textToSpeak = "Hello, this is a test of the text-to-speech system.";
-
-  const response = await client.audio.speech.create({
-    model: TTS_MODEL,
-    voice: "af_sky" as any,
-    input: textToSpeak,
-    response_format: "mp3"
-  });
+  const response = await synthesizeSpeech(
+    {
+      input: textToSpeak,
+      model: "voxtral-tts",
+      voice: "neutral_female"
+    },
+    { apiUrl: API_URL }
+  );
 
   const buffer = Buffer.from(await response.arrayBuffer());
 
-  // Verify we got back audio data
-  expect(buffer.length).toBeGreaterThan(0);
+  expect(response.headers.get("content-type")).toContain("audio/wav");
+  expect(buffer.length).toBeGreaterThan(44);
+  expect(buffer.subarray(0, 4).toString("ascii")).toBe("RIFF");
+  expect(buffer.subarray(8, 12).toString("ascii")).toBe("WAVE");
 
   console.log(`TTS response size: ${buffer.length} bytes`);
-
-  // Log the first 20 bytes to understand the format
-  const first20Bytes = buffer.slice(0, 20).toString("hex");
-  console.log(`First 20 bytes (hex): ${first20Bytes}`);
-
-  // Also log as string to see if it's JSON or text
-  const first100Chars = buffer.slice(0, 100).toString("utf-8");
-  console.log(`First 100 chars (string): ${first100Chars}`);
-
-  // MP3 files typically start with an ID3 tag or FF FB/FF FA (MPEG audio sync)
-  const firstBytes = buffer.slice(0, 3).toString("hex");
-  const isID3 = firstBytes === "494433"; // "ID3" in hex
-  const isMPEGSync = firstBytes.startsWith("fff") || firstBytes.startsWith("ffe");
-
-  // For now, just verify we got data back
-  // The format check might need adjustment based on what the server returns
-  if (!isID3 && !isMPEGSync) {
-    console.warn("Response doesn't appear to be MP3 format, but got data back");
-  }
 });
 
 // To run this test manually:
@@ -276,34 +249,26 @@ test.skip("Whisper transcription with real MP3 file", async () => {
 test.skip("TTS → Whisper transcription chain", async () => {
   await setupTestUser();
 
-  const client = new OpenAI({
-    baseURL: `${API_URL}/v1/`,
-    dangerouslyAllowBrowser: true,
-    apiKey: "api-key-doesnt-matter",
-    defaultHeaders: {
-      "Accept-Encoding": "identity"
-    },
-    fetch: createCustomFetch()
-  });
-
   // Step 1: Generate speech from simple text
   const originalText = "Hello";
 
   console.log("Generating speech from text:", originalText);
 
-  const ttsResponse = await client.audio.speech.create({
-    model: TTS_MODEL,
-    voice: "af_sky" as any,
-    input: originalText,
-    response_format: "mp3"
-  });
+  const ttsResponse = await synthesizeSpeech(
+    {
+      input: originalText,
+      model: "voxtral-tts",
+      voice: "neutral_female"
+    },
+    { apiUrl: API_URL }
+  );
 
   const audioBuffer = Buffer.from(await ttsResponse.arrayBuffer());
   console.log(`Generated audio size: ${audioBuffer.length} bytes`);
 
   // Step 2: Create a Blob from the audio buffer
-  const audioBlob = new Blob([audioBuffer], { type: "audio/mpeg" });
-  const audioFile = new File([audioBlob], "tts_output.mp3", { type: "audio/mpeg" });
+  const audioBlob = new Blob([audioBuffer], { type: "audio/wav" });
+  const audioFile = new File([audioBlob], "tts_output.wav", { type: "audio/wav" });
 
   // Step 3: Transcribe the audio back to text using Whisper
   console.log("Transcribing audio back to text...");

--- a/src/lib/test/integration/speech.test.ts
+++ b/src/lib/test/integration/speech.test.ts
@@ -1,0 +1,421 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { decode, encode } from "@stablelib/base64";
+import { ChaCha20Poly1305 } from "@stablelib/chacha20poly1305";
+import * as cbor from "cbor2";
+import nacl from "tweetnacl";
+import { synthesizeSpeech, type SpeechSynthesisRequest } from "../../ai";
+import { getApiUrl, setApiUrl } from "../../api";
+import { decryptMessage, encryptMessage } from "../../encryption";
+
+const apiUrl = "https://api.example.com";
+const apiKey = "speech-api-key";
+const sessionId = "speech-session-id";
+const sessionKey = new Uint8Array(32).fill(23);
+const originalFetch = globalThis.fetch;
+const originalApiUrl = getApiUrl();
+
+const wavBytes = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20,
+  0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x80, 0xbb, 0x00, 0x00, 0x00, 0x77, 0x01, 0x00,
+  0x02, 0x00, 0x10, 0x00, 0x64, 0x61, 0x74, 0x61, 0x00, 0x00, 0x00, 0x00
+]);
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  window.sessionStorage.setItem("sessionKey", encode(sessionKey));
+  window.sessionStorage.setItem("sessionId", sessionId);
+  setApiUrl(apiUrl);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  setApiUrl(originalApiUrl);
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+function encryptedResponse(carrier: unknown, headers?: HeadersInit): Response {
+  return new Response(
+    JSON.stringify({
+      encrypted: encryptMessage(sessionKey, JSON.stringify(carrier))
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        ...headers
+      }
+    }
+  );
+}
+
+test("synthesizeSpeech forwards provider fields unchanged and returns decoded WAV bytes", async () => {
+  const speechRequest: SpeechSynthesisRequest = {
+    input: "Read this aloud.",
+    model: "voxtral-tts",
+    voice: "neutral_female",
+    speaker: null,
+    instructions: null,
+    response_format: "wav",
+    speed: 1.2,
+    stream_format: null,
+    stream: false,
+    task_type: null,
+    language: "Auto",
+    ref_audio: null,
+    ref_text: null,
+    ref_audio_2: null,
+    ambient_sound: null,
+    duration_seconds: null,
+    x_vector_only_mode: null,
+    speaker_embedding: null,
+    max_new_tokens: 4096,
+    seed: 42,
+    initial_codec_chunk_frames: null,
+    non_streaming_mode: null,
+    extra_params: { cfg_alpha: 1.5 },
+    word_timestamps: false,
+    references: [{ audio_path: "data:audio/wav;base64,UklGRg==", text: null }],
+    future_provider_option: { nested: [1, true, null] }
+  };
+
+  globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    expect(input.toString()).toBe(`${apiUrl}/v1/audio/speech`);
+    expect(init?.method).toBe("POST");
+
+    const headers = new Headers(init?.headers);
+    expect(headers.get("authorization")).toBe(`Bearer ${apiKey}`);
+    expect(headers.get("x-session-id")).toBe(sessionId);
+    expect(headers.get("content-type")).toBe("application/json");
+
+    const encryptedRequest = JSON.parse(String(init?.body)) as { encrypted: string };
+    expect(JSON.parse(decryptMessage(sessionKey, encryptedRequest.encrypted))).toEqual(
+      speechRequest
+    );
+
+    return encryptedResponse(
+      {
+        content_base64: encode(wavBytes),
+        content_type: " audio/wav; codecs=1 "
+      },
+      {
+        "Content-Encoding": "identity",
+        "Content-Length": "999",
+        "Transfer-Encoding": "chunked",
+        "X-Preserved": "yes"
+      }
+    );
+  }) as typeof fetch;
+
+  const response = await synthesizeSpeech(speechRequest, { apiKey, apiUrl: `${apiUrl}/` });
+
+  expect(response.headers.get("content-type")).toBe("audio/wav; codecs=1");
+  expect(response.headers.get("content-encoding")).toBeNull();
+  expect(response.headers.get("content-length")).toBeNull();
+  expect(response.headers.get("transfer-encoding")).toBeNull();
+  expect(response.headers.get("x-preserved")).toBe("yes");
+  expect(new Uint8Array(await response.arrayBuffer())).toEqual(wavBytes);
+});
+
+test("synthesizeSpeech normalizes trailing-slash URLs for a fresh attestation session", async () => {
+  window.sessionStorage.clear();
+
+  const localApiUrl = "http://127.0.0.1:31587";
+  const serverKeyPair = nacl.box.keyPair();
+  const attestationPayload = cbor.encode({ public_key: serverKeyPair.publicKey });
+  const fakeAttestationDocument = encode(
+    cbor.encode([new Uint8Array(), new Map(), attestationPayload, new Uint8Array()])
+  );
+  const controller = new AbortController();
+  const requestedUrls: string[] = [];
+  let attestationNonce: string | undefined;
+
+  globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    const requestUrl = input.toString();
+    requestedUrls.push(requestUrl);
+
+    if (requestUrl.startsWith(`${localApiUrl}/attestation/`)) {
+      expect(init?.signal).toBe(controller.signal);
+      expect(requestUrl).toMatch(
+        /^http:\/\/127\.0\.0\.1:31587\/attestation\/[0-9a-f]{8}-[0-9a-f-]+$/i
+      );
+      attestationNonce = requestUrl.slice(`${localApiUrl}/attestation/`.length);
+      return Response.json({ attestation_document: fakeAttestationDocument });
+    }
+
+    if (requestUrl === `${localApiUrl}/key_exchange`) {
+      expect(init?.signal).toBe(controller.signal);
+      const body = JSON.parse(String(init?.body)) as {
+        client_public_key: string;
+        nonce: string;
+      };
+      expect(body.nonce).toBe(attestationNonce);
+
+      const clientPublicKey = decode(body.client_public_key);
+      const sharedSecret = nacl.scalarMult(serverKeyPair.secretKey, clientPublicKey);
+      const nonce = new Uint8Array(12).fill(31);
+      const ciphertext = new ChaCha20Poly1305(sharedSecret).seal(nonce, sessionKey);
+      const encryptedSessionKey = new Uint8Array(nonce.length + ciphertext.length);
+      encryptedSessionKey.set(nonce);
+      encryptedSessionKey.set(ciphertext, nonce.length);
+
+      return Response.json({
+        encrypted_session_key: encode(encryptedSessionKey),
+        session_id: sessionId
+      });
+    }
+
+    if (requestUrl === `${localApiUrl}/v1/audio/speech`) {
+      expect(init?.signal).toBe(controller.signal);
+      const encryptedRequest = JSON.parse(String(init?.body)) as { encrypted: string };
+      expect(JSON.parse(decryptMessage(sessionKey, encryptedRequest.encrypted))).toEqual({
+        input: "Cold session."
+      });
+      return encryptedResponse({
+        content_base64: encode(wavBytes),
+        content_type: "audio/wav"
+      });
+    }
+
+    throw new Error(`Unexpected request URL: ${requestUrl}`);
+  }) as typeof fetch;
+
+  const response = await synthesizeSpeech(
+    { input: "Cold session." },
+    { apiKey, apiUrl: `${localApiUrl}/`, signal: controller.signal }
+  );
+
+  expect(requestedUrls).toHaveLength(3);
+  expect(requestedUrls[0]).toStartWith(`${localApiUrl}/attestation/`);
+  expect(requestedUrls[1]).toBe(`${localApiUrl}/key_exchange`);
+  expect(requestedUrls[2]).toBe(`${localApiUrl}/v1/audio/speech`);
+  expect(requestedUrls.every((url) => !url.includes(`${localApiUrl}//`))).toBe(true);
+  expect(new Uint8Array(await response.arrayBuffer())).toEqual(wavBytes);
+});
+
+test("synthesizeSpeech preserves AbortError when cancelled during attestation", async () => {
+  window.sessionStorage.clear();
+
+  const localApiUrl = "http://127.0.0.1:31587";
+  const controller = new AbortController();
+  const abortError = new DOMException("Speech synthesis cancelled", "AbortError");
+  const requestedUrls: string[] = [];
+  let markAttestationStarted!: () => void;
+  const attestationStarted = new Promise<void>((resolve) => {
+    markAttestationStarted = resolve;
+  });
+
+  globalThis.fetch = mock(
+    async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const requestUrl = input.toString();
+      requestedUrls.push(requestUrl);
+
+      if (!requestUrl.startsWith(`${localApiUrl}/attestation/`)) {
+        throw new Error(`Unexpected request after attestation abort: ${requestUrl}`);
+      }
+
+      expect(init?.signal).toBe(controller.signal);
+      markAttestationStarted();
+
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          reject(new Error("Attestation request did not receive the AbortSignal"));
+          return;
+        }
+
+        const rejectWithAbortReason = () => reject(signal.reason);
+        if (signal.aborted) {
+          rejectWithAbortReason();
+        } else {
+          signal.addEventListener("abort", rejectWithAbortReason, { once: true });
+        }
+      });
+    }
+  ) as typeof fetch;
+
+  const synthesis = synthesizeSpeech(
+    { input: "Cancel before key exchange." },
+    {
+      apiKey,
+      apiUrl: `${localApiUrl}/`,
+      signal: controller.signal
+    }
+  );
+
+  await attestationStarted;
+  controller.abort(abortError);
+
+  let rejection: unknown;
+  try {
+    await synthesis;
+  } catch (error) {
+    rejection = error;
+  }
+
+  expect(rejection).toBe(abortError);
+  expect(requestedUrls).toHaveLength(1);
+  expect(requestedUrls[0]).toStartWith(`${localApiUrl}/attestation/`);
+  expect(requestedUrls.some((url) => url.endsWith("/key_exchange"))).toBe(false);
+  expect(requestedUrls.some((url) => url.endsWith("/v1/audio/speech"))).toBe(false);
+});
+
+test("synthesizeSpeech passes through an HTTP-200 provider JSON error carrier", async () => {
+  const providerError =
+    '{ "error": { "message": "The requested voice is unavailable" }, "request_id": "tts-7" }';
+
+  globalThis.fetch = mock(async () =>
+    encryptedResponse({
+      content_base64: encode(new TextEncoder().encode(providerError)),
+      content_type: "application/problem+json; charset=utf-8"
+    })
+  ) as typeof fetch;
+
+  const response = await synthesizeSpeech({ input: "Hello", model: "voxtral-tts" }, { apiKey });
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toBe("application/problem+json; charset=utf-8");
+  expect(await response.text()).toBe(providerError);
+});
+
+test("synthesizeSpeech decodes an application/octet-stream binary carrier", async () => {
+  const binaryBytes = new Uint8Array([0x00, 0x7f, 0x80, 0xff]);
+
+  globalThis.fetch = mock(async () =>
+    encryptedResponse({
+      content_base64: encode(binaryBytes),
+      content_type: "application/octet-stream"
+    })
+  ) as typeof fetch;
+
+  const response = await synthesizeSpeech({ input: "Binary response" }, { apiKey });
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toBe("application/octet-stream");
+  expect(new Uint8Array(await response.arrayBuffer())).toEqual(binaryBytes);
+});
+
+test("synthesizeSpeech preserves JSON objects that only resemble binary carriers", async () => {
+  const providerBodies = [
+    {
+      error: "Provider field collision",
+      content_base64: "diagnostic value, not a carrier"
+    },
+    {
+      error: "Provider field collision",
+      content_type: "application/json"
+    }
+  ];
+  let responseIndex = 0;
+
+  globalThis.fetch = mock(async () =>
+    encryptedResponse(providerBodies[responseIndex++])
+  ) as typeof fetch;
+
+  for (const providerBody of providerBodies) {
+    const response = await synthesizeSpeech({ input: "Collision response" }, { apiKey });
+
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toEqual(providerBody);
+  }
+});
+
+test("synthesizeSpeech passes through an HTTP-200 application/json error carrier", async () => {
+  const providerError = {
+    error: {
+      message: "Speech generation failed",
+      type: "provider_error"
+    }
+  };
+
+  globalThis.fetch = mock(async () =>
+    encryptedResponse({
+      content_base64: encode(new TextEncoder().encode(JSON.stringify(providerError))),
+      content_type: "application/json"
+    })
+  ) as typeof fetch;
+
+  const response = await synthesizeSpeech({ input: "Hello", model: "voxtral-tts" }, { apiKey });
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toContain("application/json");
+  expect(await response.json()).toEqual(providerError);
+});
+
+test("synthesizeSpeech rejects malformed base64 binary data", async () => {
+  globalThis.fetch = mock(async () =>
+    encryptedResponse({
+      content_base64: "%%%not-base64%%%",
+      content_type: "audio/wav"
+    })
+  ) as typeof fetch;
+
+  await expect(synthesizeSpeech({ input: "Hello" }, { apiKey })).rejects.toThrow(
+    "Invalid base64 data in binary response"
+  );
+});
+
+test("synthesizeSpeech rejects malformed binary carriers", async () => {
+  const invalidCarriers = [
+    { content_base64: encode(wavBytes), content_type: "audio/" },
+    { content_base64: encode(wavBytes), content_type: "not-a-media-type" }
+  ];
+  let responseIndex = 0;
+
+  globalThis.fetch = mock(async () =>
+    encryptedResponse(invalidCarriers[responseIndex++])
+  ) as typeof fetch;
+
+  for (const input of ["Empty subtype", "Invalid type"]) {
+    await expect(synthesizeSpeech({ input }, { apiKey })).rejects.toThrow(
+      "Invalid binary response carrier"
+    );
+  }
+});
+
+test("synthesizeSpeech preserves AbortError when cancelled during the provider request", async () => {
+  const controller = new AbortController();
+  const abortError = new DOMException("Speech synthesis cancelled", "AbortError");
+  let markRequestStarted!: () => void;
+  const requestStarted = new Promise<void>((resolve) => {
+    markRequestStarted = resolve;
+  });
+
+  globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+    expect(init?.signal).toBe(controller.signal);
+    markRequestStarted();
+
+    return new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) {
+        reject(new Error("Speech request did not receive the AbortSignal"));
+        return;
+      }
+
+      const rejectWithAbortReason = () => reject(signal.reason);
+      if (signal.aborted) {
+        rejectWithAbortReason();
+      } else {
+        signal.addEventListener("abort", rejectWithAbortReason, { once: true });
+      }
+    });
+  }) as typeof fetch;
+
+  const synthesis = synthesizeSpeech(
+    { input: "Cancelable speech." },
+    { apiKey, signal: controller.signal }
+  );
+
+  await requestStarted;
+  controller.abort(abortError);
+
+  let rejection: unknown;
+  try {
+    await synthesis;
+  } catch (error) {
+    rejection = error;
+  }
+
+  expect(rejection).toBe(abortError);
+});


### PR DESCRIPTION
## Summary

- add first-class encrypted speech synthesis APIs to the TypeScript, React, and Rust SDKs
- model the complete current vLLM-Omni speech request surface while accepting future provider fields
- preserve omitted versus explicitly `null` parameters and add no SDK-side model, voice, speed, format, or language defaults
- return exact provider bytes and MIME type for both audio and JSON success bodies
- thread TypeScript `AbortSignal` through attestation, key exchange, and provider fetch
- forward streaming-related options while documenting that the encrypted OpenSecret response remains buffered

## API surface

TypeScript/React:

- `synthesizeSpeech(request, options?)`
- `useOpenSecret().synthesizeSpeech(request, options?)`
- typed optional/nullable fields plus a future-field escape hatch
- standard `Response` output

Rust:

- `OpenSecretClient::synthesize_speech`
- `SpeechSynthesisRequest` with `NullableField` and flattened additional parameters
- `SpeechSynthesisResponse` with decoded bytes and MIME type

## Validation

- TypeScript speech suite: 10 passed
- TypeScript formatting, ESLint, typecheck, and production build
- Rust library suite: 82 passed; all test targets compile
- Rust formatting, Clippy with warnings denied, and rustdoc
- managed encrypted Free/Pro smoke through OpenSecret/Tinfoil, including neutral/French-accent voices, 1.0x/1.2x speed, explicit `language: null`, WAV inspection, and local Whisper transcription
- `git diff --check`

The broader TypeScript integration suite reached 30 passing tests but could not discover 7 live-account suites because this checkout does not contain their private `.env.local` credentials. The focused speech suite passed.

## Rollout dependency

This PR intentionally does not bump or publish either package version. Maple #694 uses the already-published `aiCustomFetch` helper, so it does not depend on this PR; this adds the maintained first-class API for SDK consumers and future Maple adoption.

Companion PRs:

- OpenSecret backend: https://github.com/OpenSecretCloud/opensecret/pull/241
- Maple: https://github.com/OpenSecretCloud/Maple/pull/694
