### PR TITLE
Recover custom fetch from stale encryption sessions

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,5 +1,5 @@
 import { decryptMessage, encryptMessage } from "./encryption";
-import { getAttestation } from "./getAttestation";
+import { getAttestation, type Attestation } from "./getAttestation";
 import * as api from "./api";
 
 export interface CustomFetchOptions {
@@ -7,9 +7,83 @@ export interface CustomFetchOptions {
   apiUrl?: string; // Optional API URL for attestation (required when not using OpenSecretProvider)
 }
 
+interface ActiveAttestation {
+  sessionKey: Uint8Array;
+  sessionId: string;
+}
+
+/** @internal Exported for deterministic transport tests, not from the package entry point. */
+export interface CustomFetchDependencies {
+  decryptMessage: typeof decryptMessage;
+  encryptMessage: typeof encryptMessage;
+  fetch: typeof globalThis.fetch;
+  getAttestation: typeof getAttestation;
+  refreshToken: typeof api.refreshToken;
+}
+
+const defaultDependencies: CustomFetchDependencies = {
+  decryptMessage,
+  encryptMessage,
+  fetch: (...args) => globalThis.fetch(...args),
+  getAttestation,
+  refreshToken: api.refreshToken
+};
+
+function requireActiveAttestation(attestation: Attestation): ActiveAttestation {
+  if (!attestation.sessionKey || !attestation.sessionId) {
+    throw new Error("No session key or ID available");
+  }
+
+  return {
+    sessionKey: attestation.sessionKey,
+    sessionId: attestation.sessionId
+  };
+}
+
+async function discardResponse(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // The response is being discarded for a bounded retry. Some runtimes may
+    // already have closed its body, which needs no further cleanup.
+  }
+}
+
 export function createCustomFetch(
   options?: CustomFetchOptions
 ): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
+  return createCustomFetchWithDependencies(options, defaultDependencies);
+}
+
+/** @internal Exported for deterministic transport tests, not from the package entry point. */
+export function createCustomFetchWithDependencies(
+  options: CustomFetchOptions | undefined,
+  dependencies: CustomFetchDependencies
+): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
+  let attestationRefresh: Promise<ActiveAttestation> | undefined;
+
+  const renewAttestation = async (failedSessionId: string): Promise<ActiveAttestation> => {
+    // A concurrent request or token refresh may already have replaced the
+    // failed session. Reuse it instead of starting another handshake.
+    const currentAttestation = requireActiveAttestation(
+      await dependencies.getAttestation(false, options?.apiUrl)
+    );
+    if (currentAttestation.sessionId !== failedSessionId) {
+      return currentAttestation;
+    }
+
+    if (!attestationRefresh) {
+      attestationRefresh = dependencies
+        .getAttestation(true, options?.apiUrl)
+        .then(requireActiveAttestation)
+        .finally(() => {
+          attestationRefresh = undefined;
+        });
+    }
+
+    return attestationRefresh;
+  };
+
   return async (requestUrl: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const getAuthHeader = () => {
       // If an API key is provided, use it instead of JWT token
@@ -26,34 +100,74 @@ export function createCustomFetch(
     };
 
     try {
-      const headers = new Headers(init?.headers);
-      headers.set("Authorization", getAuthHeader());
+      // Keep this operation bound to the identity that initiated it. An
+      // unrelated account change during attestation must not send the
+      // already-prepared plaintext request under a different token.
+      let authHeader = getAuthHeader();
 
-      const { sessionKey, sessionId } = await getAttestation(false, options?.apiUrl);
-      if (!sessionKey || !sessionId) {
-        throw new Error("No session key or ID available");
+      const makeRequest = async (attestation: ActiveAttestation) => {
+        const headers = new Headers(init?.headers);
+        headers.set("Authorization", authHeader);
+        headers.set("x-session-id", attestation.sessionId);
+
+        const requestOptions: RequestInit = { ...init, headers };
+
+        // Encrypt the original plaintext again for every attempt. Reusing an
+        // old request body with a new session ID would make recovery fail.
+        if (init?.body) {
+          const encryptedBody = dependencies.encryptMessage(
+            attestation.sessionKey,
+            init.body as string
+          );
+          requestOptions.body = JSON.stringify({ encrypted: encryptedBody });
+          headers.set("Content-Type", "application/json");
+        }
+
+        return {
+          attestation,
+          response: await dependencies.fetch(requestUrl, requestOptions)
+        };
+      };
+
+      let attestation = requireActiveAttestation(
+        await dependencies.getAttestation(false, options?.apiUrl)
+      );
+      let refreshedToken = false;
+      let renewedAttestation = false;
+      let finalAttempt: Awaited<ReturnType<typeof makeRequest>>;
+
+      while (true) {
+        const attempt = await makeRequest(attestation);
+
+        if (attempt.response.status === 401 && !options?.apiKey && !refreshedToken) {
+          refreshedToken = true;
+          await discardResponse(attempt.response);
+          console.warn("Unauthorized, refreshing access token");
+          await dependencies.refreshToken();
+          authHeader = getAuthHeader();
+
+          // The encrypted refresh call may itself have replaced a stale
+          // attestation. Always rebuild the outer request from current state.
+          attestation = requireActiveAttestation(
+            await dependencies.getAttestation(false, options?.apiUrl)
+          );
+          continue;
+        }
+
+        if (attempt.response.status === 400 && !renewedAttestation) {
+          renewedAttestation = true;
+          await discardResponse(attempt.response);
+          console.warn("Bad Request, renewing attestation and retrying once");
+          attestation = await renewAttestation(attempt.attestation.sessionId);
+          continue;
+        }
+
+        finalAttempt = attempt;
+        break;
       }
-      headers.set("x-session-id", sessionId);
 
-      const requestOptions: RequestInit = { ...init, headers };
-
-      // Encrypt the request body if it exists
-      if (init?.body) {
-        const encryptedBody = encryptMessage(sessionKey, init.body as string);
-        requestOptions.body = JSON.stringify({ encrypted: encryptedBody });
-        headers.set("Content-Type", "application/json");
-      }
-
-      let response = await fetch(requestUrl, requestOptions);
-
-      if (response.status === 401 && !options?.apiKey) {
-        // Only attempt token refresh if we're using JWT auth (not API key)
-        console.warn("Unauthorized, refreshing access token");
-        await api.refreshToken();
-        headers.set("Authorization", getAuthHeader());
-        requestOptions.headers = headers;
-        response = await fetch(requestUrl, requestOptions);
-      }
+      const { response } = finalAttempt;
+      const { sessionKey } = finalAttempt.attestation;
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -100,7 +214,7 @@ export function createCustomFetch(
                       controller.enqueue(`data: [DONE]\n\n`);
                     } else {
                       try {
-                        const decrypted = decryptMessage(sessionKey, data);
+                        const decrypted = dependencies.decryptMessage(sessionKey, data);
 
                         // Always enqueue the decrypted data
                         // Note: We don't add \n\n here because the empty line will be added separately
@@ -137,7 +251,7 @@ export function createCustomFetch(
 
         // Check if the response has an encrypted field
         if (responseData.encrypted) {
-          const decrypted = decryptMessage(sessionKey, responseData.encrypted);
+          const decrypted = dependencies.decryptMessage(sessionKey, responseData.encrypted);
 
           // Try to parse as JSON to check for TTS response format
           try {

--- a/src/lib/test/customFetch.test.ts
+++ b/src/lib/test/customFetch.test.ts
@@ -1,0 +1,349 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { createCustomFetchWithDependencies, type CustomFetchDependencies } from "../ai";
+import type { Attestation } from "../getAttestation";
+
+const staleKey = new Uint8Array(32).fill(1);
+const freshKey = new Uint8Array(32).fill(2);
+const staleAttestation: Attestation = { sessionKey: staleKey, sessionId: "stale-session" };
+const freshAttestation: Attestation = { sessionKey: freshKey, sessionId: "fresh-session" };
+
+interface RecordedRequest {
+  authorization: string | null;
+  encryptedBody: string | undefined;
+  sessionId: string | null;
+}
+
+function recordRequest(init?: RequestInit): RecordedRequest {
+  const headers = new Headers(init?.headers);
+  const body = init?.body ? (JSON.parse(init.body as string) as { encrypted?: string }) : undefined;
+
+  return {
+    authorization: headers.get("Authorization"),
+    encryptedBody: body?.encrypted,
+    sessionId: headers.get("x-session-id")
+  };
+}
+
+function encryptForTest(sessionKey: Uint8Array, plaintext: string): string {
+  return `${sessionKey[0]}:${plaintext}`;
+}
+
+function decryptForTest(sessionKey: Uint8Array, ciphertext: string): string {
+  const expectedPrefix = `${sessionKey[0]}:`;
+  if (!ciphertext.startsWith(expectedPrefix)) {
+    throw new Error(`Ciphertext was not encrypted for key ${sessionKey[0]}`);
+  }
+  return ciphertext.slice(expectedPrefix.length);
+}
+
+function dependencies(overrides: Partial<CustomFetchDependencies>): CustomFetchDependencies {
+  return {
+    decryptMessage: decryptForTest,
+    encryptMessage: encryptForTest,
+    fetch: async () => new Response(null, { status: 500 }),
+    getAttestation: async () => staleAttestation,
+    refreshToken: async () => ({
+      access_token: "refreshed-access-token",
+      refresh_token: "refreshed-refresh-token"
+    }),
+    ...overrides
+  };
+}
+
+describe("createCustomFetch stale-session recovery", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  test("renews once and rebuilds an API-key request with the fresh session", async () => {
+    let currentAttestation = staleAttestation;
+    let forcedAttestations = 0;
+    let tokenRefreshes = 0;
+    const requests: RecordedRequest[] = [];
+
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) {
+            forcedAttestations += 1;
+            currentAttestation = freshAttestation;
+          }
+          return currentAttestation;
+        },
+        refreshToken: async () => {
+          tokenRefreshes += 1;
+          return {
+            access_token: "unused-access-token",
+            refresh_token: "unused-refresh-token"
+          };
+        },
+        fetch: async (_input, init) => {
+          const request = recordRequest(init);
+          requests.push(request);
+
+          if (request.sessionId === staleAttestation.sessionId) {
+            return new Response('{"status":400,"message":"Bad Request"}', { status: 400 });
+          }
+
+          return Response.json({ encrypted: '2:{"ok":true}' });
+        }
+      })
+    );
+
+    const response = await customFetch("https://example.test/v1/responses", {
+      method: "POST",
+      body: '{"prompt":"hello"}'
+    });
+
+    expect(await response.json()).toEqual({ ok: true });
+    expect(forcedAttestations).toBe(1);
+    expect(tokenRefreshes).toBe(0);
+    expect(requests).toEqual([
+      {
+        authorization: "Bearer test-api-key",
+        encryptedBody: '1:{"prompt":"hello"}',
+        sessionId: "stale-session"
+      },
+      {
+        authorization: "Bearer test-api-key",
+        encryptedBody: '2:{"prompt":"hello"}',
+        sessionId: "fresh-session"
+      }
+    ]);
+  });
+
+  test("stops after one attestation retry when 400 persists", async () => {
+    let currentAttestation = staleAttestation;
+    let forcedAttestations = 0;
+    let requests = 0;
+
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) {
+            forcedAttestations += 1;
+            currentAttestation = freshAttestation;
+          }
+          return currentAttestation;
+        },
+        fetch: async () => {
+          requests += 1;
+          return new Response("still bad", { status: 400 });
+        }
+      })
+    );
+
+    await expect(
+      customFetch("https://example.test/v1/responses", {
+        method: "POST",
+        body: '{"prompt":"hello"}'
+      })
+    ).rejects.toThrow("Request failed with status 400: still bad");
+
+    expect(forcedAttestations).toBe(1);
+    expect(requests).toBe(2);
+  });
+
+  test("rebuilds the request after a JWT refresh replaces the attestation", async () => {
+    window.localStorage.setItem("access_token", "expired-access-token");
+    let currentAttestation = staleAttestation;
+    let tokenRefreshes = 0;
+    let forcedAttestations = 0;
+    const requests: RecordedRequest[] = [];
+
+    const customFetch = createCustomFetchWithDependencies(
+      undefined,
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) forcedAttestations += 1;
+          return currentAttestation;
+        },
+        refreshToken: async () => {
+          tokenRefreshes += 1;
+          window.localStorage.setItem("access_token", "fresh-access-token");
+          currentAttestation = freshAttestation;
+          return {
+            access_token: "fresh-access-token",
+            refresh_token: "fresh-refresh-token"
+          };
+        },
+        fetch: async (_input, init) => {
+          requests.push(recordRequest(init));
+          if (requests.length === 1) return new Response("expired JWT", { status: 401 });
+          return Response.json({ encrypted: '2:{"ok":true}' });
+        }
+      })
+    );
+
+    const response = await customFetch("https://example.test/v1/responses", {
+      method: "POST",
+      body: '{"prompt":"hello"}'
+    });
+
+    expect(await response.json()).toEqual({ ok: true });
+    expect(tokenRefreshes).toBe(1);
+    expect(forcedAttestations).toBe(0);
+    expect(requests).toEqual([
+      {
+        authorization: "Bearer expired-access-token",
+        encryptedBody: '1:{"prompt":"hello"}',
+        sessionId: "stale-session"
+      },
+      {
+        authorization: "Bearer fresh-access-token",
+        encryptedBody: '2:{"prompt":"hello"}',
+        sessionId: "fresh-session"
+      }
+    ]);
+  });
+
+  test("keeps a stale retry bound to the identity that initiated the request", async () => {
+    window.localStorage.setItem("access_token", "initiating-account-token");
+    let currentAttestation = staleAttestation;
+    const requests: RecordedRequest[] = [];
+
+    const customFetch = createCustomFetchWithDependencies(
+      undefined,
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) {
+            // Simulate an unrelated account change while re-attestation is in
+            // flight. The pending operation must retain its original token.
+            window.localStorage.setItem("access_token", "different-account-token");
+            currentAttestation = freshAttestation;
+          }
+          return currentAttestation;
+        },
+        fetch: async (_input, init) => {
+          const request = recordRequest(init);
+          requests.push(request);
+          if (request.sessionId === staleAttestation.sessionId) {
+            return new Response("stale", { status: 400 });
+          }
+          return Response.json({ encrypted: '2:{"ok":true}' });
+        }
+      })
+    );
+
+    const response = await customFetch("https://example.test/v1/responses", {
+      method: "POST",
+      body: '{"prompt":"hello"}'
+    });
+
+    expect(await response.json()).toEqual({ ok: true });
+    expect(requests.map(({ authorization }) => authorization)).toEqual([
+      "Bearer initiating-account-token",
+      "Bearer initiating-account-token"
+    ]);
+    expect(window.localStorage.getItem("access_token")).toBe("different-account-token");
+  });
+
+  test("decrypts a retried SSE response with the fresh session key", async () => {
+    let currentAttestation = staleAttestation;
+
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) currentAttestation = freshAttestation;
+          return currentAttestation;
+        },
+        fetch: async (_input, init) => {
+          if (recordRequest(init).sessionId === staleAttestation.sessionId) {
+            return new Response("stale", { status: 400 });
+          }
+
+          return new Response(
+            'event: response.output_text.delta\ndata: 2:{"delta":"hello"}\n\ndata: [DONE]\n\n',
+            { headers: { "content-type": "text/event-stream" } }
+          );
+        }
+      })
+    );
+
+    const response = await customFetch("https://example.test/v1/responses", {
+      method: "POST",
+      body: '{"prompt":"hello"}'
+    });
+
+    const responseText = await response.text();
+    expect(responseText).toContain('data: {"delta":"hello"}');
+    expect(responseText).toContain("data: [DONE]");
+    expect(responseText).not.toContain('data: 2:{"delta":"hello"}');
+  });
+
+  test("shares one attestation renewal across concurrent stale requests", async () => {
+    let currentAttestation = staleAttestation;
+    let forcedAttestations = 0;
+    const requests: RecordedRequest[] = [];
+
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) {
+            forcedAttestations += 1;
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            currentAttestation = freshAttestation;
+          }
+          return currentAttestation;
+        },
+        fetch: async (_input, init) => {
+          const request = recordRequest(init);
+          requests.push(request);
+          if (request.sessionId === staleAttestation.sessionId) {
+            return new Response("stale", { status: 400 });
+          }
+          return Response.json({ encrypted: '2:{"ok":true}' });
+        }
+      })
+    );
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, (_, index) =>
+        customFetch("https://example.test/v1/responses", {
+          method: "POST",
+          body: JSON.stringify({ prompt: `hello-${index}` })
+        }).then((response) => response.json())
+      )
+    );
+
+    expect(results).toEqual(Array.from({ length: 8 }, () => ({ ok: true })));
+    expect(forcedAttestations).toBe(1);
+    expect(requests.filter(({ sessionId }) => sessionId === "stale-session")).toHaveLength(8);
+    expect(requests.filter(({ sessionId }) => sessionId === "fresh-session")).toHaveLength(8);
+    expect(
+      requests
+        .filter(({ sessionId }) => sessionId === "fresh-session")
+        .every(({ encryptedBody }) => encryptedBody?.startsWith("2:") === true)
+    ).toBe(true);
+  });
+
+  test("does not replay non-400 application errors", async () => {
+    let requests = 0;
+    let forcedAttestations = 0;
+
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) forcedAttestations += 1;
+          return staleAttestation;
+        },
+        fetch: async () => {
+          requests += 1;
+          return new Response("invalid request", { status: 422 });
+        }
+      })
+    );
+
+    await expect(customFetch("https://example.test/v1/responses")).rejects.toThrow(
+      "Request failed with status 422: invalid request"
+    );
+    expect(requests).toBe(1);
+    expect(forcedAttestations).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- recover `createCustomFetch` when an encryption session is no longer accepted
- force a fresh attestation and rebuild/re-encrypt the original request exactly once
- single-flight concurrent stale-session recovery and decrypt JSON/SSE with the final session key
- rebuild JWT-refresh retries from current attestation state instead of resending stale ciphertext

## Compatibility

There is no public API change, and successful requests keep their existing behavior. Recovery is bounded to one attestation retry. Because the backend currently returns a generic HTTP 400 rather than a machine-readable stale-session signal, a genuine application 400 can be re-attested and replayed once; this matches the existing typed TypeScript client behavior and avoids changing the backend error contract.

## Validation

- `nix develop -c bun run format:check`
- `VITE_OPEN_SECRET_API_URL=http://127.0.0.1:9999 nix develop -c bun test src/lib/test/customFetch.test.ts --timeout 30000` — 7 passed
- `nix develop -c bun run build`
- local linked Maple + full backend stale-session smoke: JWT and API-key requests observed 400 → fresh attestation/key exchange → re-encrypted retry → decrypted 200/SSE response, with no duplicate visible output

The complete credentialed integration suite will run in GitHub Actions.

Closes #93