### PR TITLE
chore: harden SDK supply-chain controls

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
@@ -19,15 +22,17 @@ jobs:
     name: Check Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust -> target
 
@@ -39,15 +44,17 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust -> target
 
@@ -59,13 +66,15 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust -> target
 
@@ -83,13 +92,15 @@ jobs:
     name: Check Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust -> target
 
@@ -103,13 +114,15 @@ jobs:
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: rust -> target
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,20 +6,28 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
-          bun-version: latest
+          bun-version: 1.3.5
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Build library
+        run: bun run build
 
       - name: Run tests
         env:
@@ -34,3 +42,24 @@ jobs:
           VITE_TEST_DEVELOPER_NAME: ${{ secrets.VITE_TEST_DEVELOPER_NAME }}
           VITE_TEST_DEVELOPER_INVITE_CODE: ${{ secrets.VITE_TEST_DEVELOPER_INVITE_CODE }}
         run: bun test --timeout 30000
+
+  website:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
+        with:
+          bun-version: 1.3.5
+
+      - name: Install website dependencies
+        working-directory: website
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Build website
+        working-directory: website
+        run: bun run build

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# Bun is the only supported package manager for repository dependency updates.
+# The npm lock is retained for compatibility, but npm must not rewrite it by
+# default. min-release-age is defense in depth on npm 11.10 and newer only.
+ignore-scripts=true
+min-release-age=7
+save=false
+save-exact=true

--- a/README.md
+++ b/README.md
@@ -338,13 +338,20 @@ For an alternative approach using custom fetch directly, see the implementation 
 
 ### Library development
 
-This library uses [Bun](https://bun.sh/) for development.
+This library uses Bun 1.3.5 for development. The Nix shell and CI pin the same
+version. New Bun resolutions quarantine releases for seven days; routine
+installs are frozen to the committed lockfile and do not run lifecycle scripts.
+Age gates do not revalidate versions already present in either lock format.
 
-To run the demo app, run the following commands:
+The `bun.lockb` files are authoritative. The retained npm lockfiles are
+compatibility artifacts and must not be used for dependency updates; npm's age
+gate requires npm 11.10 or newer and does not revalidate locked versions.
+
+Enter the development shell and install the locked dependencies:
 
 ```bash
+nix develop
 bun install
-bun run dev
 ```
 
 To build the library, run the following command:
@@ -365,7 +372,9 @@ To test a specific file or test case:
 bun test --test-name-pattern="Developer login and token storage" src/lib/test/integration/developer.test.ts --env-file .env.local
 ```
 
-Currently this build step requires `npx` because of [a Bun incompatibility with `vite-plugin-dts`](https://github.com/OpenSecretCloud/OpenSecret-SDK/issues/16).
+The build invokes the installed Vite CLI with Node because of the historical
+[`vite-plugin-dts` Bun incompatibility](https://github.com/OpenSecretCloud/OpenSecret-SDK/issues/16).
+It never downloads a missing CLI during the build.
 
 To pack the library (for publishing) run the following command:
 
@@ -463,10 +472,13 @@ To customize the appearance:
 The documentation can be deployed to various platforms like GitHub Pages, Netlify, or Vercel. For CloudFlare Pages deployment, as mentioned in our guideline:
 
 1. In CloudFlare Pages, create a new project connected to your GitHub repo
-2. Use these build settings:
-   - Build command: `cd website && bun run build`
+2. Set `BUN_VERSION=1.3.5` to pin the available Bun binary.
+3. Set `SKIP_DEPENDENCY_INSTALL=true` to disable automatic package-manager
+   selection.
+4. Use these build settings:
+   - Build command: `cd website && bun install --frozen-lockfile --ignore-scripts && bun run build`
    - Build output directory: `website/build`
-3. Set up a custom domain through CloudFlare's dashboard
+5. Set up a custom domain through CloudFlare's dashboard
 
 #### Troubleshooting
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,10 @@
+[install]
+exact = true
+frozenLockfile = true
+ignoreScripts = true
+auto = "disable"
+minimumReleaseAge = 604800
+
 [test]
 preload = [
   "./src/lib/test/preload.ts",

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "bun-nixpkgs": {
+      "locked": {
+        "lastModified": 1767767207,
+        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +52,7 @@
     },
     "root": {
       "inputs": {
+        "bun-nixpkgs": "bun-nixpkgs",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,9 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Keep Bun aligned with package.json and CI without advancing the SDK's
+    # older Node/Rust/system package set. Update all three pins together.
+    bun-nixpkgs.url = "github:NixOS/nixpkgs/5912c1772a44e31bf1c63c0390b90501e5026886";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
@@ -10,11 +13,13 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+  outputs = { self, nixpkgs, bun-nixpkgs, flake-utils, rust-overlay }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         overlays = [ rust-overlay.overlays.default ];
         pkgs = import nixpkgs { inherit system overlays; };
+        bunPkgs = import bun-nixpkgs { inherit system; };
+        sdkBun = assert bunPkgs.bun.version == "1.3.5"; bunPkgs.bun;
         
         # Try to use rust-toolchain.toml if it exists, otherwise use stable
         rust = if builtins.pathExists ./rust-toolchain.toml
@@ -23,7 +28,7 @@
         
         commonInputs = with pkgs; [
           # TypeScript/JavaScript tooling
-          bun
+          sdkBun
           nodejs_20
           nodePackages.typescript
           nodePackages.typescript-language-server

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@eslint/js": "^9.13.0",
         "@noble/curves": "^1.6.0",
         "@noble/hashes": "^1.5.0",
-        "@types/bun": "latest",
+        "@types/bun": "1.1.13",
         "@types/react": "^19.0.0",
         "@vitejs/plugin-react": "^4.7.0",
         "eslint": "^9.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@opensecret/react",
   "version": "3.3.1",
+  "packageManager": "bun@1.3.5",
   "license": "MIT",
   "type": "module",
   "files": [
@@ -17,7 +18,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && npx vite build",
+    "build": "tsc -p tsconfig.build.json && node ./node_modules/vite/bin/vite.js build",
     "pack": "bun run build && bun pm pack",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
@@ -44,7 +45,7 @@
     "@eslint/js": "^9.13.0",
     "@noble/curves": "^1.6.0",
     "@noble/hashes": "^1.5.0",
-    "@types/bun": "latest",
+    "@types/bun": "1.1.13",
     "@types/react": "^19.0.0",
     "@vitejs/plugin-react": "^4.7.0",
     "eslint": "^9.13.0",
@@ -56,5 +57,6 @@
     "typescript-eslint": "^8.11.0",
     "vite": "^6.4.2",
     "vite-plugin-dts": "^4.3.0"
-  }
+  },
+  "trustedDependencies": []
 }

--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,0 +1,7 @@
+# Bun is the only supported package manager for repository dependency updates.
+# The npm lock is retained for compatibility, but npm must not rewrite it by
+# default. min-release-age is defense in depth on npm 11.10 and newer only.
+ignore-scripts=true
+min-release-age=7
+save=false
+save-exact=true

--- a/website/README.md
+++ b/website/README.md
@@ -2,16 +2,19 @@
 
 This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 
+Use Bun 1.3.5 for this repository. The Bun lockfile is authoritative; do not
+update website dependencies with npm or Yarn.
+
 ### Installation
 
 ```
-$ yarn
+$ bun install
 ```
 
 ### Local Development
 
 ```
-$ yarn start
+$ bun run start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -19,7 +22,7 @@ This command starts a local development server and opens up a browser window. Mo
 ### Build
 
 ```
-$ yarn build
+$ bun run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -29,13 +32,13 @@ This command generates static content into the `build` directory and can be serv
 Using SSH:
 
 ```
-$ USE_SSH=true yarn deploy
+$ USE_SSH=true bun run deploy
 ```
 
 Not using SSH:
 
 ```
-$ GIT_USER=<Your GitHub username> yarn deploy
+$ GIT_USER=<Your GitHub username> bun run deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.

--- a/website/bunfig.toml
+++ b/website/bunfig.toml
@@ -1,0 +1,6 @@
+[install]
+exact = true
+frozenLockfile = true
+ignoreScripts = true
+auto = "disable"
+minimumReleaseAge = 604800

--- a/website/package.json
+++ b/website/package.json
@@ -2,6 +2,7 @@
   "name": "website",
   "version": "0.0.0",
   "private": true,
+  "packageManager": "bun@1.3.5",
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
@@ -47,10 +48,7 @@
   "engines": {
     "node": ">=18.0"
   },
-  "trustedDependencies": [
-    "core-js",
-    "core-js-pure"
-  ],
+  "trustedDependencies": [],
   "overrides": {
     "serialize-javascript": "^7.0.5",
     "uuid": "^14.0.0"


### PR DESCRIPTION
## Summary

- pin Bun 1.3.5 across Nix, both package manifests, CI, and deployment guidance
- enforce exact, frozen, scriptless installs with a seven-day release quarantine in both dependency roots
- disable Bun auto-install, remove trusted dependency exceptions, and replace the network-capable `npx vite` fallback
- pin GitHub Actions to immutable SHAs, minimize token permissions, and add a separate website install/build job
- make Bun locks authoritative while retaining non-writing npm compatibility locks
- make Cloudflare Pages installation fail closed with `SKIP_DEPENDENCY_INSTALL=true` and an explicit frozen, scriptless Bun install

## Keyv incident check

Both locked Bun trees resolve `keyv@4.5.4`. I compared both installed Bun trees and both npm locks against all 443 package/version pairs in the live [Wiz Keyv IOC list](https://github.com/wiz-sec-public/wiz-research-iocs/blob/main/reports/keyv-packages.csv) on August 4, 2026 and found no exact matches. The current list identifies `keyv@6.0.0`, not 4.5.4.

The age gate protects new dependency resolution; it does not retroactively validate versions already committed to a lockfile. The README now states that boundary explicitly.

## Validation

- `nix flake check --no-build --print-build-logs`
- `nix develop -c bun --version` -> `1.3.5`
- frozen, script-disabled root and website installs
- root library build and website production build
- targeted secretless tests: 20 pass, 0 fail
- `actionlint .github/workflows/*.yml`
- JSON/YAML parsing and `git diff --check`
- both binary Bun lockfile hashes remained unchanged

The full integration suite additionally requires repository `VITE_*` secrets; locally it reached 20 passing tests and then reported eight missing-environment errors.

## Follow-ups

- Apply and verify the documented variables and build command in the live Cloudflare Pages project.
- Handle the existing dependency advisory backlog as a separate reviewed refresh.
- Migrate the dual binary/compatibility locks to authoritative reviewable Bun text locks after deployment configuration is confirmed.
- Pin the Rust toolchain and add a CI Cargo lock in a separate Rust reproducibility change.
