### PR TITLE
fix: enforce PCR0 trust before key exchange

### DIFF
--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -13,7 +13,7 @@ function App() {
   return (
     <OpenSecretDeveloper 
       apiUrl="https://developer.opensecret.cloud"
-      pcrConfig={{}} // Optional PCR configuration for attestation validation
+      pcrConfig={{}} // Optional PCR0 trust policy enforced before session establishment
     >
       <YourApp />
     </OpenSecretDeveloper>
@@ -351,8 +351,8 @@ function PlatformManagement() {
 
 ### Attestation Verification
 
-- `pcrConfig`: An object containing additional PCR0 hashes to validate against.
-- `getAttestation`: Gets attestation from the enclave.
+- `pcrConfig`: The PCR0 trust policy enforced before non-loopback session establishment. Custom hashes are additive to the SDK's built-in roots.
+- `getAttestation`: Gets an attested session after enforcing the effective PCR0 trust policy.
 - `authenticate`: Authenticates an attestation document.
 - `parseAttestationForView`: Parses an attestation document for viewing.
 - `awsRootCertDer`: AWS root certificate in DER format.

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,10 +1,15 @@
 import { decryptMessage, encryptMessage } from "./encryption";
 import { getAttestation, type Attestation } from "./getAttestation";
 import * as api from "./api";
+import { serializePcrConfig, snapshotPcrConfig, type PcrConfig } from "./pcr";
 
 export interface CustomFetchOptions {
-  apiKey?: string; // Optional API key to use instead of JWT token
-  apiUrl?: string; // Optional API URL for attestation (required when not using OpenSecretProvider)
+  /** Optional API key to use instead of a JWT token. */
+  apiKey?: string;
+  /** API URL used for attestation; required outside OpenSecretProvider. */
+  apiUrl?: string;
+  /** PCR0 trust policy enforced before non-loopback session key exchange. */
+  pcrConfig?: PcrConfig;
 }
 
 interface ActiveAttestation {
@@ -60,25 +65,40 @@ export function createCustomFetchWithDependencies(
   options: CustomFetchOptions | undefined,
   dependencies: CustomFetchDependencies
 ): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
-  let attestationRefresh: Promise<ActiveAttestation> | undefined;
+  const attestationRefreshes = new Map<string, Promise<ActiveAttestation>>();
 
-  const renewAttestation = async (failedSessionId: string): Promise<ActiveAttestation> => {
+  const resolveAttestationIdentity = () => {
+    const apiUrl = options?.apiUrl || api.getApiUrl() || undefined;
+    const pcrConfig = snapshotPcrConfig(options?.pcrConfig || api.getApiPcrConfig());
+    return {
+      apiUrl,
+      pcrConfig,
+      scope: `${apiUrl || ""}\n${serializePcrConfig(pcrConfig)}`
+    };
+  };
+
+  const renewAttestation = async (
+    failedSessionId: string,
+    identity: ReturnType<typeof resolveAttestationIdentity>
+  ): Promise<ActiveAttestation> => {
     // A concurrent request or token refresh may already have replaced the
     // failed session. Reuse it instead of starting another handshake.
     const currentAttestation = requireActiveAttestation(
-      await dependencies.getAttestation(false, options?.apiUrl)
+      await dependencies.getAttestation(false, identity.apiUrl, identity.pcrConfig)
     );
     if (currentAttestation.sessionId !== failedSessionId) {
       return currentAttestation;
     }
 
+    let attestationRefresh = attestationRefreshes.get(identity.scope);
     if (!attestationRefresh) {
       attestationRefresh = dependencies
-        .getAttestation(true, options?.apiUrl)
+        .getAttestation(true, identity.apiUrl, identity.pcrConfig)
         .then(requireActiveAttestation)
         .finally(() => {
-          attestationRefresh = undefined;
+          attestationRefreshes.delete(identity.scope);
         });
+      attestationRefreshes.set(identity.scope, attestationRefresh);
     }
 
     return attestationRefresh;
@@ -100,6 +120,9 @@ export function createCustomFetchWithDependencies(
     };
 
     try {
+      // Capture endpoint and trust policy together so retries cannot cross a
+      // provider reconfiguration that happens while this request is in flight.
+      const attestationIdentity = resolveAttestationIdentity();
       // Keep this operation bound to the identity that initiated it. An
       // unrelated account change during attestation must not send the
       // already-prepared plaintext request under a different token.
@@ -130,7 +153,11 @@ export function createCustomFetchWithDependencies(
       };
 
       let attestation = requireActiveAttestation(
-        await dependencies.getAttestation(false, options?.apiUrl)
+        await dependencies.getAttestation(
+          false,
+          attestationIdentity.apiUrl,
+          attestationIdentity.pcrConfig
+        )
       );
       let refreshedToken = false;
       let renewedAttestation = false;
@@ -149,7 +176,11 @@ export function createCustomFetchWithDependencies(
           // The encrypted refresh call may itself have replaced a stale
           // attestation. Always rebuild the outer request from current state.
           attestation = requireActiveAttestation(
-            await dependencies.getAttestation(false, options?.apiUrl)
+            await dependencies.getAttestation(
+              false,
+              attestationIdentity.apiUrl,
+              attestationIdentity.pcrConfig
+            )
           );
           continue;
         }
@@ -158,7 +189,7 @@ export function createCustomFetchWithDependencies(
           renewedAttestation = true;
           await discardResponse(attempt.response);
           console.warn("Bad Request, renewing attestation and retrying once");
-          attestation = await renewAttestation(attempt.attestation.sessionId);
+          attestation = await renewAttestation(attempt.attestation.sessionId, attestationIdentity);
           continue;
         }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,15 +1,22 @@
 import { encode } from "@stablelib/base64";
 import { authenticatedApiCall, encryptedApiCall, openAiAuthenticatedApiCall } from "./encryptedApi";
 import type { Model } from "openai/resources/models.js";
+import { snapshotPcrConfig, type PcrConfig } from "./pcr";
 
 let apiUrl = "";
+let apiPcrConfig: PcrConfig = snapshotPcrConfig();
 
-export function setApiUrl(url: string) {
+export function setApiUrl(url: string, pcrConfig?: PcrConfig) {
   apiUrl = url;
+  apiPcrConfig = snapshotPcrConfig(pcrConfig);
 }
 
 export function getApiUrl(): string {
   return apiUrl;
+}
+
+export function getApiPcrConfig(): PcrConfig {
+  return snapshotPcrConfig(apiPcrConfig);
 }
 
 export type LoginResponse = {

--- a/src/lib/developer.tsx
+++ b/src/lib/developer.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useState, useEffect } from "react";
 import * as platformApi from "./platformApi";
 import { setPlatformApiUrl } from "./platformApi";
-import { getAttestation } from "./getAttestation";
+import { clearAttestationSessions, getAttestation } from "./getAttestation";
 import { authenticate } from "./attestation";
 import {
   parseAttestationForView,
@@ -11,6 +11,8 @@ import {
 } from "./attestationForView";
 import type { AttestationDocument } from "./attestation";
 import { PcrConfig } from "./pcr";
+
+const DEFAULT_PCR_CONFIG: PcrConfig = {};
 import type {
   Organization,
   Project,
@@ -177,12 +179,12 @@ export type OpenSecretDeveloperContextType = {
   refetchDeveloper: () => Promise<void>;
 
   /**
-   * Additional PCR0 hashes to validate against
+   * PCR0 trust policy enforced before every non-loopback session key exchange
    */
   pcrConfig: PcrConfig;
 
   /**
-   * Gets attestation from the enclave
+   * Gets an attested session after enforcing the effective PCR0 trust policy
    */
   getAttestation: typeof getAttestation;
 
@@ -509,6 +511,7 @@ export const OpenSecretDeveloperContext = createContext<OpenSecretDeveloperConte
  * @param props - Configuration properties for the OpenSecret developer provider
  * @param props.children - React child components to be wrapped by the provider
  * @param props.apiUrl - URL of OpenSecret developer API
+ * @param props.pcrConfig - Optional PCR0 trust policy enforced before session establishment
  *
  * @example
  * ```tsx
@@ -522,7 +525,7 @@ export const OpenSecretDeveloperContext = createContext<OpenSecretDeveloperConte
 export function OpenSecretDeveloper({
   children,
   apiUrl,
-  pcrConfig = {}
+  pcrConfig = DEFAULT_PCR_CONFIG
 }: {
   children: React.ReactNode;
   apiUrl: string;
@@ -539,7 +542,7 @@ export function OpenSecretDeveloper({
         "OpenSecretDeveloper requires a non-empty apiUrl. Please provide a valid API endpoint URL."
       );
     }
-    setPlatformApiUrl(apiUrl);
+    setPlatformApiUrl(apiUrl, pcrConfig);
 
     // Configure the apiConfig service with the platform URL
     // Using dynamic import to avoid circular dependencies
@@ -554,7 +557,7 @@ export function OpenSecretDeveloper({
           "Failed to initialize OpenSecretDeveloper - could not load required dependencies"
         );
       });
-  }, [apiUrl]);
+  }, [apiUrl, pcrConfig]);
 
   async function fetchDeveloper() {
     const access_token = window.localStorage.getItem("access_token");
@@ -652,6 +655,7 @@ export function OpenSecretDeveloper({
       }
       localStorage.removeItem("access_token");
       localStorage.removeItem("refresh_token");
+      clearAttestationSessions();
       setAuth({
         loading: false,
         developer: undefined
@@ -664,7 +668,8 @@ export function OpenSecretDeveloper({
     confirmPasswordReset: platformApi.confirmPlatformPasswordReset,
     changePassword: platformApi.changePlatformPassword,
     pcrConfig,
-    getAttestation,
+    getAttestation: (forceRefresh, explicitApiUrl, explicitPcrConfig) =>
+      getAttestation(forceRefresh, explicitApiUrl || apiUrl, explicitPcrConfig || pcrConfig),
     authenticate,
     parseAttestationForView,
     awsRootCertDer: AWS_ROOT_CERT_DER,

--- a/src/lib/encryptedApi.ts
+++ b/src/lib/encryptedApi.ts
@@ -1,7 +1,7 @@
 import { encryptMessage, decryptMessage } from "./encryption";
 import { getAttestation } from "./getAttestation";
-import { refreshToken } from "./api";
-import { platformRefreshToken } from "./platformApi";
+import { getApiPcrConfig, getApiUrl, refreshToken } from "./api";
+import { getPlatformApiUrl, getPlatformPcrConfig, platformRefreshToken } from "./platformApi";
 import { apiConfig } from "./apiConfig";
 
 interface EncryptedResponse {
@@ -113,13 +113,14 @@ async function internalEncryptedApiCall<T, U>(
 ): Promise<ApiResponse<U>> {
   // Use apiConfig to determine the context and get the appropriate API URL
   const endpoint = apiConfig.resolveEndpoint(url);
-  const explicitApiUrl = endpoint.context === "platform" ? apiConfig.platformApiUrl : undefined;
+  const explicitApiUrl = endpoint.context === "platform" ? getPlatformApiUrl() : getApiUrl();
+  const pcrConfig = endpoint.context === "platform" ? getPlatformPcrConfig() : getApiPcrConfig();
 
-  let { sessionKey, sessionId } = await getAttestation(false, explicitApiUrl);
+  let { sessionKey, sessionId } = await getAttestation(false, explicitApiUrl, pcrConfig);
 
   const makeRequest = async (token: string | undefined, forceNewAttestation: boolean = false) => {
     if (forceNewAttestation || !sessionKey || !sessionId) {
-      const newAttestation = await getAttestation(true, explicitApiUrl);
+      const newAttestation = await getAttestation(true, explicitApiUrl, pcrConfig);
       sessionKey = newAttestation.sessionKey;
       sessionId = newAttestation.sessionId;
     }

--- a/src/lib/getAttestation.ts
+++ b/src/lib/getAttestation.ts
@@ -1,19 +1,59 @@
-import { verifyAttestation } from "./attestation";
-import { keyExchange } from "./api";
+import { verifyAttestation, isLocalDevelopmentApiUrl } from "./attestation";
+import type { AttestationDocument } from "./attestation";
+import { getApiUrl, keyExchange } from "./api";
 import nacl from "tweetnacl";
 import { ChaCha20Poly1305 } from "@stablelib/chacha20poly1305";
 import { encode, decode } from "@stablelib/base64";
+import {
+  requireTrustedPcr0,
+  serializePcrConfig,
+  snapshotPcrConfig,
+  validatePcr0Hash,
+  type PcrConfig
+} from "./pcr";
 
 export interface Attestation {
   sessionKey: Uint8Array | null;
   sessionId: string | null;
 }
 
-function generateNaclKeyPair(): { publicKey: Uint8Array; secretKey: Uint8Array } {
+type NaclKeyPair = { publicKey: Uint8Array; secretKey: Uint8Array };
+
+type CachedAttestationSession = {
+  version: 1;
+  apiUrl: string;
+  policyFingerprint: string;
+  sessionKey: string;
+  sessionId: string;
+  verifiedPcr0: string | "local-development";
+};
+
+const SESSION_CACHE_PREFIX = "opensecret:attested-session:v1:";
+const LEGACY_SESSION_KEYS = ["sessionKey", "sessionId"];
+const SESSION_KEY_LENGTH = 32;
+const SESSION_ID_MAX_LENGTH = 512;
+const SESSION_CACHE_MAX_LENGTH = 4096;
+const PCR0_PATTERN = /^[0-9a-f]{96}$/;
+const SESSION_ID_PATTERN = /^[\x21-\x7e]+$/;
+
+/** @internal Exported for deterministic handshake tests, not from the package entry point. */
+export interface GetAttestationDependencies {
+  verifyAttestation: typeof verifyAttestation;
+  validatePcr0Hash: typeof validatePcr0Hash;
+  keyExchange: typeof keyExchange;
+  generateNaclKeyPair: () => NaclKeyPair;
+  decryptSessionKey: (
+    encryptedSessionKey: string,
+    clientSecretKey: Uint8Array,
+    serverPublicKey: Uint8Array
+  ) => Uint8Array | null;
+  randomUUID: () => string;
+}
+
+function generateNaclKeyPair(): NaclKeyPair {
   const testNaclPublicKey = import.meta.env.VITE_TEST_NACL_PUBLIC_KEY;
   const testNaclSecretKey = import.meta.env.VITE_TEST_NACL_SECRET_KEY;
 
-  // If test keys are provided, use them
   if (testNaclPublicKey && testNaclSecretKey) {
     return {
       publicKey: decode(testNaclPublicKey),
@@ -21,71 +61,298 @@ function generateNaclKeyPair(): { publicKey: Uint8Array; secretKey: Uint8Array }
     };
   }
 
-  // Otherwise, generate a new key pair
   return nacl.box.keyPair();
+}
+
+function decryptSessionKey(
+  encryptedSessionKey: string,
+  clientSecretKey: Uint8Array,
+  serverPublicKey: Uint8Array
+): Uint8Array | null {
+  const sharedSecret = nacl.scalarMult(clientSecretKey, serverPublicKey);
+  const encryptedData = decode(encryptedSessionKey);
+  const nonceLength = 12;
+  const decryptionNonce = encryptedData.slice(0, nonceLength);
+  const ciphertext = encryptedData.slice(nonceLength);
+  return new ChaCha20Poly1305(sharedSecret).open(decryptionNonce, ciphertext);
+}
+
+const defaultDependencies: GetAttestationDependencies = {
+  verifyAttestation,
+  validatePcr0Hash,
+  keyExchange,
+  generateNaclKeyPair,
+  decryptSessionKey,
+  randomUUID: () => window.crypto.randomUUID()
+};
+
+function canonicalizeApiUrl(apiUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(apiUrl);
+  } catch {
+    throw new Error("Attestation requires a valid API URL.");
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error("Attestation API URL must use HTTP or HTTPS.");
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error("Attestation API URL must not contain credentials, a query, or a fragment.");
+  }
+
+  const path = url.pathname === "/" ? "" : url.pathname.replace(/\/+$/, "");
+  return `${url.origin}${path}`;
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function getAttestationScope(apiUrl: string, pcrConfig?: PcrConfig) {
+  const canonicalApiUrl = canonicalizeApiUrl(apiUrl);
+  const policyFingerprint = await sha256Hex(serializePcrConfig(pcrConfig));
+  const scopeFingerprint = await sha256Hex(`${canonicalApiUrl}\n${policyFingerprint}`);
+  return {
+    apiUrl: canonicalApiUrl,
+    policyFingerprint,
+    cacheKey: `${SESSION_CACHE_PREFIX}${scopeFingerprint}`
+  };
+}
+
+function getSessionStorage(): Storage | undefined {
+  try {
+    return globalThis.sessionStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function removeStorageItem(key: string): void {
+  try {
+    getSessionStorage()?.removeItem(key);
+  } catch {
+    // Storage can be unavailable in sandboxed browser contexts. A fresh,
+    // verified in-memory session is still safe to use for the current request.
+  }
+}
+
+function removeLegacySession(): void {
+  for (const key of LEGACY_SESSION_KEYS) removeStorageItem(key);
+}
+
+function readCachedSession(
+  cacheKey: string,
+  apiUrl: string,
+  policyFingerprint: string,
+  localDevelopment: boolean
+): Attestation | undefined {
+  let raw: string | null;
+  try {
+    raw = getSessionStorage()?.getItem(cacheKey) || null;
+  } catch {
+    return undefined;
+  }
+  if (!raw) return undefined;
+
+  try {
+    if (raw.length > SESSION_CACHE_MAX_LENGTH) {
+      throw new Error("Cached attestation session is too large.");
+    }
+    const cached = JSON.parse(raw) as Partial<CachedAttestationSession>;
+    const validPcrEvidence = localDevelopment
+      ? cached.verifiedPcr0 === "local-development"
+      : typeof cached.verifiedPcr0 === "string" && PCR0_PATTERN.test(cached.verifiedPcr0);
+    if (
+      cached.version !== 1 ||
+      cached.apiUrl !== apiUrl ||
+      cached.policyFingerprint !== policyFingerprint ||
+      typeof cached.sessionId !== "string" ||
+      cached.sessionId.length === 0 ||
+      cached.sessionId.length > SESSION_ID_MAX_LENGTH ||
+      !SESSION_ID_PATTERN.test(cached.sessionId) ||
+      typeof cached.sessionKey !== "string" ||
+      !validPcrEvidence
+    ) {
+      throw new Error("Invalid cached attestation session.");
+    }
+
+    const sessionKey = decode(cached.sessionKey);
+    if (sessionKey.length !== SESSION_KEY_LENGTH) {
+      throw new Error("Invalid cached attestation session key.");
+    }
+    return { sessionKey, sessionId: cached.sessionId };
+  } catch {
+    removeStorageItem(cacheKey);
+    return undefined;
+  }
+}
+
+function writeCachedSession(cacheKey: string, cached: CachedAttestationSession): void {
+  try {
+    getSessionStorage()?.setItem(cacheKey, JSON.stringify(cached));
+  } catch {
+    // A storage failure must not turn a verified handshake into an unverified
+    // one. Continue with the verified in-memory session and simply skip reuse.
+  }
+}
+
+/** @internal Exported for cache migration and integration tests. */
+export async function getAttestationSessionStorageKey(
+  apiUrl: string,
+  pcrConfig?: PcrConfig
+): Promise<string> {
+  return (await getAttestationScope(apiUrl, pcrConfig)).cacheKey;
+}
+
+/** @internal Test helper; not exported from the package entry point. */
+export async function cacheAttestationSessionForTesting(
+  apiUrl: string,
+  pcrConfig: PcrConfig | undefined,
+  attestation: { sessionKey: Uint8Array; sessionId: string },
+  verifiedPcr0: string
+): Promise<void> {
+  const scope = await getAttestationScope(apiUrl, pcrConfig);
+  writeCachedSession(scope.cacheKey, {
+    version: 1,
+    apiUrl: scope.apiUrl,
+    policyFingerprint: scope.policyFingerprint,
+    sessionKey: encode(attestation.sessionKey),
+    sessionId: attestation.sessionId,
+    verifiedPcr0
+  });
+}
+
+/** Clears both vulnerable legacy entries and all policy-scoped SDK sessions. */
+export function clearAttestationSessions(): void {
+  removeLegacySession();
+  const storage = getSessionStorage();
+  if (!storage) return;
+
+  const keys: string[] = [];
+  try {
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (key && (key.startsWith(SESSION_CACHE_PREFIX) || LEGACY_SESSION_KEYS.includes(key))) {
+        keys.push(key);
+      }
+    }
+  } catch {
+    return;
+  }
+  for (const key of keys) removeStorageItem(key);
 }
 
 export async function getAttestation(
   forceRefresh?: boolean,
-  explicitApiUrl?: string
+  explicitApiUrl?: string,
+  pcrConfig?: PcrConfig
 ): Promise<Attestation> {
-  // Check if we already have a sessionKey and sessionId in sessionstorage
-  const sessionKey = sessionStorage.getItem("sessionKey");
-  const sessionId = sessionStorage.getItem("sessionId");
+  return getAttestationWithDependencies(
+    forceRefresh,
+    explicitApiUrl,
+    pcrConfig,
+    defaultDependencies
+  );
+}
+
+/** @internal Exported for deterministic handshake tests, not from the package entry point. */
+export async function getAttestationWithDependencies(
+  forceRefresh: boolean | undefined,
+  explicitApiUrl: string | undefined,
+  pcrConfig: PcrConfig | undefined,
+  dependencies: GetAttestationDependencies
+): Promise<Attestation> {
+  removeLegacySession();
+
+  const configuredApiUrl = explicitApiUrl || getApiUrl();
+  if (!configuredApiUrl) {
+    throw new Error("Attestation requires a configured API URL.");
+  }
+
+  const policy = snapshotPcrConfig(pcrConfig);
+  const scope = await getAttestationScope(configuredApiUrl, policy);
+  const localDevelopment = isLocalDevelopmentApiUrl(scope.apiUrl);
 
   console.groupCollapsed("Attestation");
-
   try {
-    // Attestation already set up
-    if (sessionKey && sessionId && !forceRefresh) {
-      const key = decode(sessionKey);
-      console.log("Using existing attestation from session storage.");
-      return { sessionKey: key, sessionId };
-    }
-
-    // Need to get a new attestation
-    // (Will use test nonce if provided)
-    const attestationNonce = window.crypto.randomUUID();
-
-    console.log("Generated attestation nonce:", attestationNonce);
-    const document = await verifyAttestation(attestationNonce, explicitApiUrl);
-
-    if (document && document.public_key) {
-      console.log("Attestation document verification succeeded");
-      const clientKeyPair = generateNaclKeyPair();
-      console.log("Generated client key pair");
-      const serverPublicKey = new Uint8Array(document.public_key);
-
-      const { encrypted_session_key, session_id } = await keyExchange(
-        encode(clientKeyPair.publicKey),
-        attestationNonce,
-        explicitApiUrl
-      );
-      console.log("Key exchange completed.");
-
-      const sharedSecret = nacl.scalarMult(clientKeyPair.secretKey, serverPublicKey);
-
-      const encryptedData = decode(encrypted_session_key);
-
-      const nonceLength = 12;
-      const decryptionNonce = encryptedData.slice(0, nonceLength);
-      const ciphertext = encryptedData.slice(nonceLength);
-
-      const chacha = new ChaCha20Poly1305(sharedSecret);
-      const decryptedSessionKey = chacha.open(decryptionNonce, ciphertext);
-
-      if (decryptedSessionKey) {
-        console.log("Session key decrypted successfully");
-        window.sessionStorage.setItem("sessionKey", encode(decryptedSessionKey));
-        window.sessionStorage.setItem("sessionId", session_id);
-        return { sessionKey: decryptedSessionKey, sessionId: session_id };
-      } else {
-        throw new Error("Failed to decrypt session key");
-      }
+    if (forceRefresh) {
+      removeStorageItem(scope.cacheKey);
     } else {
-      throw new Error("Invalid attestation document");
+      const cached = readCachedSession(
+        scope.cacheKey,
+        scope.apiUrl,
+        scope.policyFingerprint,
+        localDevelopment
+      );
+      if (cached) {
+        console.log("Using existing PCR-verified attestation from session storage.");
+        return cached;
+      }
     }
+
+    const attestationNonce = dependencies.randomUUID();
+    console.log("Generated attestation nonce:", attestationNonce);
+    const document: AttestationDocument = await dependencies.verifyAttestation(
+      attestationNonce,
+      scope.apiUrl
+    );
+
+    if (!document.public_key) {
+      throw new Error("Invalid attestation document: missing enclave public key.");
+    }
+
+    let verifiedPcr0: string | "local-development";
+    if (localDevelopment) {
+      verifiedPcr0 = "local-development";
+      console.warn("LOCAL DEVELOPMENT: PCR0 verification is bypassed for exact HTTP loopback.");
+    } else {
+      const trustedPcr = await requireTrustedPcr0(
+        document.pcrs,
+        policy,
+        dependencies.validatePcr0Hash
+      );
+      verifiedPcr0 = trustedPcr.hash;
+      console.log("Attestation PCR0 trust verification succeeded.");
+    }
+
+    const clientKeyPair = dependencies.generateNaclKeyPair();
+    const { encrypted_session_key, session_id } = await dependencies.keyExchange(
+      encode(clientKeyPair.publicKey),
+      attestationNonce,
+      scope.apiUrl
+    );
+
+    if (
+      typeof session_id !== "string" ||
+      session_id.length === 0 ||
+      session_id.length > SESSION_ID_MAX_LENGTH ||
+      !SESSION_ID_PATTERN.test(session_id)
+    ) {
+      throw new Error("Key exchange returned an invalid session ID.");
+    }
+
+    const decryptedSessionKey = dependencies.decryptSessionKey(
+      encrypted_session_key,
+      clientKeyPair.secretKey,
+      new Uint8Array(document.public_key)
+    );
+    if (!decryptedSessionKey || decryptedSessionKey.length !== SESSION_KEY_LENGTH) {
+      throw new Error("Failed to decrypt a valid session key.");
+    }
+
+    writeCachedSession(scope.cacheKey, {
+      version: 1,
+      apiUrl: scope.apiUrl,
+      policyFingerprint: scope.policyFingerprint,
+      sessionKey: encode(decryptedSessionKey),
+      sessionId: session_id,
+      verifiedPcr0
+    });
+    return { sessionKey: decryptedSessionKey, sessionId: session_id };
   } catch (error) {
+    removeStorageItem(scope.cacheKey);
     console.error("Error verifying attestation:", error);
     throw error;
   } finally {

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useState, useEffect } from "react";
 import * as api from "./api";
 import { createCustomFetch } from "./ai";
-import { getAttestation } from "./getAttestation";
+import { clearAttestationSessions, getAttestation } from "./getAttestation";
 import type { Model } from "openai/resources/models.js";
 import { authenticate } from "./attestation";
 import {
@@ -13,6 +13,8 @@ import {
 import type { AttestationDocument } from "./attestation";
 import type { LoginResponse, ThirdPartyTokenResponse, DocumentResponse } from "./api";
 import { PcrConfig } from "./pcr";
+
+const DEFAULT_PCR_CONFIG: PcrConfig = {};
 
 export type OpenSecretAuthState = {
   loading: boolean;
@@ -350,12 +352,12 @@ export type OpenSecretContextType = {
   apiUrl: string;
 
   /**
-   * Additional PCR0 hashes to validate against
+   * PCR0 trust policy enforced before every non-loopback session key exchange
    */
   pcrConfig: PcrConfig;
 
   /**
-   * Gets attestation from the enclave
+   * Gets an attested session after enforcing the effective PCR0 trust policy
    */
   getAttestation: typeof getAttestation;
 
@@ -998,7 +1000,7 @@ export const OpenSecretContext = createContext<OpenSecretContextType>({
  * @param props.children - React child components to be wrapped by the provider
  * @param props.apiUrl - URL of OpenSecret enclave backend
  * @param props.clientId - UUID identifying which project/tenant this instance belongs to
- * @param props.pcrConfig - Optional PCR configuration for attestation validation
+ * @param props.pcrConfig - Optional PCR0 trust policy enforced before session establishment
  *
  * @remarks
  * This provider manages:
@@ -1021,7 +1023,7 @@ export function OpenSecretProvider({
   children,
   apiUrl,
   clientId,
-  pcrConfig = {}
+  pcrConfig = DEFAULT_PCR_CONFIG
 }: {
   children: React.ReactNode;
   apiUrl: string;
@@ -1063,7 +1065,7 @@ export function OpenSecretProvider({
         "OpenSecretProvider requires a non-empty clientId. Please provide a valid project UUID."
       );
     }
-    api.setApiUrl(apiUrl);
+    api.setApiUrl(apiUrl, pcrConfig);
 
     // Configure the apiConfig service with the app URL
     // Using dynamic import to avoid circular dependencies
@@ -1071,17 +1073,17 @@ export function OpenSecretProvider({
       const platformUrl = apiConfig.platformApiUrl || "";
       apiConfig.configure(apiUrl, platformUrl);
     });
-  }, [apiUrl, clientId]);
+  }, [apiUrl, clientId, pcrConfig]);
 
   // Create aiCustomFetch when API is configured (supports JWT or API key internally)
   useEffect(() => {
     if (apiUrl) {
       // Pass API key if available, otherwise falls back to JWT
-      setAiCustomFetch(() => createCustomFetch(apiKey ? { apiKey } : undefined));
+      setAiCustomFetch(() => createCustomFetch({ apiKey, apiUrl, pcrConfig }));
     } else {
       setAiCustomFetch(undefined);
     }
-  }, [apiUrl, apiKey]);
+  }, [apiUrl, apiKey, pcrConfig]);
 
   async function fetchUser() {
     const access_token = window.localStorage.getItem("access_token");
@@ -1193,8 +1195,7 @@ export function OpenSecretProvider({
     }
     localStorage.removeItem("access_token");
     localStorage.removeItem("refresh_token");
-    sessionStorage.removeItem("sessionKey");
-    sessionStorage.removeItem("sessionId");
+    clearAttestationSessions();
     // Clear any in-memory API key so no post-logout calls can use it
     setApiKey(undefined);
     setAuth({
@@ -1363,7 +1364,8 @@ export function OpenSecretProvider({
     aiCustomFetch: aiCustomFetch || (async () => new Response()),
     apiUrl,
     pcrConfig,
-    getAttestation,
+    getAttestation: (forceRefresh, explicitApiUrl, explicitPcrConfig) =>
+      getAttestation(forceRefresh, explicitApiUrl || apiUrl, explicitPcrConfig || pcrConfig),
     authenticate,
     parseAttestationForView,
     awsRootCertDer: AWS_ROOT_CERT_DER,

--- a/src/lib/pcr.ts
+++ b/src/lib/pcr.ts
@@ -38,6 +38,31 @@ const PCR_HISTORY_URLS = {
   dev: "https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrDevHistory.json"
 };
 
+const PCR0_HEX_LENGTH = 96;
+const PCR0_HEX_PATTERN = /^[0-9a-f]{96}$/;
+const PCR_HISTORY_TIMEOUT_MS = 5000;
+const PCR_HISTORY_MAX_BYTES = 1024 * 1024;
+const PCR_HISTORY_MAX_ENTRIES = 2048;
+const PCR_SIGNATURE_BYTES = 96;
+
+export type Pcr0ValidationErrorCode =
+  | "PCR0_MISSING"
+  | "PCR0_INVALID_LENGTH"
+  | "PCR0_INVALID_FORMAT"
+  | "PCR0_ALL_ZERO"
+  | "PCR0_UNTRUSTED";
+
+/** A hard attestation failure caused by an invalid or untrusted enclave identity. */
+export class Pcr0ValidationError extends Error {
+  readonly code: Pcr0ValidationErrorCode;
+
+  constructor(code: Pcr0ValidationErrorCode, message: string) {
+    super(message);
+    this.name = "Pcr0ValidationError";
+    this.code = code;
+  }
+}
+
 /**
  * PCR history entry type
  */
@@ -65,13 +90,22 @@ export type Pcr0ValidationResult = {
  * Configuration options for PCR validation
  */
 export type PcrConfig = {
-  /** Additional custom PCR0 values for production environments */
+  /**
+   * Additional trusted PCR0 values for production environments.
+   * The SDK's built-in production trust roots always remain trusted.
+   */
   pcr0Values?: string[];
-  /** Additional custom PCR0 values for development environments */
+  /**
+   * Additional trusted PCR0 values for development environments.
+   * The SDK's built-in development trust roots always remain trusted.
+   */
   pcr0DevValues?: string[];
-  /** Enable/disable remote attestation (defaults to true) */
+  /**
+   * Whether to consult pinned-key signed PCR history after local trust roots miss
+   * (defaults to true). This does not enable or disable Nitro attestation verification.
+   */
   remoteAttestation?: boolean;
-  /** Custom URLs for remote attestation */
+  /** Custom URLs for pinned-key signed PCR history */
   remoteAttestationUrls?: {
     /** URL for production PCR history */
     prod?: string;
@@ -79,6 +113,150 @@ export type PcrConfig = {
     dev?: string;
   };
 };
+
+async function readBoundedUtf8Body(response: Response, maxBytes: number): Promise<string> {
+  // Real fetch responses expose a byte stream. Some unit-test and legacy fetch
+  // implementations only expose text(), so keep a byte-counted fallback for them.
+  if (!response.body) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error("PCR history response is too large");
+    }
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let totalBytes = 0;
+  let text = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        try {
+          await reader.cancel("PCR history response is too large");
+        } catch {
+          // Preserve the size-limit failure even if the stream cannot be cancelled.
+        }
+        throw new Error("PCR history response is too large");
+      }
+
+      text += decoder.decode(value, { stream: true });
+    }
+
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+type CanonicalPcrConfig = {
+  version: "pcr0-union-v1";
+  verificationKey: string;
+  defaultPcr0Values: string[];
+  defaultPcr0DevValues: string[];
+  pcr0Values: string[];
+  pcr0DevValues: string[];
+  remoteAttestation: boolean;
+  remoteAttestationUrls: {
+    prod: string;
+    dev: string;
+  };
+};
+
+function normalizedValues(values: string[] | undefined): string[] {
+  return [...new Set((values || []).map((value) => value.trim().toLowerCase()))].sort();
+}
+
+/**
+ * Takes an immutable snapshot of a PCR policy before an asynchronous handshake.
+ * This prevents caller mutations from changing which policy is validated or cached.
+ */
+export function snapshotPcrConfig(config?: PcrConfig): PcrConfig {
+  return {
+    pcr0Values: normalizedValues(config?.pcr0Values),
+    pcr0DevValues: normalizedValues(config?.pcr0DevValues),
+    remoteAttestation: config?.remoteAttestation !== false,
+    remoteAttestationUrls: {
+      prod: config?.remoteAttestationUrls?.prod || PCR_HISTORY_URLS.prod,
+      dev: config?.remoteAttestationUrls?.dev || PCR_HISTORY_URLS.dev
+    }
+  };
+}
+
+/** Stable representation used to bind cached sessions to their trust policy. */
+export function serializePcrConfig(config?: PcrConfig): string {
+  const snapshot = snapshotPcrConfig(config);
+  const canonical: CanonicalPcrConfig = {
+    version: "pcr0-union-v1",
+    verificationKey: PCR_VERIFICATION_PUBLIC_KEY_B64,
+    defaultPcr0Values: [...DEFAULT_PCR0_VALUES].sort(),
+    defaultPcr0DevValues: [...DEFAULT_PCR0_VALUES_DEV].sort(),
+    pcr0Values: snapshot.pcr0Values || [],
+    pcr0DevValues: snapshot.pcr0DevValues || [],
+    remoteAttestation: snapshot.remoteAttestation !== false,
+    remoteAttestationUrls: {
+      prod: snapshot.remoteAttestationUrls?.prod || PCR_HISTORY_URLS.prod,
+      dev: snapshot.remoteAttestationUrls?.dev || PCR_HISTORY_URLS.dev
+    }
+  };
+
+  return JSON.stringify(canonical);
+}
+
+/** Converts the authenticated Nitro PCR0 value into its canonical SHA-384 hex form. */
+export function pcr0BytesToHex(pcr0: Uint8Array | undefined): string {
+  if (!pcr0) {
+    throw new Pcr0ValidationError("PCR0_MISSING", "Attestation document is missing PCR0.");
+  }
+  if (pcr0.length !== PCR0_HEX_LENGTH / 2) {
+    throw new Pcr0ValidationError(
+      "PCR0_INVALID_LENGTH",
+      "Attestation document contains an invalid PCR0 length."
+    );
+  }
+  if (pcr0.every((byte) => byte === 0)) {
+    throw new Pcr0ValidationError(
+      "PCR0_ALL_ZERO",
+      "Attestation document contains an all-zero PCR0."
+    );
+  }
+
+  const hash = Array.from(pcr0, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  if (!PCR0_HEX_PATTERN.test(hash)) {
+    throw new Pcr0ValidationError(
+      "PCR0_INVALID_FORMAT",
+      "Attestation document contains an invalid PCR0."
+    );
+  }
+  return hash;
+}
+
+/**
+ * Enforces PCR0 trust for the already Nitro-authenticated attestation document.
+ * Callers must run this before key exchange or session persistence.
+ */
+export async function requireTrustedPcr0(
+  pcrs: Map<number, Uint8Array>,
+  config?: PcrConfig,
+  validate: typeof validatePcr0Hash = validatePcr0Hash
+): Promise<{ hash: string; validation: Pcr0ValidationResult }> {
+  const hash = pcr0BytesToHex(pcrs.get(0));
+  const validation = await validate(hash, config);
+  if (!validation.isMatch) {
+    throw new Pcr0ValidationError(
+      "PCR0_UNTRUSTED",
+      "Attestation PCR0 is not in the configured trust roots."
+    );
+  }
+  return { hash, validation };
+}
 
 /**
  * Imports the verification public key into the Web Crypto API
@@ -116,18 +294,78 @@ async function fetchPcrHistory(
   env: "prod" | "dev",
   urls?: { prod?: string; dev?: string }
 ): Promise<PcrHistoryEntry[]> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PCR_HISTORY_TIMEOUT_MS);
   try {
     const baseUrl = urls?.[env] || PCR_HISTORY_URLS[env];
-    const response = await fetch(baseUrl);
+    const parsedUrl = new URL(baseUrl);
+    if (
+      (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") ||
+      parsedUrl.username ||
+      parsedUrl.password ||
+      parsedUrl.hash ||
+      baseUrl.length > 2048
+    ) {
+      throw new Error("Invalid PCR history URL");
+    }
 
-    if (!response.ok) {
+    const response = await fetch(baseUrl, {
+      redirect: "error",
+      signal: controller.signal
+    });
+
+    if (!response.ok || response.redirected) {
       throw new Error(`Failed to fetch PCR history: ${response.status}`);
     }
 
-    return await response.json();
+    const contentLength = response.headers.get("content-length");
+    if (contentLength && Number(contentLength) > PCR_HISTORY_MAX_BYTES) {
+      throw new Error("PCR history response is too large");
+    }
+
+    const text = await readBoundedUtf8Body(response, PCR_HISTORY_MAX_BYTES);
+
+    const history: unknown = JSON.parse(text);
+    if (
+      !Array.isArray(history) ||
+      history.length === 0 ||
+      history.length > PCR_HISTORY_MAX_ENTRIES ||
+      !history.every(isValidPcrHistoryEntry)
+    ) {
+      throw new Error("PCR history response has an invalid schema");
+    }
+    return history;
   } catch (error) {
     console.error("Error fetching PCR history:", error);
     throw new Error("Failed to fetch PCR history");
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function isValidPcrHistoryEntry(entry: unknown): entry is PcrHistoryEntry {
+  if (!entry || typeof entry !== "object") return false;
+  const candidate = entry as Partial<PcrHistoryEntry>;
+  if (
+    typeof candidate.PCR0 !== "string" ||
+    typeof candidate.PCR1 !== "string" ||
+    typeof candidate.PCR2 !== "string" ||
+    !PCR0_HEX_PATTERN.test(candidate.PCR0) ||
+    !PCR0_HEX_PATTERN.test(candidate.PCR1) ||
+    !PCR0_HEX_PATTERN.test(candidate.PCR2) ||
+    typeof candidate.timestamp !== "number" ||
+    !Number.isSafeInteger(candidate.timestamp) ||
+    candidate.timestamp <= 0 ||
+    typeof candidate.signature !== "string" ||
+    candidate.signature.length > 256
+  ) {
+    return false;
+  }
+
+  try {
+    return atob(candidate.signature).length === PCR_SIGNATURE_BYTES;
+  } catch {
+    return false;
   }
 }
 
@@ -217,18 +455,20 @@ export async function validatePcr0Hash(
   hash: string,
   config?: PcrConfig
 ): Promise<Pcr0ValidationResult> {
+  const normalizedHash = hash.trim().toLowerCase();
+  const snapshot = snapshotPcrConfig(config);
   // First check against local values
-  const validPcr0Values = [...(config?.pcr0Values || []), ...DEFAULT_PCR0_VALUES];
-  const validPcr0DevValues = [...(config?.pcr0DevValues || []), ...DEFAULT_PCR0_VALUES_DEV];
+  const validPcr0Values = [...(snapshot.pcr0Values || []), ...DEFAULT_PCR0_VALUES];
+  const validPcr0DevValues = [...(snapshot.pcr0DevValues || []), ...DEFAULT_PCR0_VALUES_DEV];
 
-  if (validPcr0Values.includes(hash)) {
+  if (validPcr0Values.includes(normalizedHash)) {
     return {
       isMatch: true,
       text: "PCR0 matches a known good value"
     };
   }
 
-  if (validPcr0DevValues.includes(hash)) {
+  if (validPcr0DevValues.includes(normalizedHash)) {
     return {
       isMatch: true,
       text: "PCR0 matches development enclave"
@@ -236,15 +476,15 @@ export async function validatePcr0Hash(
   }
 
   // If remote attestation is enabled (default is true), check against remote PCR history
-  const remoteAttestationEnabled = config?.remoteAttestation !== false;
+  const remoteAttestationEnabled = snapshot.remoteAttestation !== false;
 
   if (remoteAttestationEnabled) {
     try {
       // Try prod first
       const prodResult = await validatePcrAgainstRemoteHistory(
-        hash,
+        normalizedHash,
         "prod",
-        config?.remoteAttestationUrls
+        snapshot.remoteAttestationUrls
       );
 
       if (prodResult) {
@@ -253,9 +493,9 @@ export async function validatePcr0Hash(
 
       // Try dev if prod didn't match
       const devResult = await validatePcrAgainstRemoteHistory(
-        hash,
+        normalizedHash,
         "dev",
-        config?.remoteAttestationUrls
+        snapshot.remoteAttestationUrls
       );
 
       if (devResult) {

--- a/src/lib/platformApi.ts
+++ b/src/lib/platformApi.ts
@@ -1,4 +1,5 @@
 import { encryptedApiCall, authenticatedApiCall } from "./encryptedApi";
+import { snapshotPcrConfig, type PcrConfig } from "./pcr";
 
 // Platform Auth Types
 export type PlatformLoginResponse = {
@@ -130,13 +131,19 @@ export type OrganizationMember = {
 };
 
 let platformApiUrl = "";
+let platformPcrConfig: PcrConfig = snapshotPcrConfig();
 
-export function setPlatformApiUrl(url: string) {
+export function setPlatformApiUrl(url: string, pcrConfig?: PcrConfig) {
   platformApiUrl = url;
+  platformPcrConfig = snapshotPcrConfig(pcrConfig);
 }
 
 export function getPlatformApiUrl(): string {
   return platformApiUrl;
+}
+
+export function getPlatformPcrConfig(): PcrConfig {
+  return snapshotPcrConfig(platformPcrConfig);
 }
 
 // Platform Authentication

--- a/src/lib/test/customFetch.test.ts
+++ b/src/lib/test/customFetch.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { createCustomFetchWithDependencies, type CustomFetchDependencies } from "../ai";
+import { getApiPcrConfig, getApiUrl, setApiUrl } from "../api";
 import type { Attestation } from "../getAttestation";
+import type { PcrConfig } from "../pcr";
 
 const staleKey = new Uint8Array(32).fill(1);
 const freshKey = new Uint8Array(32).fill(2);
@@ -345,5 +347,93 @@ describe("createCustomFetch stale-session recovery", () => {
     );
     expect(requests).toBe(1);
     expect(forcedAttestations).toBe(0);
+  });
+
+  test("forwards one endpoint-bound PCR policy through lookup and renewal", async () => {
+    const apiUrl = "https://enclave.example.test/base";
+    const pcrConfig: PcrConfig = {
+      pcr0Values: ["2a".repeat(48)],
+      remoteAttestation: false
+    };
+    const expectedPcrConfig: PcrConfig = {
+      pcr0Values: ["2a".repeat(48)],
+      pcr0DevValues: [],
+      remoteAttestation: false,
+      remoteAttestationUrls: {
+        prod: "https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrProdHistory.json",
+        dev: "https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrDevHistory.json"
+      }
+    };
+    const calls: Array<[boolean | undefined, string | undefined, PcrConfig | undefined]> = [];
+    let currentAttestation = staleAttestation;
+
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key", apiUrl, pcrConfig },
+      dependencies({
+        getAttestation: async (forceRefresh, explicitApiUrl, policy) => {
+          calls.push([forceRefresh, explicitApiUrl, policy]);
+          if (forceRefresh) currentAttestation = freshAttestation;
+          return currentAttestation;
+        },
+        fetch: async (_input, init) => {
+          if (recordRequest(init).sessionId === staleAttestation.sessionId) {
+            pcrConfig.pcr0Values = ["4c".repeat(48)];
+            pcrConfig.remoteAttestation = true;
+            return new Response("stale", { status: 400 });
+          }
+          return Response.json({ encrypted: '2:{"ok":true}' });
+        }
+      })
+    );
+
+    const response = await customFetch("https://example.test/v1/responses");
+
+    expect(await response.json()).toEqual({ ok: true });
+    expect(calls).toHaveLength(3);
+    expect(calls.map(([forceRefresh]) => forceRefresh)).toEqual([false, false, true]);
+    expect(calls.every(([, endpoint]) => endpoint === apiUrl)).toBe(true);
+    expect(calls.every(([, , policy]) => policy !== pcrConfig)).toBe(true);
+    expect(calls.map(([, , policy]) => policy)).toEqual([
+      expectedPcrConfig,
+      expectedPcrConfig,
+      expectedPcrConfig
+    ]);
+    expect(calls[0][2]).toBe(calls[1][2]);
+    expect(calls[1][2]).toBe(calls[2][2]);
+  });
+
+  test("inherits the provider's global endpoint and PCR policy when options omit them", async () => {
+    const originalApiUrl = getApiUrl();
+    const originalPcrConfig = getApiPcrConfig();
+    const apiUrl = "https://provider.example.test";
+    const pcrConfig: PcrConfig = {
+      pcr0Values: ["3b".repeat(48)],
+      remoteAttestation: false
+    };
+    const calls: Array<[boolean | undefined, string | undefined, PcrConfig | undefined]> = [];
+
+    try {
+      setApiUrl(apiUrl, pcrConfig);
+      const customFetch = createCustomFetchWithDependencies(
+        { apiKey: "test-api-key" },
+        dependencies({
+          getAttestation: async (forceRefresh, explicitApiUrl, policy) => {
+            calls.push([forceRefresh, explicitApiUrl, policy]);
+            return freshAttestation;
+          },
+          fetch: async () => Response.json({ encrypted: '2:{"ok":true}' })
+        })
+      );
+
+      expect(await (await customFetch("https://example.test/v1/responses")).json()).toEqual({
+        ok: true
+      });
+      expect(calls).toHaveLength(1);
+      expect(calls[0][0]).toBe(false);
+      expect(calls[0][1]).toBe(apiUrl);
+      expect(calls[0][2]).toEqual(expect.objectContaining(pcrConfig));
+    } finally {
+      setApiUrl(originalApiUrl, originalPcrConfig);
+    }
   });
 });

--- a/src/lib/test/getAttestationSecurity.test.ts
+++ b/src/lib/test/getAttestationSecurity.test.ts
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { encode } from "@stablelib/base64";
+import type { AttestationDocument } from "../attestation";
+import {
+  getAttestationSessionStorageKey,
+  getAttestationWithDependencies,
+  type GetAttestationDependencies
+} from "../getAttestation";
+import type { PcrConfig } from "../pcr";
+
+const REMOTE_API_URL = "https://enclave.example.test/api";
+const LOCAL_API_URL = "http://127.0.0.1:31110";
+const ATTESTATION_NONCE = "00000000-0000-4000-8000-000000000001";
+const TRUSTED_PCR0 = new Uint8Array(48).fill(0x2a);
+const SESSION_KEY = new Uint8Array(32).fill(0x5a);
+const PCR_CONFIG: PcrConfig = {
+  pcr0Values: [bytesToHex(TRUSTED_PCR0)],
+  remoteAttestation: false
+};
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function attestationDocument(pcr0?: Uint8Array): AttestationDocument {
+  const pcrs = new Map<number, Uint8Array>();
+  if (pcr0) pcrs.set(0, pcr0);
+
+  return {
+    module_id: "test-enclave",
+    digest: "SHA384",
+    timestamp: Date.now(),
+    pcrs,
+    certificate: new Uint8Array([1]),
+    cabundle: [new Uint8Array([2])],
+    public_key: new Uint8Array(32).fill(0x19),
+    user_data: null,
+    nonce: new TextEncoder().encode(ATTESTATION_NONCE)
+  };
+}
+
+function dependencies(
+  overrides: Partial<GetAttestationDependencies> = {}
+): GetAttestationDependencies {
+  return {
+    verifyAttestation: async () => attestationDocument(TRUSTED_PCR0),
+    validatePcr0Hash: async () => ({
+      isMatch: true,
+      text: "PCR0 matches a test trust root"
+    }),
+    keyExchange: async () => ({
+      encrypted_session_key: "test-encrypted-session-key",
+      session_id: "trusted-session"
+    }),
+    generateNaclKeyPair: () => ({
+      publicKey: new Uint8Array(32).fill(0x11),
+      secretKey: new Uint8Array(32).fill(0x12)
+    }),
+    decryptSessionKey: () => SESSION_KEY,
+    randomUUID: () => ATTESTATION_NONCE,
+    ...overrides
+  };
+}
+
+async function establish(
+  deps: GetAttestationDependencies,
+  apiUrl = REMOTE_API_URL,
+  pcrConfig: PcrConfig | undefined = PCR_CONFIG
+) {
+  return getAttestationWithDependencies(false, apiUrl, pcrConfig, deps);
+}
+
+describe("attested session establishment", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  test("rejects an attestation with no PCR0 before key exchange", async () => {
+    const keyExchange = mock(async () => ({
+      encrypted_session_key: "must-not-be-used",
+      session_id: "must-not-be-created"
+    }));
+    const validatePcr0Hash = mock(async () => ({
+      isMatch: true,
+      text: "must not validate a missing PCR"
+    }));
+
+    await expect(
+      establish(
+        dependencies({
+          verifyAttestation: async () => attestationDocument(),
+          validatePcr0Hash,
+          keyExchange
+        })
+      )
+    ).rejects.toThrow(/PCR0/i);
+
+    expect(validatePcr0Hash).not.toHaveBeenCalled();
+    expect(keyExchange).not.toHaveBeenCalled();
+    expect(window.sessionStorage.length).toBe(0);
+  });
+
+  test("rejects a PCR0 with the wrong SHA-384 length before key exchange", async () => {
+    const keyExchange = mock(async () => ({
+      encrypted_session_key: "must-not-be-used",
+      session_id: "must-not-be-created"
+    }));
+    const validatePcr0Hash = mock(async () => ({
+      isMatch: true,
+      text: "must not validate a malformed PCR"
+    }));
+
+    await expect(
+      establish(
+        dependencies({
+          verifyAttestation: async () => attestationDocument(new Uint8Array(47)),
+          validatePcr0Hash,
+          keyExchange
+        })
+      )
+    ).rejects.toThrow(/PCR0/i);
+
+    expect(validatePcr0Hash).not.toHaveBeenCalled();
+    expect(keyExchange).not.toHaveBeenCalled();
+    expect(window.sessionStorage.length).toBe(0);
+  });
+
+  test("rejects an all-zero PCR0 before validation or key exchange", async () => {
+    const keyExchange = mock(async () => ({
+      encrypted_session_key: "must-not-be-used",
+      session_id: "must-not-be-created"
+    }));
+    const validatePcr0Hash = mock(async () => ({
+      isMatch: true,
+      text: "must not validate an all-zero PCR"
+    }));
+
+    await expect(
+      establish(
+        dependencies({
+          verifyAttestation: async () => attestationDocument(new Uint8Array(48)),
+          validatePcr0Hash,
+          keyExchange
+        })
+      )
+    ).rejects.toThrow(/PCR0/i);
+
+    expect(validatePcr0Hash).not.toHaveBeenCalled();
+    expect(keyExchange).not.toHaveBeenCalled();
+    expect(window.sessionStorage.length).toBe(0);
+  });
+
+  test("rejects an unknown PCR0 before key exchange and leaves no session cache", async () => {
+    const keyExchange = mock(async () => ({
+      encrypted_session_key: "must-not-be-used",
+      session_id: "must-not-be-created"
+    }));
+    const validatePcr0Hash = mock(async () => ({
+      isMatch: false,
+      text: "PCR0 does not match a known good value"
+    }));
+
+    await expect(establish(dependencies({ validatePcr0Hash, keyExchange }))).rejects.toThrow(
+      /PCR0/i
+    );
+
+    expect(validatePcr0Hash).toHaveBeenCalledWith(
+      bytesToHex(TRUSTED_PCR0),
+      expect.objectContaining(PCR_CONFIG)
+    );
+    expect(keyExchange).not.toHaveBeenCalled();
+    expect(window.sessionStorage.length).toBe(0);
+  });
+
+  test("an allowed PCR0 establishes and reuses a policy-scoped cached session", async () => {
+    const verifyAttestation = mock(async () => attestationDocument(TRUSTED_PCR0));
+    const validatePcr0Hash = mock(async () => ({
+      isMatch: true,
+      text: "PCR0 matches a test trust root"
+    }));
+    const keyExchange = mock(async () => ({
+      encrypted_session_key: "test-encrypted-session-key",
+      session_id: "trusted-session"
+    }));
+    const deps = dependencies({ verifyAttestation, validatePcr0Hash, keyExchange });
+
+    const established = await establish(deps);
+    const cached = await establish(deps);
+
+    expect(established).toEqual({ sessionKey: SESSION_KEY, sessionId: "trusted-session" });
+    expect(cached).toEqual(established);
+    expect(verifyAttestation).toHaveBeenCalledTimes(1);
+    expect(validatePcr0Hash).toHaveBeenCalledTimes(1);
+    expect(validatePcr0Hash).toHaveBeenCalledWith(
+      bytesToHex(TRUSTED_PCR0),
+      expect.objectContaining(PCR_CONFIG)
+    );
+    expect(keyExchange).toHaveBeenCalledTimes(1);
+    expect(
+      window.sessionStorage.getItem(
+        await getAttestationSessionStorageKey(REMOTE_API_URL, PCR_CONFIG)
+      )
+    ).not.toBeNull();
+    expect(window.sessionStorage.getItem("sessionKey")).toBeNull();
+    expect(window.sessionStorage.getItem("sessionId")).toBeNull();
+  });
+
+  test("a policy change cannot reuse a session established under the old trust roots", async () => {
+    await establish(dependencies());
+    const changedPolicy: PcrConfig = {
+      pcr0Values: ["4c".repeat(48)],
+      remoteAttestation: false
+    };
+    const keyExchange = mock(async () => ({
+      encrypted_session_key: "must-not-be-used",
+      session_id: "must-not-be-created"
+    }));
+    const verifyAttestation = mock(async () => attestationDocument(TRUSTED_PCR0));
+
+    await expect(
+      establish(
+        dependencies({
+          verifyAttestation,
+          validatePcr0Hash: async () => ({ isMatch: false, text: "not in changed policy" }),
+          keyExchange
+        }),
+        REMOTE_API_URL,
+        changedPolicy
+      )
+    ).rejects.toThrow(/PCR0/i);
+
+    expect(verifyAttestation).toHaveBeenCalledTimes(1);
+    expect(keyExchange).not.toHaveBeenCalled();
+  });
+
+  test("ignores and removes a legacy unscoped cached session", async () => {
+    window.sessionStorage.setItem("sessionKey", encode(new Uint8Array(32).fill(0xff)));
+    window.sessionStorage.setItem("sessionId", "legacy-session");
+    const verifyAttestation = mock(async () => attestationDocument(TRUSTED_PCR0));
+    const keyExchange = mock(async () => ({
+      encrypted_session_key: "test-encrypted-session-key",
+      session_id: "fresh-session"
+    }));
+
+    const result = await establish(dependencies({ verifyAttestation, keyExchange }));
+
+    expect(result).toEqual({ sessionKey: SESSION_KEY, sessionId: "fresh-session" });
+    expect(verifyAttestation).toHaveBeenCalledTimes(1);
+    expect(keyExchange).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem("sessionKey")).toBeNull();
+    expect(window.sessionStorage.getItem("sessionId")).toBeNull();
+  });
+
+  test("force refresh evicts the verified session before a failed re-attestation", async () => {
+    await establish(dependencies());
+    const cacheKey = await getAttestationSessionStorageKey(REMOTE_API_URL, PCR_CONFIG);
+    expect(window.sessionStorage.getItem(cacheKey)).not.toBeNull();
+
+    const verifyAttestation = mock(async () => {
+      throw new Error("attestation unavailable");
+    });
+    await expect(
+      getAttestationWithDependencies(
+        true,
+        REMOTE_API_URL,
+        PCR_CONFIG,
+        dependencies({ verifyAttestation })
+      )
+    ).rejects.toThrow("attestation unavailable");
+
+    expect(window.sessionStorage.getItem(cacheKey)).toBeNull();
+  });
+
+  test("key exchange failure cannot leave a partial session cache", async () => {
+    const keyExchange = mock(async () => {
+      throw new Error("key exchange unavailable");
+    });
+
+    await expect(establish(dependencies({ keyExchange }))).rejects.toThrow(
+      "key exchange unavailable"
+    );
+
+    expect(keyExchange).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.length).toBe(0);
+  });
+
+  test("bypasses PCR validation only for an exact HTTP loopback API URL", async () => {
+    const validatePcr0Hash = mock(async () => {
+      throw new Error("loopback must not invoke PCR validation");
+    });
+    const keyExchange = mock(async () => ({
+      encrypted_session_key: "test-encrypted-session-key",
+      session_id: "local-session"
+    }));
+
+    const result = await establish(
+      dependencies({
+        verifyAttestation: async () => attestationDocument(),
+        validatePcr0Hash,
+        keyExchange
+      }),
+      LOCAL_API_URL
+    );
+
+    expect(result).toEqual({ sessionKey: SESSION_KEY, sessionId: "local-session" });
+    expect(validatePcr0Hash).not.toHaveBeenCalled();
+    expect(keyExchange).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["https://localhost:31110", "http://localhost.example.test:31110"])(
+    "does not treat %s as the loopback PCR bypass",
+    async (apiUrl) => {
+      const keyExchange = mock(async () => ({
+        encrypted_session_key: "must-not-be-used",
+        session_id: "must-not-be-created"
+      }));
+
+      await expect(
+        establish(
+          dependencies({
+            verifyAttestation: async () => attestationDocument(),
+            keyExchange
+          }),
+          apiUrl
+        )
+      ).rejects.toThrow(/PCR0/i);
+
+      expect(keyExchange).not.toHaveBeenCalled();
+      expect(window.sessionStorage.length).toBe(0);
+    }
+  );
+});

--- a/src/lib/test/integration/liveAttestation.test.ts
+++ b/src/lib/test/integration/liveAttestation.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { clearAttestationSessions, getAttestation } from "../../getAttestation";
+
+const liveApiUrl = process.env.VITE_LIVE_ATTESTATION_API_URL;
+const runLive = process.env.RUN_LIVE_ATTESTATION === "1" && Boolean(liveApiUrl);
+const originalFetch = globalThis.fetch;
+
+function requestUrl(input: RequestInfo | URL): string {
+  return typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+}
+
+beforeEach(() => {
+  clearAttestationSessions();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearAttestationSessions();
+});
+
+test.skipIf(!runLive)(
+  "hosted enclave establishes a session only after signed-history PCR0 validation",
+  async () => {
+    const requests: string[] = [];
+    globalThis.fetch = async (input, init) => {
+      requests.push(requestUrl(input));
+      return originalFetch(input, init);
+    };
+
+    const attestation = await getAttestation(true, liveApiUrl);
+
+    expect(attestation.sessionKey).toHaveLength(32);
+    expect(attestation.sessionId).toBeTruthy();
+
+    const attestationIndex = requests.findIndex((url) => url.includes("/attestation/"));
+    const prodHistoryIndex = requests.findIndex((url) => url.endsWith("/pcrProdHistory.json"));
+    const devHistoryIndex = requests.findIndex((url) => url.endsWith("/pcrDevHistory.json"));
+    const keyExchangeIndex = requests.findIndex((url) => url.endsWith("/key_exchange"));
+
+    expect(attestationIndex).toBeGreaterThanOrEqual(0);
+    expect(prodHistoryIndex).toBeGreaterThan(attestationIndex);
+    expect(devHistoryIndex).toBeGreaterThan(prodHistoryIndex);
+    expect(keyExchangeIndex).toBeGreaterThan(devHistoryIndex);
+  }
+);
+
+test.skipIf(!runLive)(
+  "hosted enclave cannot reach key exchange when its PCR0 policy is deliberately unknown",
+  async () => {
+    const requests: string[] = [];
+    globalThis.fetch = async (input, init) => {
+      requests.push(requestUrl(input));
+      return originalFetch(input, init);
+    };
+
+    await expect(getAttestation(true, liveApiUrl, { remoteAttestation: false })).rejects.toThrow(
+      /PCR0/i
+    );
+
+    expect(requests.filter((url) => url.includes("/attestation/"))).toHaveLength(1);
+    expect(requests.filter((url) => url.endsWith("/key_exchange"))).toHaveLength(0);
+  }
+);

--- a/src/lib/test/integration/pcr.test.ts
+++ b/src/lib/test/integration/pcr.test.ts
@@ -45,7 +45,7 @@ const VERIFIED_SIGNATURE =
 const originalFetch = global.fetch;
 
 // Create a more complete Response-like object for TypeScript
-function createMockResponse(data: any, status = 200, ok = true): Response {
+function createMockResponse(data: any, status = 200, ok = true, redirected = false): Response {
   return {
     ok,
     status,
@@ -53,7 +53,7 @@ function createMockResponse(data: any, status = 200, ok = true): Response {
     headers: new Headers(),
     body: null,
     bodyUsed: false,
-    redirected: false,
+    redirected,
     type: "basic" as ResponseType,
     url: "",
     json: async () => data,
@@ -68,7 +68,7 @@ function createMockResponse(data: any, status = 200, ok = true): Response {
 }
 
 // Use more precise typing for the mock function
-global.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+global.fetch = mock(async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
   const url =
     typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
 
@@ -142,7 +142,7 @@ test("prioritizes local PCR0 values over remote ones", async () => {
 test("handles fetch errors gracefully", async () => {
   // Mock a failing fetch call
   const failingFetch = mock(
-    async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
       throw new Error("Network error");
     }
   );
@@ -162,7 +162,7 @@ test("handles fetch errors gracefully", async () => {
 
 test("supports custom remote attestation URLs", async () => {
   const customFetch = mock(
-    async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
       const url =
         typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
 
@@ -194,6 +194,85 @@ test("supports custom remote attestation URLs", async () => {
     const result = await validatePcr0Hash(VERIFIED_PCR0, config);
     expect(result.isMatch).toBe(true);
     expect(result.text).toBe("PCR0 matches remotely attested value");
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("rejects a matching remote PCR0 whose pinned-key signature is tampered", async () => {
+  const tamperedHistoryFetch = mock(async (): Promise<Response> => {
+    return createMockResponse([
+      {
+        PCR0: VERIFIED_PCR0,
+        PCR1: VERIFIED_PCR1,
+        PCR2: VERIFIED_PCR2,
+        timestamp: 1743710235,
+        signature: `${VERIFIED_SIGNATURE.slice(0, -2)}AA`
+      }
+    ]);
+  });
+
+  try {
+    global.fetch = tamperedHistoryFetch;
+    const result = await validatePcr0Hash(VERIFIED_PCR0);
+    expect(result.isMatch).toBe(false);
+    expect(tamperedHistoryFetch).toHaveBeenCalledTimes(2);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("rejects and cancels PCR history streams larger than one MiB", async () => {
+  let cancelCount = 0;
+  const oversizedHistoryFetch = mock(async (): Promise<Response> => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(1024 * 1024).fill(0x20));
+        controller.enqueue(new Uint8Array([0x20]));
+      },
+      cancel() {
+        cancelCount += 1;
+      }
+    });
+    return new Response(stream, { status: 200 });
+  });
+
+  try {
+    global.fetch = oversizedHistoryFetch;
+    const result = await validatePcr0Hash(VERIFIED_PCR0);
+    expect(result.isMatch).toBe(false);
+    expect(oversizedHistoryFetch).toHaveBeenCalledTimes(2);
+    expect(cancelCount).toBe(2);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("rejects signed PCR history with a malformed schema", async () => {
+  const malformedHistoryFetch = mock(async (): Promise<Response> => {
+    return createMockResponse([{ PCR0: VERIFIED_PCR0 }]);
+  });
+
+  try {
+    global.fetch = malformedHistoryFetch;
+    const result = await validatePcr0Hash(VERIFIED_PCR0);
+    expect(result.isMatch).toBe(false);
+    expect(malformedHistoryFetch).toHaveBeenCalledTimes(2);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("rejects redirected signed PCR history responses", async () => {
+  const redirectedHistoryFetch = mock(async (): Promise<Response> => {
+    return createMockResponse([], 200, true, true);
+  });
+
+  try {
+    global.fetch = redirectedHistoryFetch;
+    const result = await validatePcr0Hash(VERIFIED_PCR0);
+    expect(result.isMatch).toBe(false);
+    expect(redirectedHistoryFetch).toHaveBeenCalledTimes(2);
   } finally {
     global.fetch = originalFetch;
   }

--- a/src/lib/test/integration/platformPushSettings.test.ts
+++ b/src/lib/test/integration/platformPushSettings.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, expect, mock, test } from "bun:test";
-import { encode } from "@stablelib/base64";
 import { decryptMessage, encryptMessage } from "../../encryption";
+import { cacheAttestationSessionForTesting } from "../../getAttestation";
+import type { PcrConfig } from "../../pcr";
 import {
+  getPlatformApiUrl,
+  getPlatformPcrConfig,
   getPushSettings,
   setPlatformApiUrl,
   updatePushSettings,
@@ -12,20 +15,32 @@ const sessionKey = new Uint8Array(32).fill(7);
 const sessionId = "push-settings-session-id";
 const accessToken = "push-settings-access-token";
 const platformApiUrl = "https://platform.example.com";
+const verifiedPcr0 =
+  "eeddbb58f57c38894d6d5af5e575fbe791c5bf3bbcfb5df8da8cfcf0c2e1da1913108e6a762112444740b88c163d7f4b";
+const pcrConfig: PcrConfig = { pcr0Values: [verifiedPcr0], remoteAttestation: false };
 
 const originalFetch = globalThis.fetch;
+const originalPlatformApiUrl = getPlatformApiUrl();
+const originalPlatformPcrConfig = getPlatformPcrConfig();
 
-beforeEach(() => {
+beforeEach(async () => {
   window.localStorage.clear();
   window.sessionStorage.clear();
   window.localStorage.setItem("access_token", accessToken);
-  window.sessionStorage.setItem("sessionKey", encode(sessionKey));
-  window.sessionStorage.setItem("sessionId", sessionId);
-  setPlatformApiUrl(platformApiUrl);
+  setPlatformApiUrl(platformApiUrl, pcrConfig);
+  await cacheAttestationSessionForTesting(
+    platformApiUrl,
+    pcrConfig,
+    { sessionKey, sessionId },
+    verifiedPcr0
+  );
 });
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  setPlatformApiUrl(originalPlatformApiUrl, originalPlatformPcrConfig);
+  window.localStorage.clear();
+  window.sessionStorage.clear();
 });
 
 test("getPushSettings calls the project push settings endpoint", async () => {

--- a/src/lib/test/integration/web.test.ts
+++ b/src/lib/test/integration/web.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, expect, mock, test } from "bun:test";
-import { encode } from "@stablelib/base64";
 import { decryptMessage, encryptMessage } from "../../encryption";
+import { cacheAttestationSessionForTesting } from "../../getAttestation";
+import type { PcrConfig } from "../../pcr";
 import {
+  getApiPcrConfig,
   getApiUrl,
   setApiUrl,
   webExtract,
@@ -16,21 +18,29 @@ const apiUrl = "https://api.example.com";
 const accessToken = "web-access-token";
 const sessionId = "web-session-id";
 const sessionKey = new Uint8Array(32).fill(19);
+const verifiedPcr0 =
+  "eeddbb58f57c38894d6d5af5e575fbe791c5bf3bbcfb5df8da8cfcf0c2e1da1913108e6a762112444740b88c163d7f4b";
+const pcrConfig: PcrConfig = { pcr0Values: [verifiedPcr0], remoteAttestation: false };
 const originalFetch = globalThis.fetch;
 const originalApiUrl = getApiUrl();
+const originalApiPcrConfig = getApiPcrConfig();
 
-beforeEach(() => {
+beforeEach(async () => {
   window.localStorage.clear();
   window.sessionStorage.clear();
   window.localStorage.setItem("access_token", accessToken);
-  window.sessionStorage.setItem("sessionKey", encode(sessionKey));
-  window.sessionStorage.setItem("sessionId", sessionId);
-  setApiUrl(apiUrl);
+  setApiUrl(apiUrl, pcrConfig);
+  await cacheAttestationSessionForTesting(
+    apiUrl,
+    pcrConfig,
+    { sessionKey, sessionId },
+    verifiedPcr0
+  );
 });
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
-  setApiUrl(originalApiUrl);
+  setApiUrl(originalApiUrl, originalApiPcrConfig);
   window.localStorage.clear();
   window.sessionStorage.clear();
 });

--- a/website/api/functions/OpenSecretDeveloper.md
+++ b/website/api/functions/OpenSecretDeveloper.md
@@ -29,7 +29,9 @@ React child components to be wrapped by the provider
 
 #### pcrConfig?
 
-[`PcrConfig`](../type-aliases/PcrConfig.md) = `{}`
+[`PcrConfig`](../type-aliases/PcrConfig.md) = `DEFAULT_PCR_CONFIG`
+
+Optional PCR0 trust policy enforced before session establishment
 
 ## Returns
 

--- a/website/api/functions/OpenSecretProvider.md
+++ b/website/api/functions/OpenSecretProvider.md
@@ -34,9 +34,9 @@ UUID identifying which project/tenant this instance belongs to
 
 #### pcrConfig?
 
-[`PcrConfig`](../type-aliases/PcrConfig.md) = `{}`
+[`PcrConfig`](../type-aliases/PcrConfig.md) = `DEFAULT_PCR_CONFIG`
 
-Optional PCR configuration for attestation validation
+Optional PCR0 trust policy enforced before session establishment
 
 ## Returns
 

--- a/website/api/interfaces/CustomFetchOptions.md
+++ b/website/api/interfaces/CustomFetchOptions.md
@@ -10,8 +10,20 @@
 
 > `optional` **apiKey?**: `string`
 
+Optional API key to use instead of a JWT token.
+
 ***
 
 ### apiUrl?
 
 > `optional` **apiUrl?**: `string`
+
+API URL used for attestation; required outside OpenSecretProvider.
+
+***
+
+### pcrConfig?
+
+> `optional` **pcrConfig?**: [`PcrConfig`](../type-aliases/PcrConfig.md)
+
+PCR0 trust policy enforced before non-loopback session key exchange.

--- a/website/api/type-aliases/OpenSecretContextType.md
+++ b/website/api/type-aliases/OpenSecretContextType.md
@@ -755,7 +755,7 @@ If the key cannot be retrieved
 
 > **getAttestation**: *typeof* `getAttestation`
 
-Gets attestation from the enclave
+Gets an attested session after enforcing the effective PCR0 trust policy
 
 ***
 
@@ -1223,7 +1223,7 @@ Parses an attestation document for viewing
 
 > **pcrConfig**: [`PcrConfig`](PcrConfig.md)
 
-Additional PCR0 hashes to validate against
+PCR0 trust policy enforced before every non-loopback session key exchange
 
 ***
 

--- a/website/api/type-aliases/OpenSecretDeveloperContextType.md
+++ b/website/api/type-aliases/OpenSecretDeveloperContextType.md
@@ -343,7 +343,7 @@ Expected hash of the AWS root certificate
 
 > **getAttestation**: *typeof* `getAttestation`
 
-Gets attestation from the enclave
+Gets an attested session after enforcing the effective PCR0 trust policy
 
 ***
 
@@ -666,7 +666,7 @@ Parses an attestation document for viewing
 
 > **pcrConfig**: [`PcrConfig`](PcrConfig.md)
 
-Additional PCR0 hashes to validate against
+PCR0 trust policy enforced before every non-loopback session key exchange
 
 ***
 

--- a/website/api/type-aliases/PcrConfig.md
+++ b/website/api/type-aliases/PcrConfig.md
@@ -14,7 +14,8 @@ Configuration options for PCR validation
 
 > `optional` **pcr0DevValues?**: `string`[]
 
-Additional custom PCR0 values for development environments
+Additional trusted PCR0 values for development environments.
+The SDK's built-in development trust roots always remain trusted.
 
 ***
 
@@ -22,7 +23,8 @@ Additional custom PCR0 values for development environments
 
 > `optional` **pcr0Values?**: `string`[]
 
-Additional custom PCR0 values for production environments
+Additional trusted PCR0 values for production environments.
+The SDK's built-in production trust roots always remain trusted.
 
 ***
 
@@ -30,7 +32,8 @@ Additional custom PCR0 values for production environments
 
 > `optional` **remoteAttestation?**: `boolean`
 
-Enable/disable remote attestation (defaults to true)
+Whether to consult pinned-key signed PCR history after local trust roots miss
+(defaults to true). This does not enable or disable Nitro attestation verification.
 
 ***
 
@@ -38,7 +41,7 @@ Enable/disable remote attestation (defaults to true)
 
 > `optional` **remoteAttestationUrls?**: `object`
 
-Custom URLs for remote attestation
+Custom URLs for pinned-key signed PCR history
 
 #### dev?
 

--- a/website/docs/api/functions/OpenSecretDeveloper.md
+++ b/website/docs/api/functions/OpenSecretDeveloper.md
@@ -31,7 +31,9 @@ React child components to be wrapped by the provider
 
 #### pcrConfig?
 
-[`PcrConfig`](../type-aliases/PcrConfig.md) = `{}`
+[`PcrConfig`](../type-aliases/PcrConfig.md) = `DEFAULT_PCR_CONFIG`
+
+Optional PCR0 trust policy enforced before session establishment
 
 ## Returns
 

--- a/website/docs/api/functions/OpenSecretProvider.md
+++ b/website/docs/api/functions/OpenSecretProvider.md
@@ -36,9 +36,9 @@ UUID identifying which project/tenant this instance belongs to
 
 #### pcrConfig?
 
-[`PcrConfig`](../type-aliases/PcrConfig.md) = `{}`
+[`PcrConfig`](../type-aliases/PcrConfig.md) = `DEFAULT_PCR_CONFIG`
 
-Optional PCR configuration for attestation validation
+Optional PCR0 trust policy enforced before session establishment
 
 ## Returns
 

--- a/website/docs/api/type-aliases/OpenSecretContextType.md
+++ b/website/docs/api/type-aliases/OpenSecretContextType.md
@@ -334,7 +334,7 @@ If the key cannot be retrieved
 
 > **getAttestation**: *typeof* `getAttestation`
 
-Gets attestation from the enclave
+Gets an attested session after enforcing the effective PCR0 trust policy
 
 ***
 
@@ -620,7 +620,7 @@ Parses an attestation document for viewing
 
 > **pcrConfig**: [`PcrConfig`](PcrConfig.md)
 
-Additional PCR0 hashes to validate against
+PCR0 trust policy enforced before every non-loopback session key exchange
 
 ***
 

--- a/website/docs/api/type-aliases/OpenSecretDeveloperContextType.md
+++ b/website/docs/api/type-aliases/OpenSecretDeveloperContextType.md
@@ -349,7 +349,7 @@ Expected hash of the AWS root certificate
 
 > **getAttestation**: *typeof* `getAttestation`
 
-Gets attestation from the enclave
+Gets an attested session after enforcing the effective PCR0 trust policy
 
 ***
 
@@ -648,7 +648,7 @@ Parses an attestation document for viewing
 
 > **pcrConfig**: [`PcrConfig`](PcrConfig.md)
 
-Additional PCR0 hashes to validate against
+PCR0 trust policy enforced before every non-loopback session key exchange
 
 ***
 

--- a/website/docs/api/type-aliases/PcrConfig.md
+++ b/website/docs/api/type-aliases/PcrConfig.md
@@ -16,7 +16,8 @@ Configuration options for PCR validation
 
 > `optional` **pcr0DevValues**: `string`[]
 
-Additional custom PCR0 values for development environments
+Additional trusted PCR0 values for development environments.
+The SDK's built-in development trust roots always remain trusted.
 
 ***
 
@@ -24,7 +25,8 @@ Additional custom PCR0 values for development environments
 
 > `optional` **pcr0Values**: `string`[]
 
-Additional custom PCR0 values for production environments
+Additional trusted PCR0 values for production environments.
+The SDK's built-in production trust roots always remain trusted.
 
 ***
 
@@ -32,7 +34,8 @@ Additional custom PCR0 values for production environments
 
 > `optional` **remoteAttestation**: `boolean`
 
-Enable/disable remote attestation (defaults to true)
+Whether to consult pinned-key signed PCR history after local trust roots miss
+(defaults to true). This does not enable or disable Nitro attestation verification.
 
 ***
 
@@ -40,7 +43,7 @@ Enable/disable remote attestation (defaults to true)
 
 > `optional` **remoteAttestationUrls**: `object`
 
-Custom URLs for remote attestation
+Custom URLs for pinned-key signed PCR history
 
 #### dev?
 


### PR DESCRIPTION
## Summary

- require PCR0 from the nonce-bound, AWS Nitro-authenticated document to match the configured trust policy before `/key_exchange`
- propagate one endpoint-bound PCR policy through providers, encrypted API calls, and custom fetch retries
- replace legacy unscoped session storage with endpoint-and-policy-scoped verified sessions, and clear them on sign-out
- harden pinned-key signed PCR history fetches with timeout, redirect, size, schema, and signature checks

## Compatibility

Exact HTTP loopback endpoints retain the existing local-development bypass. Production and development roots remain an additive union, matching current SDK behavior. Existing unscoped cached sessions are discarded and re-established. The API additions are optional and backward compatible.

This PR intentionally does not bump the package version; the release bump will follow after merge.

## Validation

- `bun run format:check`
- `bun run build`
- focused PCR/session/transport tests: 42 passed, 0 failed
- hosted dev enclave smoke: a trusted signed-history PCR0 reached key exchange; a deliberately unknown PCR0 policy made zero key-exchange requests
- locally packed SDK consumed by Maple against the hosted dev environment: typecheck/build passed and 608 tests passed
- website production build

Credential-gated SDK integration files were not runnable locally because the required `VITE_TEST_*` credentials were unavailable.
