### PR TITLE
chore: bump SDK minor versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensecret/react",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensecret/react",
-      "version": "3.3.1",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/react",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "packageManager": "bun@1.3.5",
   "license": "MIT",
   "type": "module",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensecret"
-version = "3.5.0"
+version = "3.6.0"
 edition = "2021"
 authors = ["OpenSecret"]
 description = "Rust SDK for OpenSecret - secure AI API interactions with nitro attestation"

--- a/rust/README.md
+++ b/rust/README.md
@@ -17,7 +17,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-opensecret = "3.5.0"
+opensecret = "3.6.0"
 bytes = "1"
 futures = "0.3"
 http = "1"

--- a/website/docs/maple-ai/index.md
+++ b/website/docs/maple-ai/index.md
@@ -306,7 +306,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-opensecret = "3.5.0"
+opensecret = "3.6.0"
 bytes = "1"
 futures = "0.3"
 http = "1"


### PR DESCRIPTION
## Summary

- bump `@opensecret/react` from `3.3.1` to `3.4.0`
- bump the Rust `opensecret` crate from `3.5.0` to `3.6.0`
- update the root npm lock metadata and published Rust dependency examples

These minor releases include the PCR0 session-establishment enforcement from #96 and the production/development trust-policy separation from #98.

## Validation

- `bun run format:check`
- `bun run build`
- `cargo check --all-targets --all-features`
- website production build
- `bun pm pack --dry-run` produced `opensecret-react-3.4.0.tgz`
- `cargo package --no-verify` packaged `opensecret v3.6.0`

This PR only prepares version metadata. It does not publish either package or create release tags.