### PR TITLE
Scope PCR0 trust by deployment environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # API URL
 VITE_OPEN_SECRET_API_URL=
+# PCR trust environment: production (default) or development
+VITE_OPEN_SECRET_PCR_ENVIRONMENT=production
 
 # Test credentials
 VITE_TEST_EMAIL=

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,6 +83,7 @@ jobs:
         run: cargo test --all-features
         env:
           VITE_OPEN_SECRET_API_URL: ${{ secrets.VITE_OPEN_SECRET_API_URL }}
+          VITE_OPEN_SECRET_PCR_ENVIRONMENT: development
           VITE_TEST_EMAIL: ${{ secrets.VITE_TEST_EMAIL }}
           VITE_TEST_PASSWORD: ${{ secrets.VITE_TEST_PASSWORD }}
           VITE_TEST_NAME: ${{ secrets.VITE_TEST_NAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Run tests
         env:
           VITE_OPEN_SECRET_API_URL: ${{ secrets.VITE_OPEN_SECRET_API_URL }}
+          VITE_OPEN_SECRET_PCR_ENVIRONMENT: development
           VITE_TEST_EMAIL: ${{ secrets.VITE_TEST_EMAIL }}
           VITE_TEST_PASSWORD: ${{ secrets.VITE_TEST_PASSWORD }}
           VITE_TEST_NAME: ${{ secrets.VITE_TEST_NAME }}

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -13,7 +13,7 @@ function App() {
   return (
     <OpenSecretDeveloper 
       apiUrl="https://developer.opensecret.cloud"
-      pcrConfig={{}} // Optional PCR0 trust policy enforced before session establishment
+      pcrConfig={{ environment: "production" }} // Optional; production is the default
     >
       <YourApp />
     </OpenSecretDeveloper>
@@ -351,7 +351,7 @@ function PlatformManagement() {
 
 ### Attestation Verification
 
-- `pcrConfig`: The PCR0 trust policy enforced before non-loopback session establishment. Custom hashes are additive to the SDK's built-in roots.
+- `pcrConfig`: The PCR0 trust policy enforced before non-loopback session establishment. Its environment defaults to production. Only the selected environment's embedded roots, custom roots, and pinned-key signed GitHub history are trusted; set `environment: "development"` explicitly for development enclaves.
 - `getAttestation`: Gets an attested session after enforcing the effective PCR0 trust policy.
 - `authenticate`: Authenticates an attestation document.
 - `parseAttestationForView`: Parses an attestation document for viewing.

--- a/rust/.env.example
+++ b/rust/.env.example
@@ -1,5 +1,7 @@
 # OpenSecret API Configuration
 VITE_OPEN_SECRET_API_URL=http://localhost:3000
+# PCR trust environment: production (default) or development
+VITE_OPEN_SECRET_PCR_ENVIRONMENT=production
 
 # Test credentials
 VITE_TEST_EMAIL=your-email@example.com

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -62,4 +62,4 @@ dotenv = "0.15"
 
 [features]
 default = []
-mock-attestation = []  # Enable mock attestation for development
+mock-attestation = []  # Expose mock document helpers; client bypass remains exact-loopback only

--- a/rust/README.md
+++ b/rust/README.md
@@ -26,7 +26,7 @@ http = "1"
 ## Quick Start
 
 ```rust
-use opensecret::{OpenSecretClient, Pcr0TrustPolicy, Result};
+use opensecret::{OpenSecretClient, Pcr0Environment, Pcr0TrustPolicy, Result};
 use uuid::Uuid;
 
 #[tokio::main]
@@ -53,8 +53,23 @@ async fn main() -> Result<()> {
 
 Production clients verify both the AWS Nitro attestation and the enclave's
 PCR0 deployment identity. `OpenSecretClient::new` uses pinned official PCR0
-values and OpenSecret's signed production and development histories. Custom
-deployments can add a static allowlist without replacing official trust:
+values and OpenSecret's signed production history. Development trust must be
+selected explicitly and checks only the development roots and signed history:
+
+```rust
+let development_client = OpenSecretClient::new_with_pcr0_environment(
+    "https://enclave.secretgpt.ai",
+    Pcr0Environment::Development,
+)?;
+```
+
+The API-key equivalent is
+`OpenSecretClient::new_with_api_key_and_pcr0_environment`. A signed PCR0 added
+to the selected GitHub history is accepted without a client update. Neither
+official policy falls back to the other environment.
+
+Custom deployments can add a static allowlist without replacing the selected
+official trust policy:
 
 ```rust
 let policy = Pcr0TrustPolicy::official().with_additional_pcr0s([
@@ -215,8 +230,12 @@ The SDK reads configuration from `.env.local` in the parent directory (OpenSecre
 Required environment variables in `.env.local`:
 ```bash
 VITE_OPEN_SECRET_API_URL=http://localhost:3000
+VITE_OPEN_SECRET_PCR_ENVIRONMENT=production
 VITE_TEST_CLIENT_ID=your-client-id-uuid
 ```
+
+Production is the default when `VITE_OPEN_SECRET_PCR_ENVIRONMENT` is omitted.
+Set it to `development` when the configured URL is a hosted development enclave.
 
 Run tests:
 ```bash

--- a/rust/src/attestation.rs
+++ b/rust/src/attestation.rs
@@ -27,19 +27,9 @@ pub struct AttestationDocument {
 /// authenticity alone does not identify an OpenSecret deployment. Production
 /// callers should use `OpenSecretClient`, which additionally enforces its
 /// configured `Pcr0TrustPolicy` before key exchange.
+#[derive(Default)]
 pub struct AttestationVerifier {
     expected_pcrs: Option<std::collections::HashMap<usize, Vec<u8>>>,
-    allow_debug: bool,
-}
-
-#[allow(clippy::derivable_impls)]
-impl Default for AttestationVerifier {
-    fn default() -> Self {
-        Self {
-            expected_pcrs: None,
-            allow_debug: cfg!(feature = "mock-attestation"),
-        }
-    }
 }
 
 impl AttestationVerifier {
@@ -294,11 +284,6 @@ impl AttestationVerifier {
     }
 
     fn verify_certificate_chain(&self, doc: &AttestationDocument) -> Result<()> {
-        // In mock mode, skip certificate verification
-        if self.allow_debug && doc.module_id.starts_with("mock-") {
-            return Ok(());
-        }
-
         // Step 1: Verify the first cert in cabundle matches AWS Nitro root
         if doc.cabundle.is_empty() {
             return Err(Error::AttestationVerificationFailed(
@@ -466,11 +451,6 @@ impl AttestationVerifier {
         signature_bytes: &[u8],
         doc: &AttestationDocument,
     ) -> Result<()> {
-        // In mock mode, skip signature verification
-        if self.allow_debug && doc.module_id.starts_with("mock-") {
-            return Ok(());
-        }
-
         // Parse the leaf certificate
         let (_, cert) = X509Certificate::from_der(&doc.certificate).map_err(|e| {
             Error::AttestationVerificationFailed(format!(
@@ -664,4 +644,21 @@ pub fn create_mock_attestation_document(nonce: &str) -> Result<String> {
 
     let cose_bytes = cbor::to_vec(&CborValue::Array(cose_sign1))?;
     Ok(BASE64.encode(cose_bytes))
+}
+
+#[cfg(all(test, feature = "mock-attestation"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_verifier_never_accepts_feature_gated_mock_documents() {
+        let nonce = "test-nonce";
+        let document = create_mock_attestation_document(nonce).unwrap();
+
+        let error = AttestationVerifier::new()
+            .verify_attestation_document(&document, nonce)
+            .unwrap_err();
+
+        assert!(matches!(error, Error::AttestationVerificationFailed(_)));
+    }
 }

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -3,7 +3,7 @@ use crate::{
     cbor::{self, Value as CborValue},
     crypto::{self},
     error::{Error, Result},
-    pcr::Pcr0TrustPolicy,
+    pcr::{Pcr0Environment, Pcr0TrustPolicy},
     session::SessionManager,
     types::*,
 };
@@ -424,11 +424,20 @@ fn uses_mock_attestation(base_url: &str) -> Result<bool> {
 }
 
 impl OpenSecretClient {
+    /// Construct a client using the official production PCR0 trust roots.
     pub fn new(base_url: impl Into<String>) -> Result<Self> {
-        Self::new_with_pcr0_trust_policy(base_url, Pcr0TrustPolicy::official())
+        Self::new_with_pcr0_environment(base_url, Pcr0Environment::default())
     }
 
-    /// Construct a client with an explicit production PCR0 trust policy.
+    /// Construct a client using one explicit official PCR0 environment.
+    pub fn new_with_pcr0_environment(
+        base_url: impl Into<String>,
+        pcr0_environment: Pcr0Environment,
+    ) -> Result<Self> {
+        Self::new_with_pcr0_trust_policy(base_url, Pcr0TrustPolicy::official_for(pcr0_environment))
+    }
+
+    /// Construct a client with an explicit PCR0 trust policy.
     pub fn new_with_pcr0_trust_policy(
         base_url: impl Into<String>,
         pcr0_trust_policy: Pcr0TrustPolicy,
@@ -446,11 +455,25 @@ impl OpenSecretClient {
         })
     }
 
+    /// Construct an API-key client using the official production PCR0 trust roots.
     pub fn new_with_api_key(base_url: impl Into<String>, api_key: String) -> Result<Self> {
-        Self::new_with_api_key_and_pcr0_trust_policy(base_url, api_key, Pcr0TrustPolicy::official())
+        Self::new_with_api_key_and_pcr0_environment(base_url, api_key, Pcr0Environment::default())
     }
 
-    /// Construct an API-key client with an explicit production PCR0 policy.
+    /// Construct an API-key client using one explicit official PCR0 environment.
+    pub fn new_with_api_key_and_pcr0_environment(
+        base_url: impl Into<String>,
+        api_key: String,
+        pcr0_environment: Pcr0Environment,
+    ) -> Result<Self> {
+        Self::new_with_api_key_and_pcr0_trust_policy(
+            base_url,
+            api_key,
+            Pcr0TrustPolicy::official_for(pcr0_environment),
+        )
+    }
+
+    /// Construct an API-key client with an explicit PCR0 trust policy.
     pub fn new_with_api_key_and_pcr0_trust_policy(
         base_url: impl Into<String>,
         api_key: String,
@@ -485,22 +508,40 @@ impl OpenSecretClient {
         let attestation_doc = self.get_attestation_document(&nonce).await?;
 
         // Step 2: Parse and verify attestation document
-        let doc = if !self.use_mock_attestation {
+        if !self.use_mock_attestation {
             let verifier = AttestationVerifier::new();
             let doc = verifier
                 .verify_attestation_document(&attestation_doc.attestation_document, &nonce)?;
-            let pcr0 = doc.pcrs.get(&0).ok_or_else(|| {
-                Error::AttestationVerificationFailed(
-                    "Missing PCR0 in attestation document".to_string(),
-                )
-            })?;
-            self.pcr0_trust_policy.verify_pcr0(pcr0).await?;
-            doc
+            self.establish_session_from_verified_attestation(&nonce, doc)
+                .await
         } else {
             // For mock mode, extract without full verification
-            self.parse_mock_attestation(&attestation_doc.attestation_document)?
-        };
+            let doc = self.parse_mock_attestation(&attestation_doc.attestation_document)?;
+            self.establish_session_from_document(&nonce, doc).await
+        }
+    }
 
+    /// Establish a session from a Nitro-authenticated document.
+    ///
+    /// Keeping PCR0 enforcement in the same path as key exchange makes the
+    /// fail-before-key-exchange ordering explicit and independently testable.
+    async fn establish_session_from_verified_attestation(
+        &self,
+        nonce: &str,
+        doc: AttestationDocument,
+    ) -> Result<()> {
+        let pcr0 = doc.pcrs.get(&0).ok_or_else(|| {
+            Error::AttestationVerificationFailed("Missing PCR0 in attestation document".to_string())
+        })?;
+        self.pcr0_trust_policy.verify_pcr0(pcr0).await?;
+        self.establish_session_from_document(nonce, doc).await
+    }
+
+    async fn establish_session_from_document(
+        &self,
+        nonce: &str,
+        doc: AttestationDocument,
+    ) -> Result<()> {
         let server_public_key = doc.public_key.ok_or_else(|| {
             Error::AttestationVerificationFailed(
                 "No public key in attestation document".to_string(),
@@ -508,8 +549,7 @@ impl OpenSecretClient {
         })?;
 
         // Step 3: Perform key exchange
-        self.perform_key_exchange(&nonce, &server_public_key)
-            .await?;
+        self.perform_key_exchange(nonce, &server_public_key).await?;
 
         Ok(())
     }
@@ -2513,6 +2553,23 @@ mod tests {
         Match, Mock, MockServer, Request, Respond, ResponseTemplate,
     };
 
+    const DEVELOPMENT_PCR0: &str =
+        "62c0407056217a4c10764ed9045694c29fa93255d3cc04c2f989cdd9a1f8050c8b169714c71f1118ebce2fcc9951d1a9";
+
+    fn synthetic_verified_attestation(pcr0: &str) -> AttestationDocument {
+        AttestationDocument {
+            module_id: "test-module".to_string(),
+            timestamp: 1,
+            digest: "SHA384".to_string(),
+            pcrs: HashMap::from([(0, hex::decode(pcr0).expect("valid test PCR0"))]),
+            certificate: Vec::new(),
+            cabundle: Vec::new(),
+            public_key: Some(vec![7; 32]),
+            user_data: None,
+            nonce: Some(b"test-nonce".to_vec()),
+        }
+    }
+
     struct MissingHeaderMatcher(&'static str);
 
     impl Match for MissingHeaderMatcher {
@@ -2852,6 +2909,60 @@ mod tests {
         let client = OpenSecretClient::new("http://localhost:3000").unwrap();
         assert_eq!(client.base_url, "http://localhost:3000");
         assert!(client.use_mock_attestation);
+    }
+
+    #[tokio::test]
+    async fn cross_environment_pcr0_fails_before_key_exchange() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/key_exchange"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let production_policy =
+            Pcr0TrustPolicy::official_for(Pcr0Environment::Production).without_remote_history();
+        let client =
+            OpenSecretClient::new_with_pcr0_trust_policy(mock_server.uri(), production_policy)
+                .unwrap();
+        let document = synthetic_verified_attestation(DEVELOPMENT_PCR0);
+
+        let error = client
+            .establish_session_from_verified_attestation("test-nonce", document)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, Error::AttestationVerificationFailed(_)));
+        assert!(client.get_session_id().unwrap().is_none());
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn development_environment_accepts_development_pcr0_before_key_exchange() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/key_exchange"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let client = OpenSecretClient::new_with_pcr0_environment(
+            mock_server.uri(),
+            Pcr0Environment::Development,
+        )
+        .unwrap();
+        let document = synthetic_verified_attestation(DEVELOPMENT_PCR0);
+
+        let error = client
+            .establish_session_from_verified_attestation("test-nonce", document)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, Error::Api { status: 500, .. }));
+        assert!(client.get_session_id().unwrap().is_none());
+        mock_server.verify().await;
     }
 
     #[test]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -10,6 +10,6 @@ pub mod types;
 
 pub use client::{InferenceRequest, InferenceResponse, OpenSecretClient, OpenSecretResponseBody};
 pub use error::{Error, Result};
-pub use pcr::Pcr0TrustPolicy;
+pub use pcr::{Pcr0Environment, Pcr0TrustPolicy};
 pub use push::*;
 pub use types::*;

--- a/rust/src/pcr.rs
+++ b/rust/src/pcr.rs
@@ -47,10 +47,22 @@ const OFFICIAL_DEVELOPMENT_PCR0S: &[&str] = &[
     "c4285443b87b9b12a6cea3bef1064ec060f652b235a297095975af8f134e5ed65f92d70d4616fdec80af9dff48bb9f35",
 ];
 
+/// OpenSecret deployment environment whose PCR0 trust roots should be used.
+///
+/// Production is the fail-closed default. Development must be selected
+/// explicitly by clients that connect to an OpenSecret development enclave.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Pcr0Environment {
+    #[default]
+    Production,
+    Development,
+}
+
 /// PCR0 deployment-identity policy enforced after Nitro document validation.
 ///
-/// The default policy trusts OpenSecret's pinned PCR0 values and falls back to
-/// the signed official production and development histories. Use
+/// The default policy trusts OpenSecret's pinned production PCR0 values and
+/// falls back to the signed official production history. Use
+/// [`Self::official_for`] to explicitly select development trust roots, or
 /// [`Self::from_static_allowlist`] for a custom deployment that must not use
 /// remote history.
 #[derive(Debug, Clone)]
@@ -60,20 +72,29 @@ pub struct Pcr0TrustPolicy {
 }
 
 impl Pcr0TrustPolicy {
-    /// Return the official OpenSecret policy used by default.
+    /// Return the official production policy used by default.
     pub fn official() -> Self {
-        let trusted_pcr0s = OFFICIAL_PRODUCTION_PCR0S
-            .iter()
-            .chain(OFFICIAL_DEVELOPMENT_PCR0S)
-            .map(|pcr0| (*pcr0).to_string())
-            .collect();
-        let remote_history_urls = [
-            OFFICIAL_PRODUCTION_PCR_HISTORY_URL,
-            OFFICIAL_DEVELOPMENT_PCR_HISTORY_URL,
-        ]
-        .into_iter()
-        .map(|url| Url::parse(url).expect("official PCR history URL must be valid"))
-        .collect();
+        Self::official_for(Pcr0Environment::Production)
+    }
+
+    /// Return the official policy for one explicit OpenSecret environment.
+    ///
+    /// The selected policy contains only that environment's pinned PCR0 roots
+    /// and signed history URL. It never falls back to the other environment.
+    pub fn official_for(environment: Pcr0Environment) -> Self {
+        let (pcr0s, remote_history_url) = match environment {
+            Pcr0Environment::Production => (
+                OFFICIAL_PRODUCTION_PCR0S,
+                OFFICIAL_PRODUCTION_PCR_HISTORY_URL,
+            ),
+            Pcr0Environment::Development => (
+                OFFICIAL_DEVELOPMENT_PCR0S,
+                OFFICIAL_DEVELOPMENT_PCR_HISTORY_URL,
+            ),
+        };
+        let trusted_pcr0s = pcr0s.iter().map(|pcr0| (*pcr0).to_string()).collect();
+        let remote_history_urls =
+            vec![Url::parse(remote_history_url).expect("official PCR history URL must be valid")];
 
         Self {
             trusted_pcr0s,
@@ -157,6 +178,11 @@ impl Pcr0TrustPolicy {
             return Err(Error::AttestationVerificationFailed(format!(
                 "PCR0 must be {PCR0_BYTES_LEN} bytes"
             )));
+        }
+        if pcr0.iter().all(|byte| *byte == 0) {
+            return Err(Error::AttestationVerificationFailed(
+                "PCR0 must not be all zero".to_string(),
+            ));
         }
         let pcr0_hex = hex::encode(pcr0);
         if self.trusted_pcr0s.contains(&pcr0_hex) {
@@ -302,6 +328,11 @@ fn validate_pcr0_hex(pcr0: &str) -> Result<()> {
             "PCR0 values must be 96 lowercase hexadecimal characters".to_string(),
         ));
     }
+    if pcr0.bytes().all(|byte| byte == b'0') {
+        return Err(Error::Configuration(
+            "PCR0 values must not be all zero".to_string(),
+        ));
+    }
     Ok(())
 }
 
@@ -347,6 +378,22 @@ mod tests {
         "3637534c33a8bafc5034d5763e441a481f161bbbe888e375ce14b016c7497dc4e550afe866bd8e65969b409d54766481";
     const SIGNED_PCR0_SIGNATURE: &str =
         "GZTXC0Xt0+yAaAatmMUd37pUJpF0nRAOj3Df9qxDOvDvRkiTF8UbGlzlL4kIOi/nd7dXAaEqYnY7OlpyngHBED2CSTpRRwV0xGo109epfqUKWWudrFaXpMsJ+GRKJLFO";
+    const UNKNOWN_PCR0: &str = concat!(
+        "1111111111111111",
+        "1111111111111111",
+        "1111111111111111",
+        "1111111111111111",
+        "1111111111111111",
+        "1111111111111111",
+    );
+    const ALL_ZERO_PCR0: &str = concat!(
+        "0000000000000000",
+        "0000000000000000",
+        "0000000000000000",
+        "0000000000000000",
+        "0000000000000000",
+        "0000000000000000",
+    );
 
     fn pcr_bytes(value: &str) -> Vec<u8> {
         hex::decode(value).unwrap()
@@ -361,6 +408,76 @@ mod tests {
             "signature": signature,
             "futureMetadata": { "release": "ignored" },
         }])
+    }
+
+    #[tokio::test]
+    async fn official_policy_defaults_to_production_only() {
+        let policy = Pcr0TrustPolicy::official();
+        let default_policy = Pcr0TrustPolicy::default();
+        let production_history =
+            Url::parse(OFFICIAL_PRODUCTION_PCR_HISTORY_URL).expect("valid production URL");
+
+        for candidate in [&policy, &default_policy] {
+            assert_eq!(
+                candidate.remote_history_urls,
+                vec![production_history.clone()]
+            );
+            assert_eq!(
+                candidate.trusted_pcr0s.len(),
+                OFFICIAL_PRODUCTION_PCR0S.len()
+            );
+            assert!(OFFICIAL_PRODUCTION_PCR0S
+                .iter()
+                .all(|pcr0| candidate.trusted_pcr0s.contains(*pcr0)));
+            assert!(OFFICIAL_DEVELOPMENT_PCR0S
+                .iter()
+                .all(|pcr0| !candidate.trusted_pcr0s.contains(*pcr0)));
+        }
+
+        let static_policy = policy.without_remote_history();
+        static_policy
+            .verify_pcr0(&pcr_bytes(OFFICIAL_PRODUCTION_PCR0S[0]))
+            .await
+            .unwrap();
+        assert!(static_policy
+            .verify_pcr0(&pcr_bytes(OFFICIAL_DEVELOPMENT_PCR0S[0]))
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn development_policy_excludes_production_trust() {
+        let policy = Pcr0TrustPolicy::official_for(Pcr0Environment::Development);
+        assert_eq!(
+            policy.remote_history_urls,
+            vec![Url::parse(OFFICIAL_DEVELOPMENT_PCR_HISTORY_URL).expect("valid development URL")]
+        );
+        assert_eq!(policy.trusted_pcr0s.len(), OFFICIAL_DEVELOPMENT_PCR0S.len());
+        assert!(OFFICIAL_DEVELOPMENT_PCR0S
+            .iter()
+            .all(|pcr0| policy.trusted_pcr0s.contains(*pcr0)));
+        assert!(OFFICIAL_PRODUCTION_PCR0S
+            .iter()
+            .all(|pcr0| !policy.trusted_pcr0s.contains(*pcr0)));
+
+        let static_policy = policy.without_remote_history();
+        static_policy
+            .verify_pcr0(&pcr_bytes(OFFICIAL_DEVELOPMENT_PCR0S[0]))
+            .await
+            .unwrap();
+        assert!(static_policy
+            .verify_pcr0(&pcr_bytes(OFFICIAL_PRODUCTION_PCR0S[0]))
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn all_zero_pcr0_is_never_trusted() {
+        assert!(Pcr0TrustPolicy::from_static_allowlist([ALL_ZERO_PCR0]).is_err());
+
+        let policy = Pcr0TrustPolicy::official().without_remote_history();
+        let error = policy.verify_pcr0(&[0; PCR0_BYTES_LEN]).await.unwrap_err();
+        assert!(matches!(error, Error::AttestationVerificationFailed(_)));
     }
 
     #[tokio::test]
@@ -383,7 +500,7 @@ mod tests {
             .expect(1)
             .mount(&server)
             .await;
-        let policy = Pcr0TrustPolicy::from_static_allowlist(["000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"])
+        let policy = Pcr0TrustPolicy::from_static_allowlist([UNKNOWN_PCR0])
             .unwrap()
             .with_remote_history_urls([format!("{}/history.json", server.uri())])
             .unwrap();
@@ -400,7 +517,7 @@ mod tests {
             .expect(1)
             .mount(&server)
             .await;
-        let policy = Pcr0TrustPolicy::from_static_allowlist(["000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"])
+        let policy = Pcr0TrustPolicy::from_static_allowlist([UNKNOWN_PCR0])
             .unwrap()
             .with_remote_history_urls([format!("{}/history.json", server.uri())])
             .unwrap();
@@ -426,7 +543,7 @@ mod tests {
             .expect(1)
             .mount(&server)
             .await;
-        let policy = Pcr0TrustPolicy::from_static_allowlist(["000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"])
+        let policy = Pcr0TrustPolicy::from_static_allowlist([UNKNOWN_PCR0])
             .unwrap()
             .with_remote_history_urls([format!("{}/history.json", server.uri())])
             .unwrap();
@@ -448,7 +565,7 @@ mod tests {
             .expect(0)
             .mount(&server)
             .await;
-        let policy = Pcr0TrustPolicy::from_static_allowlist(["000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"])
+        let policy = Pcr0TrustPolicy::from_static_allowlist([UNKNOWN_PCR0])
             .unwrap()
             .with_remote_history_urls([format!("{}/history.json", server.uri())])
             .unwrap();

--- a/rust/tests/account_management.rs
+++ b/rust/tests/account_management.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use opensecret::{OpenSecretClient, Result};
 use std::env;
 use uuid::Uuid;
@@ -16,7 +18,7 @@ async fn setup_client() -> Result<OpenSecretClient> {
 
     let base_url = env::var("VITE_OPEN_SECRET_API_URL")
         .unwrap_or_else(|_| "http://localhost:3000".to_string());
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
     Ok(client)
 }

--- a/rust/tests/agent_integration.rs
+++ b/rust/tests/agent_integration.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use futures::StreamExt;
 use opensecret::{
     AgentItemsListParams, AgentSseEvent, ConversationItem, CreateSubagentRequest,
@@ -25,7 +27,7 @@ async fn setup_authenticated_client() -> Result<OpenSecretClient> {
 
     let base_url = env::var("VITE_OPEN_SECRET_API_URL")
         .unwrap_or_else(|_| "http://localhost:3000".to_string());
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
 
     let email = env::var("VITE_TEST_EMAIL").expect("VITE_TEST_EMAIL must be set");

--- a/rust/tests/ai_integration.rs
+++ b/rust/tests/ai_integration.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use base64::{engine::general_purpose, Engine as _};
 use futures::StreamExt;
 use opensecret::{
@@ -63,7 +65,7 @@ async fn setup_authenticated_client() -> Result<OpenSecretClient> {
 
     let base_url = env::var("VITE_OPEN_SECRET_API_URL")
         .unwrap_or_else(|_| "http://localhost:3000".to_string());
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
 
     // Login with test credentials
@@ -357,7 +359,7 @@ async fn test_guest_user_cannot_use_ai() {
         .and_then(|id| Uuid::parse_str(&id).ok())
         .unwrap_or_else(Uuid::new_v4);
 
-    let client = OpenSecretClient::new(base_url).expect("Failed to create client");
+    let client = common::new_test_client(base_url).expect("Failed to create client");
     client
         .perform_attestation_handshake()
         .await

--- a/rust/tests/api_integration.rs
+++ b/rust/tests/api_integration.rs
@@ -1,4 +1,6 @@
-use opensecret::{KeyOptions, OpenSecretClient, Result, SigningAlgorithm};
+mod common;
+
+use opensecret::{KeyOptions, Result, SigningAlgorithm};
 use uuid::Uuid;
 
 #[tokio::test]
@@ -21,7 +23,7 @@ async fn test_user_profile_api() -> Result<()> {
         std::env::var("VITE_TEST_PASSWORD").expect("VITE_TEST_PASSWORD must be set");
 
     // Create client and login
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
 
     // Try to login, register if it fails
@@ -61,7 +63,7 @@ async fn test_kv_storage_apis() -> Result<()> {
         .expect("VITE_TEST_CLIENT_ID must be set");
 
     // Create client and login as guest for isolation
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
 
     let guest_password = "test_kv_password";
@@ -116,7 +118,7 @@ async fn test_kv_delete_all() -> Result<()> {
         .expect("VITE_TEST_CLIENT_ID must be set");
 
     // Create client and login as guest for isolation
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
 
     client
@@ -161,7 +163,7 @@ async fn test_kv_storage_with_special_characters() -> Result<()> {
         .expect("VITE_TEST_CLIENT_ID must be set");
 
     // Create client and login
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
     client
         .register_guest("test_kv_special".to_string(), client_id)
@@ -226,7 +228,7 @@ async fn test_private_key_generation() -> Result<()> {
         .expect("VITE_TEST_CLIENT_ID must be set");
 
     // Create client and login as guest
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
     client
         .register_guest("test_key_gen".to_string(), client_id)
@@ -277,7 +279,7 @@ async fn test_message_signing() -> Result<()> {
         .expect("VITE_TEST_CLIENT_ID must be set");
 
     // Create client and login
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
     client
         .register_guest("test_signing".to_string(), client_id)
@@ -331,7 +333,7 @@ async fn test_public_key_retrieval() -> Result<()> {
         .expect("VITE_TEST_CLIENT_ID must be set");
 
     // Create client and login
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
     client
         .register_guest("test_pubkey".to_string(), client_id)
@@ -384,7 +386,7 @@ async fn test_encryption_decryption() -> Result<()> {
         .expect("VITE_TEST_CLIENT_ID must be set");
 
     // Create client and login
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
     client
         .register_guest("test_crypto".to_string(), client_id)
@@ -482,7 +484,7 @@ async fn test_third_party_token() -> Result<()> {
         std::env::var("VITE_TEST_PASSWORD").expect("VITE_TEST_PASSWORD must be set");
 
     // Create client and login with email user (third party tokens may require email user)
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
 
     let _ = match client

--- a/rust/tests/api_keys.rs
+++ b/rust/tests/api_keys.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use opensecret::{Error, OpenSecretClient, Result};
 use std::env;
 use uuid::Uuid;
@@ -45,7 +47,7 @@ fn is_live_ai_usage_limit(error: &Error) -> bool {
 async fn setup_test_client() -> Result<OpenSecretClient> {
     let (api_url, email, password, client_id) = get_test_config();
 
-    let client = OpenSecretClient::new(&api_url)?;
+    let client = common::new_test_client(&api_url)?;
     client.perform_attestation_handshake().await?;
     client.login(email, password, client_id).await?;
 
@@ -92,7 +94,7 @@ async fn test_api_key_authentication() -> Result<()> {
     let (api_url, email, password, client_id) = get_test_config();
 
     // First create an API key using regular auth
-    let client = OpenSecretClient::new(&api_url)?;
+    let client = common::new_test_client(&api_url)?;
     client.perform_attestation_handshake().await?;
     client.login(email, password, client_id).await?;
 
@@ -102,7 +104,7 @@ async fn test_api_key_authentication() -> Result<()> {
     let api_key_name = created_key.name.clone();
 
     // Now create a new client with just the API key
-    let api_client = OpenSecretClient::new_with_api_key(&api_url, api_key.clone())?;
+    let api_client = common::new_test_client_with_api_key(&api_url, api_key.clone())?;
     api_client.perform_attestation_handshake().await?;
 
     // Test fetching models with API key authentication
@@ -133,7 +135,7 @@ async fn test_streaming_chat_with_api_key() -> Result<()> {
     let (api_url, email, password, client_id) = get_test_config();
 
     // First create an API key using regular auth
-    let client = OpenSecretClient::new(&api_url)?;
+    let client = common::new_test_client(&api_url)?;
     client.perform_attestation_handshake().await?;
     client.login(email, password, client_id).await?;
 
@@ -143,7 +145,7 @@ async fn test_streaming_chat_with_api_key() -> Result<()> {
     let api_key_name = created_key.name.clone();
 
     // Create a new client with the API key
-    let api_client = OpenSecretClient::new_with_api_key(&api_url, api_key)?;
+    let api_client = common::new_test_client_with_api_key(&api_url, api_key)?;
     api_client.perform_attestation_handshake().await?;
 
     // Test streaming chat completion
@@ -232,7 +234,7 @@ async fn test_invalid_api_key_fails() -> Result<()> {
 
     // Create a client with an invalid API key
     let invalid_key = "550e8400-e29b-41d4-a716-000000000000".to_string();
-    let api_client = OpenSecretClient::new_with_api_key(&api_url, invalid_key)?;
+    let api_client = common::new_test_client_with_api_key(&api_url, invalid_key)?;
     api_client.perform_attestation_handshake().await?;
 
     // This should fail with authentication error

--- a/rust/tests/attestation.rs
+++ b/rust/tests/attestation.rs
@@ -1,4 +1,6 @@
-use opensecret::{OpenSecretClient, Result};
+mod common;
+
+use opensecret::{Error, OpenSecretClient, Pcr0Environment, Result};
 use std::env;
 
 #[tokio::test]
@@ -12,7 +14,7 @@ async fn test_attestation_handshake_localhost() -> Result<()> {
         return Ok(());
     }
 
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
 
     // Perform attestation handshake with mock attestation
     client.perform_attestation_handshake().await?;
@@ -28,22 +30,23 @@ async fn test_attestation_handshake_localhost() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_attestation_handshake_production() -> Result<()> {
+async fn test_attestation_handshake_hosted_selected_environment() -> Result<()> {
     // Try to load .env.local if it exists (for local testing)
     if std::path::Path::new("../.env.local").exists() {
         dotenv::from_path("../.env.local").ok();
     }
 
-    // This test requires VITE_OPEN_SECRET_API_URL to be set to a production endpoint
+    // This test requires VITE_OPEN_SECRET_API_URL to be set to a hosted endpoint.
     let base_url = env::var("VITE_OPEN_SECRET_API_URL")
         .unwrap_or_else(|_| "http://localhost:3000".to_string());
 
     if base_url.contains("localhost") || base_url.contains("127.0.0.1") {
-        println!("Skipping production attestation test - running against localhost");
+        println!("Skipping hosted attestation test - running against localhost");
         return Ok(());
     }
 
-    let client = OpenSecretClient::new(base_url.clone())?;
+    let pcr0_environment = common::selected_pcr0_environment()?;
+    let client = common::new_test_client(base_url.clone())?;
 
     // Perform attestation handshake with real AWS Nitro attestation
     client.perform_attestation_handshake().await?;
@@ -54,9 +57,34 @@ async fn test_attestation_handshake_production() -> Result<()> {
         .expect("Session ID should be set after successful handshake");
 
     assert!(!session_id.to_string().is_empty());
-    println!("✅ Production attestation successful against {}", base_url);
+    println!(
+        "✅ Hosted {:?} attestation successful against {}",
+        pcr0_environment, base_url
+    );
     println!("   Session ID: {}", session_id);
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_hosted_development_rejects_default_production_policy() -> Result<()> {
+    let base_url = env::var("VITE_OPEN_SECRET_API_URL")
+        .unwrap_or_else(|_| "http://localhost:3000".to_string());
+
+    if base_url.contains("localhost") || base_url.contains("127.0.0.1") {
+        println!("Skipping hosted policy-separation test - running against localhost");
+        return Ok(());
+    }
+    if common::selected_pcr0_environment()? != Pcr0Environment::Development {
+        println!("Skipping hosted development policy-separation test");
+        return Ok(());
+    }
+
+    let client = OpenSecretClient::new(base_url)?;
+    let error = client.perform_attestation_handshake().await.unwrap_err();
+
+    assert!(matches!(error, Error::AttestationVerificationFailed(_)));
+    assert!(client.get_session_id()?.is_none());
     Ok(())
 }
 
@@ -65,14 +93,14 @@ async fn test_attestation_nonce_verification() -> Result<()> {
     let base_url = env::var("VITE_OPEN_SECRET_API_URL")
         .unwrap_or_else(|_| "http://localhost:3000".to_string());
 
-    let client = OpenSecretClient::new(base_url.clone())?;
+    let client = common::new_test_client(base_url.clone())?;
 
     // The handshake should generate a unique nonce internally
     client.perform_attestation_handshake().await?;
     let first_session = client.get_session_id()?.expect("Should have session");
 
     // Create a new client and do another handshake - should get different session
-    let client2 = OpenSecretClient::new(base_url)?;
+    let client2 = common::new_test_client(base_url)?;
     client2.perform_attestation_handshake().await?;
     let second_session = client2.get_session_id()?.expect("Should have session");
 
@@ -90,7 +118,7 @@ async fn test_connection_health_check() -> Result<()> {
     let base_url = env::var("VITE_OPEN_SECRET_API_URL")
         .unwrap_or_else(|_| "http://localhost:3000".to_string());
 
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
 
     // Test basic connection without attestation
     let response = client.test_connection().await?;

--- a/rust/tests/auth_integration.rs
+++ b/rust/tests/auth_integration.rs
@@ -1,4 +1,6 @@
-use opensecret::{OpenSecretClient, Result};
+mod common;
+
+use opensecret::Result;
 use uuid::Uuid;
 
 #[tokio::test]
@@ -24,7 +26,7 @@ async fn test_login_signup_flow() -> Result<()> {
         });
 
     // Create client
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
 
     // Perform attestation handshake first
     println!("Performing attestation handshake...");
@@ -140,7 +142,7 @@ async fn test_login_signup_flow() -> Result<()> {
 async fn test_session_management() -> Result<()> {
     let base_url = std::env::var("VITE_OPEN_SECRET_API_URL")
         .unwrap_or_else(|_| "http://localhost:3000".to_string());
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
 
     // Should have no session initially
     assert!(client.get_session_id()?.is_none());

--- a/rust/tests/bip85_integration.rs
+++ b/rust/tests/bip85_integration.rs
@@ -1,4 +1,6 @@
-use opensecret::{KeyOptions, OpenSecretClient, Result, SigningAlgorithm};
+mod common;
+
+use opensecret::{KeyOptions, Result, SigningAlgorithm};
 use uuid::Uuid;
 
 // BIP-85 test constants (matching TypeScript tests)
@@ -22,7 +24,7 @@ async fn test_bip85_derive_child_mnemonic() -> Result<()> {
         .expect("VITE_TEST_CLIENT_ID must be set");
 
     // Create client and login
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
     client
         .register_guest("test_bip85".to_string(), client_id)
@@ -77,7 +79,7 @@ async fn test_bip85_private_key_bytes() -> Result<()> {
         .expect("VITE_TEST_CLIENT_ID must be set");
 
     // Create client and login
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
     client
         .register_guest("test_bip85_bytes".to_string(), client_id)
@@ -133,7 +135,7 @@ async fn test_bip85_public_key_derivation() -> Result<()> {
         .expect("VITE_TEST_CLIENT_ID must be set");
 
     // Create client and login
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
     client
         .register_guest("test_bip85_pubkey".to_string(), client_id)
@@ -191,7 +193,7 @@ async fn test_bip85_message_signing() -> Result<()> {
         .expect("VITE_TEST_CLIENT_ID must be set");
 
     // Create client and login
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
     client
         .register_guest("test_bip85_signing".to_string(), client_id)
@@ -259,7 +261,7 @@ async fn test_bip85_encryption_decryption() -> Result<()> {
         .expect("VITE_TEST_CLIENT_ID must be set");
 
     // Create client and login
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
     client
         .register_guest("test_bip85_encrypt".to_string(), client_id)

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -1,0 +1,46 @@
+#![allow(dead_code)]
+
+use opensecret::{Error, OpenSecretClient, Pcr0Environment, Result};
+use std::env::{self, VarError};
+
+const PCR_ENVIRONMENT_VARIABLE: &str = "VITE_OPEN_SECRET_PCR_ENVIRONMENT";
+const PCR_ENVIRONMENT_ERROR: &str =
+    "VITE_OPEN_SECRET_PCR_ENVIRONMENT must be either \"production\" or \"development\"";
+
+pub fn parse_pcr0_environment(
+    value: Option<&str>,
+) -> std::result::Result<Pcr0Environment, &'static str> {
+    match value {
+        None | Some("production") => Ok(Pcr0Environment::Production),
+        Some("development") => Ok(Pcr0Environment::Development),
+        Some(_) => Err(PCR_ENVIRONMENT_ERROR),
+    }
+}
+
+pub fn selected_pcr0_environment() -> Result<Pcr0Environment> {
+    let configured = match env::var(PCR_ENVIRONMENT_VARIABLE) {
+        Ok(value) => Some(value),
+        Err(VarError::NotPresent) => None,
+        Err(VarError::NotUnicode(_)) => {
+            return Err(Error::Configuration(PCR_ENVIRONMENT_ERROR.to_string()));
+        }
+    };
+
+    parse_pcr0_environment(configured.as_deref())
+        .map_err(|message| Error::Configuration(message.to_string()))
+}
+
+pub fn new_test_client(base_url: impl Into<String>) -> Result<OpenSecretClient> {
+    OpenSecretClient::new_with_pcr0_environment(base_url, selected_pcr0_environment()?)
+}
+
+pub fn new_test_client_with_api_key(
+    base_url: impl Into<String>,
+    api_key: String,
+) -> Result<OpenSecretClient> {
+    OpenSecretClient::new_with_api_key_and_pcr0_environment(
+        base_url,
+        api_key,
+        selected_pcr0_environment()?,
+    )
+}

--- a/rust/tests/integration.rs
+++ b/rust/tests/integration.rs
@@ -1,4 +1,6 @@
-use opensecret::{OpenSecretClient, Result};
+mod common;
+
+use opensecret::Result;
 use std::env;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -7,7 +9,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 async fn test_client_initialization() -> Result<()> {
     let base_url = env::var("VITE_OPEN_SECRET_API_URL")
         .unwrap_or_else(|_| "http://localhost:3000".to_string());
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     assert!(client.get_session_id()?.is_none());
     Ok(())
 }
@@ -26,7 +28,7 @@ async fn test_health_check_mock() -> Result<()> {
         .mount(&mock_server)
         .await;
 
-    let client = OpenSecretClient::new(mock_server.uri())?;
+    let client = common::new_test_client(mock_server.uri())?;
     let response = client.test_connection().await?;
 
     assert!(response.contains("healthy"));
@@ -45,7 +47,7 @@ async fn test_full_flow_with_real_server() -> Result<()> {
 
     println!("Testing against: {}", base_url);
 
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
 
     // 1. Test connection
     let health = client.test_connection().await?;

--- a/rust/tests/pcr_environment.rs
+++ b/rust/tests/pcr_environment.rs
@@ -1,0 +1,31 @@
+mod common;
+
+use common::parse_pcr0_environment;
+use opensecret::Pcr0Environment;
+
+#[test]
+fn pcr_environment_defaults_to_production() {
+    assert_eq!(
+        parse_pcr0_environment(None).unwrap(),
+        Pcr0Environment::Production
+    );
+}
+
+#[test]
+fn pcr_environment_accepts_exact_supported_values() {
+    assert_eq!(
+        parse_pcr0_environment(Some("production")).unwrap(),
+        Pcr0Environment::Production
+    );
+    assert_eq!(
+        parse_pcr0_environment(Some("development")).unwrap(),
+        Pcr0Environment::Development
+    );
+}
+
+#[test]
+fn pcr_environment_rejects_empty_differently_cased_and_unknown_values() {
+    for value in ["", "Production", "dev", " development "] {
+        assert!(parse_pcr0_environment(Some(value)).is_err());
+    }
+}

--- a/rust/tests/session.rs
+++ b/rust/tests/session.rs
@@ -1,4 +1,6 @@
-use opensecret::{OpenSecretClient, Result};
+mod common;
+
+use opensecret::Result;
 use std::env;
 
 #[tokio::test]
@@ -6,7 +8,7 @@ async fn test_session_establishment() -> Result<()> {
     let base_url = env::var("VITE_OPEN_SECRET_API_URL")
         .unwrap_or_else(|_| "http://localhost:3000".to_string());
 
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
 
     // Initially should have no session
     assert!(

--- a/rust/tests/web_integration.rs
+++ b/rust/tests/web_integration.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use opensecret::{OpenSecretClient, Result, WebExtractRequest, WebSearchRequest};
 use uuid::Uuid;
 
@@ -11,7 +13,7 @@ async fn authenticated_client() -> Result<OpenSecretClient> {
         .parse::<Uuid>()
         .expect("VITE_TEST_CLIENT_ID must be a UUID");
 
-    let client = OpenSecretClient::new(base_url)?;
+    let client = common::new_test_client(base_url)?;
     client.perform_attestation_handshake().await?;
 
     if client

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -8,7 +8,7 @@ export interface CustomFetchOptions {
   apiKey?: string;
   /** API URL used for attestation; required outside OpenSecretProvider. */
   apiUrl?: string;
-  /** PCR0 trust policy enforced before non-loopback session key exchange. */
+  /** PCR0 trust policy enforced before non-loopback session key exchange; defaults to production. */
   pcrConfig?: PcrConfig;
 }
 

--- a/src/lib/developer.tsx
+++ b/src/lib/developer.tsx
@@ -12,7 +12,7 @@ import {
 import type { AttestationDocument } from "./attestation";
 import { PcrConfig } from "./pcr";
 
-const DEFAULT_PCR_CONFIG: PcrConfig = {};
+const DEFAULT_PCR_CONFIG: PcrConfig = { environment: "production" };
 import type {
   Organization,
   Project,
@@ -179,7 +179,8 @@ export type OpenSecretDeveloperContextType = {
   refetchDeveloper: () => Promise<void>;
 
   /**
-   * PCR0 trust policy enforced before every non-loopback session key exchange
+   * PCR0 trust policy enforced before every non-loopback session key exchange.
+   * The trust environment defaults to production.
    */
   pcrConfig: PcrConfig;
 
@@ -467,7 +468,7 @@ export const OpenSecretDeveloperContext = createContext<OpenSecretDeveloperConte
   requestPasswordReset: platformApi.requestPlatformPasswordReset,
   confirmPasswordReset: platformApi.confirmPlatformPasswordReset,
   changePassword: platformApi.changePlatformPassword,
-  pcrConfig: {},
+  pcrConfig: DEFAULT_PCR_CONFIG,
   getAttestation,
   authenticate,
   parseAttestationForView,
@@ -511,7 +512,7 @@ export const OpenSecretDeveloperContext = createContext<OpenSecretDeveloperConte
  * @param props - Configuration properties for the OpenSecret developer provider
  * @param props.children - React child components to be wrapped by the provider
  * @param props.apiUrl - URL of OpenSecret developer API
- * @param props.pcrConfig - Optional PCR0 trust policy enforced before session establishment
+ * @param props.pcrConfig - Optional PCR0 trust policy enforced before session establishment; its environment defaults to production
  *
  * @example
  * ```tsx

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -143,7 +143,7 @@ export type {
 } from "./developer";
 export type { AttestationDocument } from "./attestation";
 export type { ParsedAttestationView } from "./attestationForView";
-export type { PcrConfig, Pcr0ValidationResult } from "./pcr";
+export type { PcrConfig, PcrEnvironment, Pcr0ValidationResult } from "./pcr";
 
 // Export crypto utilities
 // TODO: these can actually just be used internally by the password reset function

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -14,7 +14,7 @@ import type { AttestationDocument } from "./attestation";
 import type { LoginResponse, ThirdPartyTokenResponse, DocumentResponse } from "./api";
 import { PcrConfig } from "./pcr";
 
-const DEFAULT_PCR_CONFIG: PcrConfig = {};
+const DEFAULT_PCR_CONFIG: PcrConfig = { environment: "production" };
 
 export type OpenSecretAuthState = {
   loading: boolean;
@@ -352,7 +352,8 @@ export type OpenSecretContextType = {
   apiUrl: string;
 
   /**
-   * PCR0 trust policy enforced before every non-loopback session key exchange
+   * PCR0 trust policy enforced before every non-loopback session key exchange.
+   * The trust environment defaults to production.
    */
   pcrConfig: PcrConfig;
 
@@ -942,7 +943,7 @@ export const OpenSecretContext = createContext<OpenSecretContextType>({
   signMessage: api.signMessage,
   aiCustomFetch: async () => new Response(),
   apiUrl: "",
-  pcrConfig: {},
+  pcrConfig: DEFAULT_PCR_CONFIG,
   getAttestation,
   authenticate,
   parseAttestationForView,
@@ -1000,7 +1001,7 @@ export const OpenSecretContext = createContext<OpenSecretContextType>({
  * @param props.children - React child components to be wrapped by the provider
  * @param props.apiUrl - URL of OpenSecret enclave backend
  * @param props.clientId - UUID identifying which project/tenant this instance belongs to
- * @param props.pcrConfig - Optional PCR0 trust policy enforced before session establishment
+ * @param props.pcrConfig - Optional PCR0 trust policy enforced before session establishment; its environment defaults to production
  *
  * @remarks
  * This provider manages:

--- a/src/lib/pcr.ts
+++ b/src/lib/pcr.ts
@@ -86,18 +86,29 @@ export type Pcr0ValidationResult = {
   verifiedAt?: string;
 };
 
+/** The OpenSecret deployment environment whose PCR0 roots are trusted. */
+export type PcrEnvironment = "production" | "development";
+
 /**
  * Configuration options for PCR validation
  */
 export type PcrConfig = {
   /**
+   * OpenSecret deployment environment to trust (defaults to production).
+   * Only this environment's embedded roots, additional roots, and signed
+   * history are considered during session establishment.
+   */
+  environment?: PcrEnvironment;
+  /**
    * Additional trusted PCR0 values for production environments.
-   * The SDK's built-in production trust roots always remain trusted.
+   * These and the SDK's built-in production roots are considered only when
+   * `environment` is `"production"`.
    */
   pcr0Values?: string[];
   /**
    * Additional trusted PCR0 values for development environments.
-   * The SDK's built-in development trust roots always remain trusted.
+   * These and the SDK's built-in development roots are considered only when
+   * `environment` is `"development"`.
    */
   pcr0DevValues?: string[];
   /**
@@ -105,7 +116,7 @@ export type PcrConfig = {
    * (defaults to true). This does not enable or disable Nitro attestation verification.
    */
   remoteAttestation?: boolean;
-  /** Custom URLs for pinned-key signed PCR history */
+  /** Custom URLs for pinned-key signed PCR history. Only the selected environment is fetched. */
   remoteAttestationUrls?: {
     /** URL for production PCR history */
     prod?: string;
@@ -157,21 +168,23 @@ async function readBoundedUtf8Body(response: Response, maxBytes: number): Promis
 }
 
 type CanonicalPcrConfig = {
-  version: "pcr0-union-v1";
+  version: "pcr0-environment-v1";
+  environment: PcrEnvironment;
   verificationKey: string;
   defaultPcr0Values: string[];
-  defaultPcr0DevValues: string[];
   pcr0Values: string[];
-  pcr0DevValues: string[];
   remoteAttestation: boolean;
-  remoteAttestationUrls: {
-    prod: string;
-    dev: string;
-  };
+  remoteAttestationUrl: string;
 };
 
 function normalizedValues(values: string[] | undefined): string[] {
   return [...new Set((values || []).map((value) => value.trim().toLowerCase()))].sort();
+}
+
+function normalizePcrEnvironment(environment: unknown): PcrEnvironment {
+  if (environment === undefined || environment === "production") return "production";
+  if (environment === "development") return "development";
+  throw new TypeError('PCR environment must be either "production" or "development".');
 }
 
 /**
@@ -180,6 +193,7 @@ function normalizedValues(values: string[] | undefined): string[] {
  */
 export function snapshotPcrConfig(config?: PcrConfig): PcrConfig {
   return {
+    environment: normalizePcrEnvironment(config?.environment),
     pcr0Values: normalizedValues(config?.pcr0Values),
     pcr0DevValues: normalizedValues(config?.pcr0DevValues),
     remoteAttestation: config?.remoteAttestation !== false,
@@ -193,18 +207,18 @@ export function snapshotPcrConfig(config?: PcrConfig): PcrConfig {
 /** Stable representation used to bind cached sessions to their trust policy. */
 export function serializePcrConfig(config?: PcrConfig): string {
   const snapshot = snapshotPcrConfig(config);
+  const environment = snapshot.environment || "production";
+  const development = environment === "development";
   const canonical: CanonicalPcrConfig = {
-    version: "pcr0-union-v1",
+    version: "pcr0-environment-v1",
+    environment,
     verificationKey: PCR_VERIFICATION_PUBLIC_KEY_B64,
-    defaultPcr0Values: [...DEFAULT_PCR0_VALUES].sort(),
-    defaultPcr0DevValues: [...DEFAULT_PCR0_VALUES_DEV].sort(),
-    pcr0Values: snapshot.pcr0Values || [],
-    pcr0DevValues: snapshot.pcr0DevValues || [],
+    defaultPcr0Values: [...(development ? DEFAULT_PCR0_VALUES_DEV : DEFAULT_PCR0_VALUES)].sort(),
+    pcr0Values: development ? snapshot.pcr0DevValues || [] : snapshot.pcr0Values || [],
     remoteAttestation: snapshot.remoteAttestation !== false,
-    remoteAttestationUrls: {
-      prod: snapshot.remoteAttestationUrls?.prod || PCR_HISTORY_URLS.prod,
-      dev: snapshot.remoteAttestationUrls?.dev || PCR_HISTORY_URLS.dev
-    }
+    remoteAttestationUrl: development
+      ? snapshot.remoteAttestationUrls?.dev || PCR_HISTORY_URLS.dev
+      : snapshot.remoteAttestationUrls?.prod || PCR_HISTORY_URLS.prod
   };
 
   return JSON.stringify(canonical);
@@ -457,21 +471,15 @@ export async function validatePcr0Hash(
 ): Promise<Pcr0ValidationResult> {
   const normalizedHash = hash.trim().toLowerCase();
   const snapshot = snapshotPcrConfig(config);
-  // First check against local values
-  const validPcr0Values = [...(snapshot.pcr0Values || []), ...DEFAULT_PCR0_VALUES];
-  const validPcr0DevValues = [...(snapshot.pcr0DevValues || []), ...DEFAULT_PCR0_VALUES_DEV];
+  const development = snapshot.environment === "development";
+  const validPcr0Values = development
+    ? [...(snapshot.pcr0DevValues || []), ...DEFAULT_PCR0_VALUES_DEV]
+    : [...(snapshot.pcr0Values || []), ...DEFAULT_PCR0_VALUES];
 
   if (validPcr0Values.includes(normalizedHash)) {
     return {
       isMatch: true,
-      text: "PCR0 matches a known good value"
-    };
-  }
-
-  if (validPcr0DevValues.includes(normalizedHash)) {
-    return {
-      isMatch: true,
-      text: "PCR0 matches development enclave"
+      text: development ? "PCR0 matches development enclave" : "PCR0 matches a known good value"
     };
   }
 
@@ -480,27 +488,13 @@ export async function validatePcr0Hash(
 
   if (remoteAttestationEnabled) {
     try {
-      // Try prod first
-      const prodResult = await validatePcrAgainstRemoteHistory(
+      const remoteResult = await validatePcrAgainstRemoteHistory(
         normalizedHash,
-        "prod",
+        development ? "dev" : "prod",
         snapshot.remoteAttestationUrls
       );
 
-      if (prodResult) {
-        return prodResult;
-      }
-
-      // Try dev if prod didn't match
-      const devResult = await validatePcrAgainstRemoteHistory(
-        normalizedHash,
-        "dev",
-        snapshot.remoteAttestationUrls
-      );
-
-      if (devResult) {
-        return devResult;
-      }
+      if (remoteResult) return remoteResult;
     } catch (error) {
       console.error("Error during remote PCR validation:", error);
       // We continue with default behavior if remote validation fails

--- a/src/lib/test/api-url-loader.ts
+++ b/src/lib/test/api-url-loader.ts
@@ -1,13 +1,16 @@
 import { setApiUrl } from "../api";
+import { parseTestPcrEnvironment } from "./testPcrEnvironment";
 
 // Get the API URL from environment variables
 const apiUrl = process.env.VITE_OPEN_SECRET_API_URL;
+const pcrEnvironment = parseTestPcrEnvironment(process.env.VITE_OPEN_SECRET_PCR_ENVIRONMENT);
 
 if (!apiUrl) {
   throw new Error("VITE_OPEN_SECRET_API_URL must be set in environment variables");
 }
 
-// Set the API URL before tests run
-setApiUrl(apiUrl);
+// Bind the hosted endpoint to one explicit PCR trust environment before tests run.
+setApiUrl(apiUrl, { environment: pcrEnvironment });
 
 console.log("API URL set to:", apiUrl);
+console.log("PCR trust environment set to:", pcrEnvironment);

--- a/src/lib/test/customFetch.test.ts
+++ b/src/lib/test/customFetch.test.ts
@@ -352,12 +352,14 @@ describe("createCustomFetch stale-session recovery", () => {
   test("forwards one endpoint-bound PCR policy through lookup and renewal", async () => {
     const apiUrl = "https://enclave.example.test/base";
     const pcrConfig: PcrConfig = {
-      pcr0Values: ["2a".repeat(48)],
+      environment: "development",
+      pcr0DevValues: ["2a".repeat(48)],
       remoteAttestation: false
     };
     const expectedPcrConfig: PcrConfig = {
-      pcr0Values: ["2a".repeat(48)],
-      pcr0DevValues: [],
+      environment: "development",
+      pcr0Values: [],
+      pcr0DevValues: ["2a".repeat(48)],
       remoteAttestation: false,
       remoteAttestationUrls: {
         prod: "https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrProdHistory.json",
@@ -377,7 +379,8 @@ describe("createCustomFetch stale-session recovery", () => {
         },
         fetch: async (_input, init) => {
           if (recordRequest(init).sessionId === staleAttestation.sessionId) {
-            pcrConfig.pcr0Values = ["4c".repeat(48)];
+            pcrConfig.environment = "production";
+            pcrConfig.pcr0DevValues = ["4c".repeat(48)];
             pcrConfig.remoteAttestation = true;
             return new Response("stale", { status: 400 });
           }
@@ -432,6 +435,7 @@ describe("createCustomFetch stale-session recovery", () => {
       expect(calls[0][0]).toBe(false);
       expect(calls[0][1]).toBe(apiUrl);
       expect(calls[0][2]).toEqual(expect.objectContaining(pcrConfig));
+      expect(calls[0][2]?.environment).toBe("production");
     } finally {
       setApiUrl(originalApiUrl, originalPcrConfig);
     }

--- a/src/lib/test/getAttestationSecurity.test.ts
+++ b/src/lib/test/getAttestationSecurity.test.ts
@@ -166,7 +166,7 @@ describe("attested session establishment", () => {
 
     expect(validatePcr0Hash).toHaveBeenCalledWith(
       bytesToHex(TRUSTED_PCR0),
-      expect.objectContaining(PCR_CONFIG)
+      expect.objectContaining({ ...PCR_CONFIG, environment: "production" })
     );
     expect(keyExchange).not.toHaveBeenCalled();
     expect(window.sessionStorage.length).toBe(0);
@@ -193,7 +193,7 @@ describe("attested session establishment", () => {
     expect(validatePcr0Hash).toHaveBeenCalledTimes(1);
     expect(validatePcr0Hash).toHaveBeenCalledWith(
       bytesToHex(TRUSTED_PCR0),
-      expect.objectContaining(PCR_CONFIG)
+      expect.objectContaining({ ...PCR_CONFIG, environment: "production" })
     );
     expect(keyExchange).toHaveBeenCalledTimes(1);
     expect(
@@ -231,6 +231,73 @@ describe("attested session establishment", () => {
 
     expect(verifyAttestation).toHaveBeenCalledTimes(1);
     expect(keyExchange).not.toHaveBeenCalled();
+  });
+
+  test("production and development use distinct session cache scopes", async () => {
+    const productionKey = await getAttestationSessionStorageKey(REMOTE_API_URL, PCR_CONFIG);
+    const explicitProductionKey = await getAttestationSessionStorageKey(REMOTE_API_URL, {
+      ...PCR_CONFIG,
+      environment: "production"
+    });
+    const developmentKey = await getAttestationSessionStorageKey(REMOTE_API_URL, {
+      environment: "development",
+      pcr0DevValues: [bytesToHex(TRUSTED_PCR0)],
+      remoteAttestation: false
+    });
+
+    expect(productionKey).toBe(explicitProductionKey);
+    expect(developmentKey).not.toBe(productionKey);
+  });
+
+  test("an environment change cannot reuse a session or reach key exchange when PCR0 mismatches", async () => {
+    await establish(dependencies());
+
+    const verifyAttestation = mock(async () => attestationDocument(TRUSTED_PCR0));
+    const validatePcr0Hash = mock(async () => ({
+      isMatch: false,
+      text: "PCR0 belongs to the production environment"
+    }));
+    const keyExchange = mock(async () => ({
+      encrypted_session_key: "must-not-be-used",
+      session_id: "must-not-be-created"
+    }));
+    const developmentPolicy: PcrConfig = {
+      environment: "development",
+      remoteAttestation: false
+    };
+
+    await expect(
+      establish(
+        dependencies({ verifyAttestation, validatePcr0Hash, keyExchange }),
+        REMOTE_API_URL,
+        developmentPolicy
+      )
+    ).rejects.toThrow(/PCR0/i);
+
+    expect(verifyAttestation).toHaveBeenCalledTimes(1);
+    expect(validatePcr0Hash).toHaveBeenCalledWith(
+      bytesToHex(TRUSTED_PCR0),
+      expect.objectContaining(developmentPolicy)
+    );
+    expect(keyExchange).not.toHaveBeenCalled();
+  });
+
+  test("rejects an invalid runtime environment before attestation or key exchange", async () => {
+    const verifyAttestation = mock(async () => attestationDocument(TRUSTED_PCR0));
+    const keyExchange = mock(async () => ({
+      encrypted_session_key: "must-not-be-used",
+      session_id: "must-not-be-created"
+    }));
+
+    await expect(
+      establish(dependencies({ verifyAttestation, keyExchange }), REMOTE_API_URL, {
+        environment: "staging"
+      } as unknown as PcrConfig)
+    ).rejects.toThrow(/environment/i);
+
+    expect(verifyAttestation).not.toHaveBeenCalled();
+    expect(keyExchange).not.toHaveBeenCalled();
+    expect(window.sessionStorage.length).toBe(0);
   });
 
   test("ignores and removes a legacy unscoped cached session", async () => {

--- a/src/lib/test/integration/liveAttestation.test.ts
+++ b/src/lib/test/integration/liveAttestation.test.ts
@@ -27,7 +27,9 @@ test.skipIf(!runLive)(
       return originalFetch(input, init);
     };
 
-    const attestation = await getAttestation(true, liveApiUrl);
+    const attestation = await getAttestation(true, liveApiUrl, {
+      environment: "development"
+    });
 
     expect(attestation.sessionKey).toHaveLength(32);
     expect(attestation.sessionId).toBeTruthy();
@@ -38,8 +40,8 @@ test.skipIf(!runLive)(
     const keyExchangeIndex = requests.findIndex((url) => url.endsWith("/key_exchange"));
 
     expect(attestationIndex).toBeGreaterThanOrEqual(0);
-    expect(prodHistoryIndex).toBeGreaterThan(attestationIndex);
-    expect(devHistoryIndex).toBeGreaterThan(prodHistoryIndex);
+    expect(prodHistoryIndex).toBe(-1);
+    expect(devHistoryIndex).toBeGreaterThan(attestationIndex);
     expect(keyExchangeIndex).toBeGreaterThan(devHistoryIndex);
   }
 );
@@ -53,11 +55,32 @@ test.skipIf(!runLive)(
       return originalFetch(input, init);
     };
 
-    await expect(getAttestation(true, liveApiUrl, { remoteAttestation: false })).rejects.toThrow(
-      /PCR0/i
-    );
+    await expect(
+      getAttestation(true, liveApiUrl, {
+        environment: "development",
+        remoteAttestation: false
+      })
+    ).rejects.toThrow(/PCR0/i);
 
     expect(requests.filter((url) => url.includes("/attestation/"))).toHaveLength(1);
+    expect(requests.filter((url) => url.endsWith("/key_exchange"))).toHaveLength(0);
+  }
+);
+
+test.skipIf(!runLive)(
+  "hosted development enclave is rejected by the default production policy",
+  async () => {
+    const requests: string[] = [];
+    globalThis.fetch = async (input, init) => {
+      requests.push(requestUrl(input));
+      return originalFetch(input, init);
+    };
+
+    await expect(getAttestation(true, liveApiUrl)).rejects.toThrow(/PCR0/i);
+
+    expect(requests.filter((url) => url.includes("/attestation/"))).toHaveLength(1);
+    expect(requests.filter((url) => url.endsWith("/pcrProdHistory.json"))).toHaveLength(1);
+    expect(requests.filter((url) => url.endsWith("/pcrDevHistory.json"))).toHaveLength(0);
     expect(requests.filter((url) => url.endsWith("/key_exchange"))).toHaveLength(0);
   }
 );

--- a/src/lib/test/integration/pcr.test.ts
+++ b/src/lib/test/integration/pcr.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, mock, afterAll } from "bun:test";
-import { validatePcr0Hash, type PcrConfig } from "../../pcr";
+import { serializePcrConfig, snapshotPcrConfig, validatePcr0Hash, type PcrConfig } from "../../pcr";
 
 // Mock localStorage and other browser APIs
 const storageMock = () => {
@@ -29,7 +29,8 @@ const VALID_PCR0_PROD =
   "eeddbb58f57c38894d6d5af5e575fbe791c5bf3bbcfb5df8da8cfcf0c2e1da1913108e6a762112444740b88c163d7f4b";
 const VALID_PCR0_DEV =
   "62c0407056217a4c10764ed9045694c29fa93255d3cc04c2f989cdd9a1f8050c8b169714c71f1118ebce2fcc9951d1a9";
-const CUSTOM_PCR0 = "custom_pcr0_value_for_testing";
+const CUSTOM_PCR0 = "11".repeat(48);
+const CUSTOM_PCR0_DEV = "22".repeat(48);
 
 // Verified PCR0 with matching signature
 const VERIFIED_PCR0 =
@@ -94,9 +95,25 @@ test("validates known production PCR0 values", async () => {
 });
 
 test("validates known development PCR0 values", async () => {
-  const result = await validatePcr0Hash(VALID_PCR0_DEV);
+  const result = await validatePcr0Hash(VALID_PCR0_DEV, {
+    environment: "development",
+    remoteAttestation: false
+  });
   expect(result.isMatch).toBe(true);
   expect(result.text).toBe("PCR0 matches development enclave");
+});
+
+test("defaults to production and rejects development PCR0 values", async () => {
+  const result = await validatePcr0Hash(VALID_PCR0_DEV, { remoteAttestation: false });
+  expect(result.isMatch).toBe(false);
+});
+
+test("development rejects production PCR0 values", async () => {
+  const result = await validatePcr0Hash(VALID_PCR0_PROD, {
+    environment: "development",
+    remoteAttestation: false
+  });
+  expect(result.isMatch).toBe(false);
 });
 
 test("validates custom PCR0 values", async () => {
@@ -108,6 +125,54 @@ test("validates custom PCR0 values", async () => {
   expect(result.text).toBe("PCR0 matches a known good value");
 });
 
+test("additional PCR0 values are scoped to the selected environment", async () => {
+  const config: PcrConfig = {
+    pcr0Values: [CUSTOM_PCR0],
+    pcr0DevValues: [CUSTOM_PCR0_DEV],
+    remoteAttestation: false
+  };
+
+  expect((await validatePcr0Hash(CUSTOM_PCR0, config)).isMatch).toBe(true);
+  expect((await validatePcr0Hash(CUSTOM_PCR0_DEV, config)).isMatch).toBe(false);
+  expect(
+    (
+      await validatePcr0Hash(CUSTOM_PCR0_DEV, {
+        ...config,
+        environment: "development"
+      })
+    ).isMatch
+  ).toBe(true);
+  expect(
+    (
+      await validatePcr0Hash(CUSTOM_PCR0, {
+        ...config,
+        environment: "development"
+      })
+    ).isMatch
+  ).toBe(false);
+});
+
+test("snapshots a production default and rejects invalid runtime environments", () => {
+  expect(snapshotPcrConfig().environment).toBe("production");
+  expect(snapshotPcrConfig({ environment: "production" }).environment).toBe("production");
+  expect(() => snapshotPcrConfig({ environment: "staging" } as unknown as PcrConfig)).toThrow(
+    /environment/i
+  );
+});
+
+test("serializes only the effective environment policy", () => {
+  const productionPolicy = serializePcrConfig();
+  expect(JSON.parse(productionPolicy).version).toBe("pcr0-environment-v1");
+  expect(productionPolicy).toBe(serializePcrConfig({ environment: "production" }));
+  expect(serializePcrConfig()).toBe(serializePcrConfig({ pcr0DevValues: [CUSTOM_PCR0_DEV] }));
+  expect(productionPolicy).toBe(
+    serializePcrConfig({
+      remoteAttestationUrls: { dev: "https://unused.example.test/dev.json" }
+    })
+  );
+  expect(serializePcrConfig()).not.toBe(serializePcrConfig({ environment: "development" }));
+});
+
 test("rejects unknown PCR0 values when remote attestation is disabled", async () => {
   const config: PcrConfig = {
     remoteAttestation: false
@@ -116,12 +181,63 @@ test("rejects unknown PCR0 values when remote attestation is disabled", async ()
   expect(result.isMatch).toBe(false);
 });
 
-test("validates PCR0 from remote attestation", async () => {
-  // Need to use the exact PCR0 that matches our signature
-  const result = await validatePcr0Hash(VERIFIED_PCR0);
-  expect(result.isMatch).toBe(true);
-  expect(result.text).toBe("PCR0 matches remotely attested value");
-  expect(result.verifiedAt).toBeDefined();
+test("validates PCR0 from only the selected production history by default", async () => {
+  const historyFetch = mock(
+    async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      expect(url).toContain("pcrProdHistory.json");
+      return createMockResponse([
+        {
+          PCR0: VERIFIED_PCR0,
+          PCR1: VERIFIED_PCR1,
+          PCR2: VERIFIED_PCR2,
+          timestamp: 1743710235,
+          signature: VERIFIED_SIGNATURE
+        }
+      ]);
+    }
+  );
+
+  try {
+    global.fetch = historyFetch;
+    const result = await validatePcr0Hash(VERIFIED_PCR0);
+    expect(result.isMatch).toBe(true);
+    expect(result.text).toBe("PCR0 matches remotely attested value");
+    expect(result.verifiedAt).toBeDefined();
+    expect(historyFetch).toHaveBeenCalledTimes(1);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("validates PCR0 from only the selected development history", async () => {
+  const historyFetch = mock(
+    async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      expect(url).toContain("pcrDevHistory.json");
+      return createMockResponse([
+        {
+          PCR0: VERIFIED_PCR0,
+          PCR1: VERIFIED_PCR1,
+          PCR2: VERIFIED_PCR2,
+          timestamp: 1743710235,
+          signature: VERIFIED_SIGNATURE
+        }
+      ]);
+    }
+  );
+
+  try {
+    global.fetch = historyFetch;
+    const result = await validatePcr0Hash(VERIFIED_PCR0, { environment: "development" });
+    expect(result.isMatch).toBe(true);
+    expect(result.text).toBe("PCR0 matches remotely attested value");
+    expect(historyFetch).toHaveBeenCalledTimes(1);
+  } finally {
+    global.fetch = originalFetch;
+  }
 });
 
 test("prioritizes local PCR0 values over remote ones", async () => {
@@ -154,6 +270,7 @@ test("handles fetch errors gracefully", async () => {
     // Should fall back to rejecting the PCR0
     expect(result.isMatch).toBe(false);
     expect(result.text).toBe("PCR0 does not match a known good value");
+    expect(failingFetch).toHaveBeenCalledTimes(1);
   } finally {
     // Restore the working fetch mock
     global.fetch = originalFetch;
@@ -194,6 +311,122 @@ test("supports custom remote attestation URLs", async () => {
     const result = await validatePcr0Hash(VERIFIED_PCR0, config);
     expect(result.isMatch).toBe(true);
     expect(result.text).toBe("PCR0 matches remotely attested value");
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    expect(String(customFetch.mock.calls[0]?.[0])).toContain("/prod.json");
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("selects the custom development history without requesting production", async () => {
+  const customFetch = mock(
+    async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      expect(url).toBe("https://custom.example.com/dev.json");
+      return createMockResponse([
+        {
+          PCR0: VERIFIED_PCR0,
+          PCR1: VERIFIED_PCR1,
+          PCR2: VERIFIED_PCR2,
+          timestamp: 1743710235,
+          signature: VERIFIED_SIGNATURE
+        }
+      ]);
+    }
+  );
+
+  try {
+    global.fetch = customFetch;
+    const result = await validatePcr0Hash(VERIFIED_PCR0, {
+      environment: "development",
+      remoteAttestationUrls: {
+        prod: "https://custom.example.com/prod.json",
+        dev: "https://custom.example.com/dev.json"
+      }
+    });
+    expect(result.isMatch).toBe(true);
+    expect(customFetch).toHaveBeenCalledTimes(1);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("does not fall back to the opposite environment's signed history", async () => {
+  const historyFetch = mock(
+    async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("pcrDevHistory.json")) {
+        return createMockResponse([
+          {
+            PCR0: VERIFIED_PCR0,
+            PCR1: VERIFIED_PCR1,
+            PCR2: VERIFIED_PCR2,
+            timestamp: 1743710235,
+            signature: VERIFIED_SIGNATURE
+          }
+        ]);
+      }
+      return createMockResponse([
+        {
+          PCR0: CUSTOM_PCR0,
+          PCR1: VERIFIED_PCR1,
+          PCR2: VERIFIED_PCR2,
+          timestamp: 1743710235,
+          signature: VERIFIED_SIGNATURE
+        }
+      ]);
+    }
+  );
+
+  try {
+    global.fetch = historyFetch;
+    const result = await validatePcr0Hash(VERIFIED_PCR0);
+    expect(result.isMatch).toBe(false);
+    expect(historyFetch).toHaveBeenCalledTimes(1);
+    expect(String(historyFetch.mock.calls[0]?.[0])).toContain("pcrProdHistory.json");
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("development does not fall back to the production signed history", async () => {
+  const historyFetch = mock(
+    async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("pcrProdHistory.json")) {
+        return createMockResponse([
+          {
+            PCR0: VERIFIED_PCR0,
+            PCR1: VERIFIED_PCR1,
+            PCR2: VERIFIED_PCR2,
+            timestamp: 1743710235,
+            signature: VERIFIED_SIGNATURE
+          }
+        ]);
+      }
+      return createMockResponse([
+        {
+          PCR0: CUSTOM_PCR0_DEV,
+          PCR1: VERIFIED_PCR1,
+          PCR2: VERIFIED_PCR2,
+          timestamp: 1743710235,
+          signature: VERIFIED_SIGNATURE
+        }
+      ]);
+    }
+  );
+
+  try {
+    global.fetch = historyFetch;
+    const result = await validatePcr0Hash(VERIFIED_PCR0, {
+      environment: "development"
+    });
+    expect(result.isMatch).toBe(false);
+    expect(historyFetch).toHaveBeenCalledTimes(1);
+    expect(String(historyFetch.mock.calls[0]?.[0])).toContain("pcrDevHistory.json");
   } finally {
     global.fetch = originalFetch;
   }
@@ -216,7 +449,7 @@ test("rejects a matching remote PCR0 whose pinned-key signature is tampered", as
     global.fetch = tamperedHistoryFetch;
     const result = await validatePcr0Hash(VERIFIED_PCR0);
     expect(result.isMatch).toBe(false);
-    expect(tamperedHistoryFetch).toHaveBeenCalledTimes(2);
+    expect(tamperedHistoryFetch).toHaveBeenCalledTimes(1);
   } finally {
     global.fetch = originalFetch;
   }
@@ -241,8 +474,8 @@ test("rejects and cancels PCR history streams larger than one MiB", async () => 
     global.fetch = oversizedHistoryFetch;
     const result = await validatePcr0Hash(VERIFIED_PCR0);
     expect(result.isMatch).toBe(false);
-    expect(oversizedHistoryFetch).toHaveBeenCalledTimes(2);
-    expect(cancelCount).toBe(2);
+    expect(oversizedHistoryFetch).toHaveBeenCalledTimes(1);
+    expect(cancelCount).toBe(1);
   } finally {
     global.fetch = originalFetch;
   }
@@ -257,7 +490,7 @@ test("rejects signed PCR history with a malformed schema", async () => {
     global.fetch = malformedHistoryFetch;
     const result = await validatePcr0Hash(VERIFIED_PCR0);
     expect(result.isMatch).toBe(false);
-    expect(malformedHistoryFetch).toHaveBeenCalledTimes(2);
+    expect(malformedHistoryFetch).toHaveBeenCalledTimes(1);
   } finally {
     global.fetch = originalFetch;
   }
@@ -272,7 +505,7 @@ test("rejects redirected signed PCR history responses", async () => {
     global.fetch = redirectedHistoryFetch;
     const result = await validatePcr0Hash(VERIFIED_PCR0);
     expect(result.isMatch).toBe(false);
-    expect(redirectedHistoryFetch).toHaveBeenCalledTimes(2);
+    expect(redirectedHistoryFetch).toHaveBeenCalledTimes(1);
   } finally {
     global.fetch = originalFetch;
   }

--- a/src/lib/test/platform-api-url-loader.ts
+++ b/src/lib/test/platform-api-url-loader.ts
@@ -1,13 +1,16 @@
 import { setPlatformApiUrl } from "../platformApi";
+import { parseTestPcrEnvironment } from "./testPcrEnvironment";
 
 // Get the API URL from environment variables
 const apiUrl = process.env.VITE_OPEN_SECRET_API_URL;
+const pcrEnvironment = parseTestPcrEnvironment(process.env.VITE_OPEN_SECRET_PCR_ENVIRONMENT);
 
 if (!apiUrl) {
   throw new Error("VITE_OPEN_SECRET_API_URL must be set in environment variables");
 }
 
-// Set the Platform API URL before tests run
-setPlatformApiUrl(apiUrl);
+// Bind the hosted endpoint to one explicit PCR trust environment before tests run.
+setPlatformApiUrl(apiUrl, { environment: pcrEnvironment });
 
 console.log("Platform API URL set to:", apiUrl);
+console.log("Platform PCR trust environment set to:", pcrEnvironment);

--- a/src/lib/test/testPcrEnvironment.test.ts
+++ b/src/lib/test/testPcrEnvironment.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { parseTestPcrEnvironment } from "./testPcrEnvironment";
+
+describe("hosted test PCR environment", () => {
+  test("defaults to production when omitted", () => {
+    expect(parseTestPcrEnvironment(undefined)).toBe("production");
+  });
+
+  test("accepts exact production and development values", () => {
+    expect(parseTestPcrEnvironment("production")).toBe("production");
+    expect(parseTestPcrEnvironment("development")).toBe("development");
+  });
+
+  test("rejects empty, differently-cased, or unknown values", () => {
+    for (const value of ["", "Production", "dev", " development "]) {
+      expect(() => parseTestPcrEnvironment(value)).toThrow(
+        'VITE_OPEN_SECRET_PCR_ENVIRONMENT must be either "production" or "development"'
+      );
+    }
+  });
+});

--- a/src/lib/test/testPcrEnvironment.ts
+++ b/src/lib/test/testPcrEnvironment.ts
@@ -1,0 +1,11 @@
+import type { PcrEnvironment } from "../pcr";
+
+const PCR_ENVIRONMENT_VARIABLE = "VITE_OPEN_SECRET_PCR_ENVIRONMENT";
+
+/** Parse the PCR trust environment used by hosted integration tests. */
+export function parseTestPcrEnvironment(value: string | undefined): PcrEnvironment {
+  if (value === undefined) return "production";
+  if (value === "production" || value === "development") return value;
+
+  throw new Error(`${PCR_ENVIRONMENT_VARIABLE} must be either "production" or "development"`);
+}

--- a/website/api/README.md
+++ b/website/api/README.md
@@ -66,6 +66,7 @@
 - [ParsedAttestationView](type-aliases/ParsedAttestationView.md)
 - [Pcr0ValidationResult](type-aliases/Pcr0ValidationResult.md)
 - [PcrConfig](type-aliases/PcrConfig.md)
+- [PcrEnvironment](type-aliases/PcrEnvironment.md)
 - [ProjectDetails](type-aliases/ProjectDetails.md)
 - [ProjectSettings](type-aliases/ProjectSettings.md)
 - [PushSettings](type-aliases/PushSettings.md)

--- a/website/api/functions/OpenSecretDeveloper.md
+++ b/website/api/functions/OpenSecretDeveloper.md
@@ -31,7 +31,7 @@ React child components to be wrapped by the provider
 
 [`PcrConfig`](../type-aliases/PcrConfig.md) = `DEFAULT_PCR_CONFIG`
 
-Optional PCR0 trust policy enforced before session establishment
+Optional PCR0 trust policy enforced before session establishment; its environment defaults to production
 
 ## Returns
 

--- a/website/api/functions/OpenSecretProvider.md
+++ b/website/api/functions/OpenSecretProvider.md
@@ -36,7 +36,7 @@ UUID identifying which project/tenant this instance belongs to
 
 [`PcrConfig`](../type-aliases/PcrConfig.md) = `DEFAULT_PCR_CONFIG`
 
-Optional PCR0 trust policy enforced before session establishment
+Optional PCR0 trust policy enforced before session establishment; its environment defaults to production
 
 ## Returns
 

--- a/website/api/interfaces/CustomFetchOptions.md
+++ b/website/api/interfaces/CustomFetchOptions.md
@@ -26,4 +26,4 @@ API URL used for attestation; required outside OpenSecretProvider.
 
 > `optional` **pcrConfig?**: [`PcrConfig`](../type-aliases/PcrConfig.md)
 
-PCR0 trust policy enforced before non-loopback session key exchange.
+PCR0 trust policy enforced before non-loopback session key exchange; defaults to production.

--- a/website/api/type-aliases/OpenSecretContextType.md
+++ b/website/api/type-aliases/OpenSecretContextType.md
@@ -1223,7 +1223,8 @@ Parses an attestation document for viewing
 
 > **pcrConfig**: [`PcrConfig`](PcrConfig.md)
 
-PCR0 trust policy enforced before every non-loopback session key exchange
+PCR0 trust policy enforced before every non-loopback session key exchange.
+The trust environment defaults to production.
 
 ***
 

--- a/website/api/type-aliases/OpenSecretDeveloperContextType.md
+++ b/website/api/type-aliases/OpenSecretDeveloperContextType.md
@@ -666,7 +666,8 @@ Parses an attestation document for viewing
 
 > **pcrConfig**: [`PcrConfig`](PcrConfig.md)
 
-PCR0 trust policy enforced before every non-loopback session key exchange
+PCR0 trust policy enforced before every non-loopback session key exchange.
+The trust environment defaults to production.
 
 ***
 

--- a/website/api/type-aliases/PcrConfig.md
+++ b/website/api/type-aliases/PcrConfig.md
@@ -10,12 +10,23 @@ Configuration options for PCR validation
 
 ## Properties
 
+### environment?
+
+> `optional` **environment?**: [`PcrEnvironment`](PcrEnvironment.md)
+
+OpenSecret deployment environment to trust (defaults to production).
+Only this environment's embedded roots, additional roots, and signed
+history are considered during session establishment.
+
+***
+
 ### pcr0DevValues?
 
 > `optional` **pcr0DevValues?**: `string`[]
 
 Additional trusted PCR0 values for development environments.
-The SDK's built-in development trust roots always remain trusted.
+These and the SDK's built-in development roots are considered only when
+`environment` is `"development"`.
 
 ***
 
@@ -24,7 +35,8 @@ The SDK's built-in development trust roots always remain trusted.
 > `optional` **pcr0Values?**: `string`[]
 
 Additional trusted PCR0 values for production environments.
-The SDK's built-in production trust roots always remain trusted.
+These and the SDK's built-in production roots are considered only when
+`environment` is `"production"`.
 
 ***
 
@@ -41,7 +53,7 @@ Whether to consult pinned-key signed PCR history after local trust roots miss
 
 > `optional` **remoteAttestationUrls?**: `object`
 
-Custom URLs for pinned-key signed PCR history
+Custom URLs for pinned-key signed PCR history. Only the selected environment is fetched.
 
 #### dev?
 

--- a/website/api/type-aliases/PcrEnvironment.md
+++ b/website/api/type-aliases/PcrEnvironment.md
@@ -1,0 +1,9 @@
+[**@opensecret/react**](../README.md)
+
+***
+
+# Type Alias: PcrEnvironment
+
+> **PcrEnvironment** = `"production"` \| `"development"`
+
+The OpenSecret deployment environment whose PCR0 roots are trusted.

--- a/website/docs/api/README.md
+++ b/website/docs/api/README.md
@@ -26,6 +26,7 @@ sidebar_position: 100
 - [ParsedAttestationView](type-aliases/ParsedAttestationView.md)
 - [Pcr0ValidationResult](type-aliases/Pcr0ValidationResult.md)
 - [PcrConfig](type-aliases/PcrConfig.md)
+- [PcrEnvironment](type-aliases/PcrEnvironment.md)
 - [ProjectDetails](type-aliases/ProjectDetails.md)
 - [ProjectSettings](type-aliases/ProjectSettings.md)
 - [UserResponse](type-aliases/UserResponse.md)

--- a/website/docs/api/functions/OpenSecretDeveloper.md
+++ b/website/docs/api/functions/OpenSecretDeveloper.md
@@ -33,7 +33,7 @@ React child components to be wrapped by the provider
 
 [`PcrConfig`](../type-aliases/PcrConfig.md) = `DEFAULT_PCR_CONFIG`
 
-Optional PCR0 trust policy enforced before session establishment
+Optional PCR0 trust policy enforced before session establishment; its environment defaults to production
 
 ## Returns
 

--- a/website/docs/api/functions/OpenSecretProvider.md
+++ b/website/docs/api/functions/OpenSecretProvider.md
@@ -38,7 +38,7 @@ UUID identifying which project/tenant this instance belongs to
 
 [`PcrConfig`](../type-aliases/PcrConfig.md) = `DEFAULT_PCR_CONFIG`
 
-Optional PCR0 trust policy enforced before session establishment
+Optional PCR0 trust policy enforced before session establishment; its environment defaults to production
 
 ## Returns
 

--- a/website/docs/api/type-aliases/OpenSecretContextType.md
+++ b/website/docs/api/type-aliases/OpenSecretContextType.md
@@ -620,7 +620,8 @@ Parses an attestation document for viewing
 
 > **pcrConfig**: [`PcrConfig`](PcrConfig.md)
 
-PCR0 trust policy enforced before every non-loopback session key exchange
+PCR0 trust policy enforced before every non-loopback session key exchange.
+The trust environment defaults to production.
 
 ***
 

--- a/website/docs/api/type-aliases/OpenSecretDeveloperContextType.md
+++ b/website/docs/api/type-aliases/OpenSecretDeveloperContextType.md
@@ -648,7 +648,8 @@ Parses an attestation document for viewing
 
 > **pcrConfig**: [`PcrConfig`](PcrConfig.md)
 
-PCR0 trust policy enforced before every non-loopback session key exchange
+PCR0 trust policy enforced before every non-loopback session key exchange.
+The trust environment defaults to production.
 
 ***
 

--- a/website/docs/api/type-aliases/PcrConfig.md
+++ b/website/docs/api/type-aliases/PcrConfig.md
@@ -12,12 +12,23 @@ Configuration options for PCR validation
 
 ## Properties
 
+### environment?
+
+> `optional` **environment**: [`PcrEnvironment`](PcrEnvironment.md)
+
+OpenSecret deployment environment to trust (defaults to production).
+Only this environment's embedded roots, additional roots, and signed
+history are considered during session establishment.
+
+***
+
 ### pcr0DevValues?
 
 > `optional` **pcr0DevValues**: `string`[]
 
 Additional trusted PCR0 values for development environments.
-The SDK's built-in development trust roots always remain trusted.
+These and the SDK's built-in development roots are considered only when
+`environment` is `"development"`.
 
 ***
 
@@ -26,7 +37,8 @@ The SDK's built-in development trust roots always remain trusted.
 > `optional` **pcr0Values**: `string`[]
 
 Additional trusted PCR0 values for production environments.
-The SDK's built-in production trust roots always remain trusted.
+These and the SDK's built-in production roots are considered only when
+`environment` is `"production"`.
 
 ***
 
@@ -43,7 +55,7 @@ Whether to consult pinned-key signed PCR history after local trust roots miss
 
 > `optional` **remoteAttestationUrls**: `object`
 
-Custom URLs for pinned-key signed PCR history
+Custom URLs for pinned-key signed PCR history. Only the selected environment is fetched.
 
 #### dev?
 

--- a/website/docs/api/type-aliases/PcrEnvironment.md
+++ b/website/docs/api/type-aliases/PcrEnvironment.md
@@ -1,0 +1,11 @@
+[**@opensecret/react**](../README.md)
+
+---
+
+[@opensecret/react](../README.md) / PcrEnvironment
+
+# Type Alias: PcrEnvironment
+
+> **PcrEnvironment** = `"production"` \| `"development"`
+
+The OpenSecret deployment environment whose PCR0 roots are trusted.

--- a/website/docs/guides/remote-attestation.md
+++ b/website/docs/guides/remote-attestation.md
@@ -42,18 +42,25 @@ OpenSecret primarily validates PCR0, which is the most critical measurement as i
 
 ## PCR0 Validation Process
 
-OpenSecret uses a multi-layered approach to PCR0 validation:
+OpenSecret uses an environment-scoped approach to PCR0 validation. The trust environment defaults
+to production and must be set explicitly to development for a hosted development enclave:
 
-1. **Local Validation**: First, the SDK checks if the PCR0 value matches one of the known good values:
-   - Built-in production PCR0 values
-   - Built-in development PCR0 values
-   - Custom PCR0 values provided in your configuration
+1. **Local Validation**: The SDK checks only the selected environment's built-in and custom PCR0
+   values. Static production roots are not checked by a development policy, and static development
+   roots are not checked by a production policy.
 
-2. **Remote Attestation**: If local validation doesn't find a match, the SDK fetches and verifies signed PCR history from:
-   - Production PCR history: `https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrProdHistory.json`
-   - Development PCR history: `https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrDevHistory.json`
+2. **Signed History**: If local validation doesn't find a match, the SDK fetches only the selected
+   environment's pinned-key signed history:
+   - Production: `https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrProdHistory.json`
+   - Development: `https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrDevHistory.json`
 
-3. **Signature Verification**: The SDK verifies that the PCR history entries are properly signed by OpenSecret
+3. **Signature Verification**: The SDK verifies matching history entries with OpenSecret's pinned
+   public key. It never falls back to the other environment's history.
+
+Environment separation for signed history is currently enforced by selecting one pinned history
+URL. History signatures authenticate the PCR0 value with a shared verification key; they do not
+cryptographically encode the environment. Separate keys or an environment-bearing signed payload
+would be required for cryptographic domain separation between the two history files.
 
 ## Configuration Options
 
@@ -70,14 +77,12 @@ function App() {
       apiUrl="https://api.opensecret.cloud"
       clientId="your-project-uuid"
       pcrConfig={{
-        // Add custom PCR0 values you want to trust (production environment)
+        // Optional: production is the default trust environment.
+        environment: "production",
+        // Additional roots are scoped to the selected environment.
         pcr0Values: [
           "your-trusted-pcr0-value-1",
           "your-trusted-pcr0-value-2"
-        ],
-        // Add custom PCR0 values for development environment
-        pcr0DevValues: [
-          "your-dev-pcr0-value"
         ]
       }}
     >
@@ -85,6 +90,22 @@ function App() {
     </OpenSecretProvider>
   );
 }
+```
+
+For a hosted development enclave, select development explicitly and use `pcr0DevValues` for any
+additional development roots:
+
+```tsx
+<OpenSecretProvider
+  apiUrl="https://your-development-enclave.example"
+  clientId="your-project-uuid"
+  pcrConfig={{
+    environment: "development",
+    pcr0DevValues: ["your-dev-pcr0-value"]
+  }}
+>
+  <YourApp />
+</OpenSecretProvider>
 ```
 
 ### Disabling Remote Attestation
@@ -100,6 +121,7 @@ function App() {
       apiUrl="https://api.opensecret.cloud"
       clientId="your-project-uuid"
       pcrConfig={{
+        environment: "production",
         // Disable remote attestation - only use local PCR0 values
         remoteAttestation: false,
         // Your trusted PCR0 values
@@ -114,7 +136,8 @@ function App() {
 
 ### Custom Remote Attestation URLs
 
-You can specify custom URLs for remote attestation verification:
+You can specify custom URLs for signed-history verification. Only the URL for the selected
+environment is requested:
 
 ```tsx
 import { OpenSecretProvider } from "@opensecret/react";
@@ -125,6 +148,7 @@ function App() {
       apiUrl="https://api.opensecret.cloud"
       clientId="your-project-uuid"
       pcrConfig={{
+        environment: "production",
         // Custom URLs for remote attestation
         remoteAttestationUrls: {
           prod: "https://your-custom-url/pcrProdHistory.json",
@@ -248,15 +272,17 @@ The attestation document returned by `getAttestationDocument()` includes:
 OpenSecret's PCR0 validation process follows these steps:
 
 1. **Local Static Validation**:
-   - First checks against hardcoded production PCR0 values
-   - Then checks against hardcoded development PCR0 values
-   - Then checks against any custom PCR0 values you've provided
+   - Defaults to the production trust environment
+   - Checks only the selected environment's hardcoded PCR0 values
+   - Checks only custom PCR0 values for that environment (`pcr0Values` for production or
+     `pcr0DevValues` for development)
 
 2. **Remote Attestation** (if enabled):
-   - Fetches signed PCR history from the configured URLs
+   - Fetches signed PCR history only for the selected environment
    - Verifies the authenticity of each entry using OpenSecret's public key
    - Checks if the PCR0 value matches any entry in the history
    - Validates the signature on the matching entry
+   - Does not fall back to the other environment
 
 3. **Result Reporting**:
    - Returns a validation result indicating whether the PCR0 value is trusted
@@ -269,13 +295,20 @@ OpenSecret's PCR0 validation process follows these steps:
 
 For production deployments:
 
-1. **Use explicit PCR values**: Specify the exact PCR0 values you trust rather than relying solely on remote attestation.
+1. **Keep the production default or select it explicitly**: Never configure a production client
+   with `environment: "development"`.
 
-2. **Keep remote attestation enabled**: Remote attestation provides an additional security layer that can detect new legitimate PCR0 values.
+2. **Use explicit PCR values when appropriate**: Additional values are additive to the selected
+   environment's built-in roots.
 
-3. **Verify attestation before sensitive operations**: Always verify attestation before sending sensitive data to the enclave.
+3. **Keep signed-history lookup enabled**: The signed GitHub history lets approved backend PCR0
+   values rotate without requiring every client to update immediately.
 
-4. **Rotate sensitive data**: If you discover that a PCR0 value is no longer trusted, rotate any sensitive data that was sent to that enclave.
+4. **Verify attestation before sensitive operations**: Always verify attestation before sending
+   sensitive data to the enclave.
+
+5. **Rotate sensitive data**: If you discover that a PCR0 value is no longer trusted, rotate any
+   sensitive data that was sent to that enclave.
 
 ### Obtaining Trusted PCR0 Values
 


### PR DESCRIPTION
## Summary

- add explicit production/development PCR0 trust selection to the React and Rust SDKs, with production as the fail-closed default
- accept only the selected environment embedded/additional roots and pinned-key signed GitHub PCR history before key exchange, with no cross-environment fallback
- bind React cached-session and custom-fetch retry identity to the effective environment policy
- remove the Cargo-feature-gated hosted mock-verifier bypass while preserving the exact HTTP loopback mock path
- wire explicit environment selection through hosted test clients and document the new contract

## API and compatibility

- React adds `PcrConfig.environment?: "production" | "development"`
- Rust exports `Pcr0Environment` and adds environment-aware constructors for normal and API-key clients
- existing constructors remain source-compatible, but omitted environment now means production-only instead of the former production/development union
- signed GitHub histories remain the normal PCR rotation path, and custom roots/history URLs remain supported
- no REST request or response contract changes
- version files are intentionally untouched; draft PR #97 will be revisited after this lands, and Maple/maple-proxy consumer updates will follow the published SDKs

## Validation

- TypeScript format/build and 48 focused PCR/session/transport tests
- hosted development enclave: explicit development succeeded through the dev signed history; default production and remote-disabled policies rejected before key exchange
- Rust all-features library tests: 76 passed; strict Clippy, checks, integration-test compilation, and docs passed
- hosted Rust development positive/default-production negative tests, plus a hosted production positive test
- local Maple: focused tests, TypeScript build, native Rust compatibility test, and PR/dev web artifact build passed against local SDK paths
- local maple-proxy: strict checks and 38 tests passed; hosted dev reached encrypted upstream only with explicit development, while the production default failed closed
- website production build

## Trust boundary

The existing production and development history files share one verification key and sign the bare PCR0 value. This change enforces operational separation by selecting exactly one trusted history file, but full cryptographic domain separation would require environment-bearing signed payloads or separate keys.