### PR TITLE
chore: bump SDK patch versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensecret/react",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensecret/react",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "1.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/react",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "packageManager": "bun@1.3.5",
   "license": "MIT",
   "type": "module",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensecret"
-version = "3.6.0"
+version = "3.6.1"
 edition = "2021"
 authors = ["OpenSecret"]
 description = "Rust SDK for OpenSecret - secure AI API interactions with nitro attestation"


### PR DESCRIPTION
## Summary

- bump `@opensecret/react` from `3.4.0` to `3.4.1`
- bump the Rust `opensecret` crate from `3.6.0` to `3.6.1`
- keep the npm compatibility lock metadata aligned

Both target versions are currently unclaimed in their registries.

## Validation

- frozen Bun install
- `bun audit --audit-level=high`
- TypeScript format and production build
- npm package dry-run reports `@opensecret/react@3.4.1` with the expected six-file boundary
- Rust format and `cargo check --all-features`
- clean-room `cargo package --allow-dirty` verification for `opensecret v3.6.1`