### PR TITLE
Add Maple device pairing client

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,6 +33,7 @@ p256 = { version = "0.13", features = ["ecdh", "pkcs8"] }
 sha2 = "0.10"
 base64 = "0.22"
 ring = "0.17"  # For certificate validation
+ed25519-dalek = { version = "3.0.0", default-features = false, features = ["fast"] }
 hex = "0.4"  # For debug output
 
 # X.509 and certificate handling

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1881,13 +1881,20 @@ impl OpenSecretClient {
     }
 
     /// Approves one pending pairing as its selected host installation.
+    ///
+    /// The returned exact-operation receipt may be historical when replayed.
+    /// Its issuer-verified authorization is only a durable, non-admitting
+    /// stage candidate. After staging it, fetch a fresh current host status and
+    /// reconcile through
+    /// [`VerifiedMaplePairingStatusResponse::confirm_ready_after_durable_stage`]
+    /// before constructing CONFIRM.
     pub async fn approve_maple_pairing(
         &self,
         prepared: &PreparedMaplePairingApprovalV1,
         host_signing_public_key: &[u8; 32],
         issuers: &MaplePairingIssuerKeySet,
         trusted_now_unix_ms: i64,
-    ) -> Result<VerifiedMaplePairingMutationResponse> {
+    ) -> Result<VerifiedMaplePairingApprovalReceipt> {
         let request = prepared.as_inner();
         request.validate_with_signing_key(host_signing_public_key)?;
         let response: MaplePairingMutationResponse = self
@@ -1896,18 +1903,24 @@ impl OpenSecretClient {
         response.verify_approve(request, issuers, trusted_now_unix_ms)
     }
 
-    /// Confirms that the host durably committed the approved authorization.
+    /// Confirms that the host durably staged the approved authorization without
+    /// admitting it.
     ///
-    /// Callers must not invoke this until their local allowlist write is
-    /// durable. Only the resulting `active` receipt makes the controller view
-    /// eligible to dial the host.
+    /// Callers must not invoke this until the non-admitting stage is durable
+    /// and a fresh current host status yielded the prepared CONFIRM capability.
+    /// The returned exact-operation receipt may itself be historical and never
+    /// promotes the stage. Fetch current status again; only
+    /// [`VerifiedMaplePairingStatusResponse::admission_ready_after_confirm`]
+    /// may produce material for the active admission set. A conflict or
+    /// verified non-active status must fence or remove the stage, while an
+    /// ambiguous network result leaves it staged and retryable.
     pub async fn confirm_maple_pairing(
         &self,
         prepared: &PreparedMaplePairingHostCommitV1,
         host_signing_public_key: &[u8; 32],
         issuers: &MaplePairingIssuerKeySet,
         trusted_now_unix_ms: i64,
-    ) -> Result<VerifiedMaplePairingMutationResponse> {
+    ) -> Result<VerifiedMaplePairingConfirmationReceipt> {
         let request = prepared.as_inner();
         request.validate_with_signing_key(host_signing_public_key)?;
         let response: MaplePairingMutationResponse = self

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -3,6 +3,7 @@ use crate::{
     cbor::{self, Value as CborValue},
     crypto::{self},
     error::{Error, Result},
+    pairing::*,
     pcr::{Pcr0Environment, Pcr0TrustPolicy},
     session::SessionManager,
     types::*,
@@ -17,7 +18,7 @@ use reqwest::{
     Client,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{net::IpAddr, pin::Pin};
+use std::{collections::HashSet, net::IpAddr, pin::Pin};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
@@ -38,6 +39,53 @@ pub type InferenceResponse = HttpResponse<OpenSecretResponseBody>;
 #[serde(deny_unknown_fields)]
 struct EncryptedBody {
     encrypted: String,
+}
+
+const MAPLE_SECURITY_EPOCH_STALE_CODE: &str = "MapleSecurityEpochStale";
+const MAPLE_SECURITY_EPOCH_STALE_MESSAGE: &str =
+    "Maple device security epoch is stale; refresh device state and retry.";
+const MAPLE_PAIRING_RESET_CLEAR_REQUIRED_CODE: &str = "MaplePairingResetClearRequired";
+const MAPLE_PAIRING_RESET_CLEAR_REQUIRED_MESSAGE: &str =
+    "Maple remote access must be cleared on the host before this operation can continue.";
+const MAPLE_INSTALLATION_RETIRED_CODE: &str = "MapleInstallationRetired";
+const MAPLE_INSTALLATION_RETIRED_MESSAGE: &str =
+    "This Maple installation enrollment is retired; reset Remote access on this device and enroll it again.";
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ApiErrorBody {
+    status: u16,
+    code: Option<String>,
+    message: String,
+}
+
+fn classify_api_error(status: u16, body: String) -> Error {
+    if status == 409 {
+        if let Ok(error) = serde_json::from_str::<ApiErrorBody>(&body) {
+            if error.status == 409
+                && error.code.as_deref() == Some(MAPLE_SECURITY_EPOCH_STALE_CODE)
+                && error.message == MAPLE_SECURITY_EPOCH_STALE_MESSAGE
+            {
+                return Error::MapleSecurityEpochStale;
+            }
+            if error.status == 409
+                && error.code.as_deref() == Some(MAPLE_PAIRING_RESET_CLEAR_REQUIRED_CODE)
+                && error.message == MAPLE_PAIRING_RESET_CLEAR_REQUIRED_MESSAGE
+            {
+                return Error::MaplePairingResetClearRequired;
+            }
+            if error.status == 409
+                && error.code.as_deref() == Some(MAPLE_INSTALLATION_RETIRED_CODE)
+                && error.message == MAPLE_INSTALLATION_RETIRED_MESSAGE
+            {
+                return Error::MapleInstallationRetired;
+            }
+        }
+    }
+    Error::Api {
+        status,
+        message: body,
+    }
 }
 
 const MAX_INFERENCE_SSE_LINE_BYTES: usize = 16 * 1024 * 1024;
@@ -165,6 +213,27 @@ fn build_conversation_projects_endpoint(params: Option<&ConversationProjectListP
         }
         if let Some(order) = &params.order {
             append_query_param(&mut query, "order", order);
+        }
+    }
+
+    if !query.is_empty() {
+        endpoint.push('?');
+        endpoint.push_str(&query.join("&"));
+    }
+
+    endpoint
+}
+
+fn build_maple_devices_endpoint(params: Option<&MapleDeviceListParams>) -> String {
+    let mut endpoint = "/protected/maple/devices".to_string();
+    let mut query = Vec::new();
+
+    if let Some(params) = params {
+        if let Some(cursor) = &params.cursor {
+            append_query_param(&mut query, "cursor", cursor);
+        }
+        if let Some(limit) = params.limit {
+            append_query_param(&mut query, "limit", limit);
         }
     }
 
@@ -749,7 +818,7 @@ impl OpenSecretClient {
         method: &str,
         data: Option<T>,
     ) -> Result<U> {
-        self.retry_encrypted_json_call(endpoint, method, data, AuthHeaderMode::Jwt, true)
+        self.retry_encrypted_json_call(endpoint, method, data, AuthHeaderMode::Jwt, true, true)
             .await
     }
 
@@ -788,6 +857,7 @@ impl OpenSecretClient {
         data: Option<T>,
         auth_mode: AuthHeaderMode,
         allow_refresh: bool,
+        retry_bad_request_as_stale_session: bool,
     ) -> Result<U> {
         let mut retried_attestation = false;
         let mut retried_refresh = false;
@@ -799,7 +869,13 @@ impl OpenSecretClient {
                 .await
             {
                 Ok(result) => return Ok(result),
-                Err(error) if !retried_attestation && Self::is_attestation_retryable(&error) => {
+                Err(error)
+                    if !retried_attestation
+                        && Self::is_attestation_retryable_with_policy(
+                            &error,
+                            retry_bad_request_as_stale_session,
+                        ) =>
+                {
                     self.perform_attestation_handshake().await?;
                     retried_attestation = true;
                 }
@@ -817,6 +893,36 @@ impl OpenSecretClient {
                 }
                 Err(error) => return Err(error),
             }
+        }
+    }
+
+    /// Sends one Maple pairing control-plane request and only replays it after
+    /// the service explicitly reports an evicted attested session with HTTP
+    /// 410. Transport, encryption, decryption, and semantic failures are
+    /// returned to the caller because their mutation outcome can be ambiguous.
+    async fn maple_pairing_json_call<T: Serialize + Clone, U: DeserializeOwned>(
+        &self,
+        endpoint: &str,
+        data: &T,
+    ) -> Result<U> {
+        // Establishing an absent session is preparation for the first send,
+        // not a replay. A session disappearing after this point is surfaced.
+        if self.session_manager.get_session()?.is_none() {
+            self.perform_attestation_handshake().await?;
+        }
+
+        let auth = self.resolve_auth(AuthHeaderMode::Jwt)?;
+        match self
+            .encrypted_json_call_inner(endpoint, "POST", Some(data), &auth)
+            .await
+        {
+            Err(Error::Api { status: 410, .. }) => {
+                self.perform_attestation_handshake().await?;
+                let auth = self.resolve_auth(AuthHeaderMode::Jwt)?;
+                self.encrypted_json_call_inner(endpoint, "POST", Some(data), &auth)
+                    .await
+            }
+            result => result,
         }
     }
 
@@ -898,12 +1004,10 @@ impl OpenSecretClient {
                 .await;
 
             match result {
-                // OpenSecret currently uses the same 400 for stale sessions and
-                // pre-provider validation. Preserve the legacy one-retry behavior
-                // until the backend exposes an explicit re-attestation signal.
+                // An evicted attested session has an explicit status distinct
+                // from semantic request validation, so replay is unambiguous.
                 Ok((response, _session_key))
-                    if response.status() == reqwest::StatusCode::BAD_REQUEST
-                        && !retried_attestation =>
+                    if response.status() == reqwest::StatusCode::GONE && !retried_attestation =>
                 {
                     self.perform_attestation_handshake().await?;
                     retried_attestation = true;
@@ -1147,10 +1251,7 @@ impl OpenSecretClient {
                 .text()
                 .await
                 .unwrap_or_else(|_| "Unknown error".to_string());
-            return Err(Error::Api {
-                status,
-                message: error_msg,
-            });
+            return Err(classify_api_error(status, error_msg));
         }
 
         Ok((response, session.session_key))
@@ -1222,13 +1323,14 @@ impl OpenSecretClient {
     }
 
     fn is_attestation_retryable(error: &Error) -> bool {
+        Self::is_attestation_retryable_with_policy(error, true)
+    }
+
+    fn is_attestation_retryable_with_policy(error: &Error, retry_stale_session: bool) -> bool {
         matches!(
             error,
-            Error::Session(_)
-                | Error::Api { status: 400, .. }
-                | Error::Encryption(_)
-                | Error::Decryption(_)
-        )
+            Error::Session(_) | Error::Encryption(_) | Error::Decryption(_)
+        ) || (retry_stale_session && matches!(error, Error::Api { status: 410, .. }))
     }
 
     // Auth Methods
@@ -1598,6 +1700,280 @@ impl OpenSecretClient {
     pub async fn get_user(&self) -> Result<UserResponse> {
         self.authenticated_api_call("/protected/user", "GET", None::<()>)
             .await
+    }
+
+    /// Registers or refreshes this account's signed Maple device record.
+    ///
+    /// The caller owns key generation, secure private-key storage, and signing
+    /// the shared structured-field transcript returned by
+    /// [`RegisterMapleDeviceRequest::canonical_transcript`]. The server
+    /// reconstructs the same transcript rather than trusting caller-supplied
+    /// canonical bytes. Keep `request.operation_id` stable until this operation
+    /// has an unambiguous result: authentication and attestation recovery may
+    /// send the cloned encrypted request again.
+    ///
+    /// [`Error::MapleInstallationRetired`] is a permanent enrollment-lineage
+    /// result, not a retryable stale-state response. Reset local Remote
+    /// enrollment state, generate a fresh installation ID and identity, then
+    /// submit a new enrollment. The retired installation can never become
+    /// current again.
+    pub async fn register_maple_device(
+        &self,
+        request: &RegisterMapleDeviceRequest,
+        issuers: &MaplePairingIssuerKeySet,
+    ) -> Result<VerifiedRegisterMapleDeviceResponseV1> {
+        request.validate()?;
+        let response: MapleDeviceRegistrationResponse = self
+            .retry_encrypted_json_call(
+                "/protected/maple/devices/register",
+                "POST",
+                Some(request),
+                AuthHeaderMode::Jwt,
+                true,
+                true,
+            )
+            .await?;
+        if response.protocol_version != MAPLE_DEVICE_PROTOCOL_VERSION
+            || response.operation_id != request.operation_id
+            || response.device_id != request.device_id
+            || response.registration_id.is_nil()
+            || response.revision != request.expected_revision.map_or(1, |revision| revision + 1)
+            || response.security_epoch != request.known_security_epoch
+        {
+            return Err(Error::InvalidResponse(
+                "Maple device registration response did not match the submitted request"
+                    .to_string(),
+            ));
+        }
+        let revocation_sync = response.revocation_sync.verify_against_registration(
+            request,
+            response.registration_id,
+            response.security_epoch,
+            issuers,
+        )?;
+        Ok(VerifiedRegisterMapleDeviceResponseV1::new(
+            response,
+            revocation_sync,
+        ))
+    }
+
+    /// Lists a bounded page of account-scoped Maple device records.
+    pub async fn list_maple_devices(
+        &self,
+        params: Option<MapleDeviceListParams>,
+    ) -> Result<MapleDeviceListResponse> {
+        if let Some(params) = &params {
+            if params.cursor.as_ref().is_some_and(|cursor| {
+                cursor.is_empty() || cursor.len() > MAPLE_DEVICE_LIST_MAX_CURSOR_BYTES
+            }) {
+                return Err(Error::Configuration(
+                    format!(
+                        "Maple device cursor must contain 1 to {MAPLE_DEVICE_LIST_MAX_CURSOR_BYTES} bytes"
+                    ),
+                ));
+            }
+            if let Some(limit) = params.limit {
+                if limit == 0 || limit > MAPLE_DEVICE_LIST_MAX_LIMIT {
+                    return Err(Error::Configuration(format!(
+                        "Maple device page limit must be between 1 and {MAPLE_DEVICE_LIST_MAX_LIMIT}"
+                    )));
+                }
+            }
+        }
+
+        let incoming_cursor = params.as_ref().and_then(|params| params.cursor.as_deref());
+        let requested_limit = params
+            .as_ref()
+            .and_then(|params| params.limit)
+            .unwrap_or(MAPLE_DEVICE_LIST_DEFAULT_LIMIT);
+        let endpoint = build_maple_devices_endpoint(params.as_ref());
+        let response: MapleDeviceListResponse = self
+            .authenticated_api_call(&endpoint, "GET", None::<()>)
+            .await?;
+        let cursor_consistent = response.has_more == response.next_cursor.is_some();
+        let cursor_valid = response.next_cursor.as_ref().is_none_or(|cursor| {
+            !cursor.is_empty() && cursor.len() <= MAPLE_DEVICE_LIST_MAX_CURSOR_BYTES
+        });
+        let page_progresses = !response.has_more
+            || (!response.devices.is_empty() && response.next_cursor.as_deref() != incoming_cursor);
+        if response.protocol_version != MAPLE_DEVICE_PROTOCOL_VERSION
+            || response.security_epoch == 0
+            || response.security_epoch > i64::MAX as u64
+            || !cursor_consistent
+            || !cursor_valid
+            || !page_progresses
+            || response.devices.len() > usize::from(requested_limit)
+        {
+            return Err(Error::InvalidResponse(
+                "Maple device list response is unsupported or internally inconsistent".to_string(),
+            ));
+        }
+        let mut registration_ids = HashSet::with_capacity(response.devices.len());
+        let mut device_ids = HashSet::with_capacity(response.devices.len());
+        let mut installation_ids = HashSet::with_capacity(response.devices.len());
+        let mut endpoint_ids = HashSet::with_capacity(response.devices.len());
+        for device in &response.devices {
+            device.validate().map_err(|error| {
+                Error::InvalidResponse(format!("Invalid Maple device directory record: {error}"))
+            })?;
+            if !registration_ids.insert(device.registration_id)
+                || !device_ids.insert(device.device_id)
+                || !installation_ids.insert(device.installation_id)
+                || !endpoint_ids.insert(device.iroh_endpoint_id.as_str())
+            {
+                return Err(Error::InvalidResponse(
+                    "Maple device list response contains duplicate device identities".to_string(),
+                ));
+            }
+        }
+        Ok(response)
+    }
+
+    /// Creates a short-lived, explicitly directed Maple pairing request.
+    ///
+    /// The borrowed request remains caller-owned on every error, including an
+    /// ambiguous transport failure. Its operation ID must be reused until the
+    /// caller obtains an unambiguous receipt or queries status. The SDK only
+    /// replays the exact cloned request automatically for HTTP 410 stale
+    /// attested-session recovery; semantic 400/409 responses are never replayed.
+    pub async fn create_maple_pairing(
+        &self,
+        request: &CreateMaplePairingRequest,
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingMutationResponse> {
+        request.validate()?;
+        let response: MaplePairingMutationResponse = self
+            .maple_pairing_json_call("/protected/maple/pairings/request", request)
+            .await?;
+        response.verify_create(request, issuers, trusted_now_unix_ms)
+    }
+
+    /// Lists a bounded, signed participant view of Maple pairings.
+    pub async fn list_maple_pairings(
+        &self,
+        request: &ListMaplePairingsRequest,
+        actor_signing_public_key: &[u8; 32],
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingListResponse> {
+        request.validate_with_signing_key(actor_signing_public_key)?;
+        let response: MaplePairingListResponse = self
+            .maple_pairing_json_call("/protected/maple/pairings/list", request)
+            .await?;
+        response.verify_for(request, issuers, trusted_now_unix_ms)
+    }
+
+    /// Fetches one participant-visible pairing status.
+    pub async fn get_maple_pairing_status(
+        &self,
+        request: &MaplePairingStatusRequest,
+        actor_role: MaplePairingRole,
+        actor_signing_public_key: &[u8; 32],
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingStatusResponse> {
+        request.validate_with_signing_key(actor_signing_public_key)?;
+        let response: MaplePairingStatusResponse = self
+            .maple_pairing_json_call("/protected/maple/pairings/status", request)
+            .await?;
+        response.verify_for(request, actor_role, issuers, trusted_now_unix_ms)
+    }
+
+    /// Approves one pending pairing as its selected host installation.
+    pub async fn approve_maple_pairing(
+        &self,
+        prepared: &PreparedMaplePairingApprovalV1,
+        host_signing_public_key: &[u8; 32],
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingMutationResponse> {
+        let request = prepared.as_inner();
+        request.validate_with_signing_key(host_signing_public_key)?;
+        let response: MaplePairingMutationResponse = self
+            .maple_pairing_json_call("/protected/maple/pairings/approve", request)
+            .await?;
+        response.verify_approve(request, issuers, trusted_now_unix_ms)
+    }
+
+    /// Confirms that the host durably committed the approved authorization.
+    ///
+    /// Callers must not invoke this until their local allowlist write is
+    /// durable. Only the resulting `active` receipt makes the controller view
+    /// eligible to dial the host.
+    pub async fn confirm_maple_pairing(
+        &self,
+        prepared: &PreparedMaplePairingHostCommitV1,
+        host_signing_public_key: &[u8; 32],
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingMutationResponse> {
+        let request = prepared.as_inner();
+        request.validate_with_signing_key(host_signing_public_key)?;
+        let response: MaplePairingMutationResponse = self
+            .maple_pairing_json_call("/protected/maple/pairings/confirm", request)
+            .await?;
+        response.verify_confirm(request, issuers, trusted_now_unix_ms)
+    }
+
+    /// Revokes one approved or active directional pairing.
+    pub async fn revoke_maple_pairing(
+        &self,
+        request: &RevokeMaplePairingRequest,
+        actor_signing_public_key: &[u8; 32],
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingMutationResponse> {
+        request.validate_with_signing_key(actor_signing_public_key)?;
+        let response: MaplePairingMutationResponse = self
+            .maple_pairing_json_call("/protected/maple/pairings/revoke", request)
+            .await?;
+        response.verify_revoke(request, issuers, trusted_now_unix_ms)
+    }
+
+    /// Lists a contiguous bounded sequence of issuer-signed revocations.
+    ///
+    /// Use the exact nil/zero/after-zero request to discover the current signed
+    /// namespace. The returned checkpoint must be compared with durable host
+    /// state and, on a higher generation, committed through the documented
+    /// clear-all-admissions/reset-cursor transaction before accepting grants or
+    /// events. Returned events remain deliberately non-ACK-ready until bound to
+    /// both the corresponding ticket-bound authorization and that durably
+    /// reconciled namespace.
+    pub async fn list_maple_pairing_revocations(
+        &self,
+        request: &ListMaplePairingRevocationsRequest,
+        host_signing_public_key: &[u8; 32],
+        issuers: &MaplePairingIssuerKeySet,
+    ) -> Result<VerifiedMaplePairingRevocationListResponse> {
+        request.validate_with_signing_key(host_signing_public_key)?;
+        let response: MaplePairingRevocationListResponse = self
+            .maple_pairing_json_call("/protected/maple/pairings/revocations/list", request)
+            .await?;
+        response.verify_for(request, issuers)
+    }
+
+    /// Acknowledges a revocation only after the caller durably commits it.
+    ///
+    /// This API never acknowledges automatically while listing or verifying an
+    /// event. The returned value is an exact operation receipt, not current
+    /// readiness authority: idempotent replay may return an older receipt after
+    /// newer events exist. Fetch and verify a fresh registration or revocation
+    /// list sync before treating the host as Ready or installing current
+    /// namespace state. The borrowed request and operation ID remain available
+    /// to the caller after an ambiguous failure.
+    pub async fn ack_maple_pairing_revocation(
+        &self,
+        prepared: &PreparedMaplePairingRevocationAckV1,
+        host_signing_public_key: &[u8; 32],
+        issuers: &MaplePairingIssuerKeySet,
+    ) -> Result<VerifiedMaplePairingRevocationAckResponse> {
+        let request = prepared.as_inner();
+        request.validate_with_signing_key(host_signing_public_key)?;
+        let response: MaplePairingRevocationAckResponse = self
+            .maple_pairing_json_call("/protected/maple/pairings/revocations/ack", request)
+            .await?;
+        response.verify_for(request, issuers)
     }
 
     pub async fn register_push_device(
@@ -2538,7 +2914,9 @@ impl OpenSecretClient {
 mod tests {
     use super::*;
     use crate::PushNotificationKeyPair;
+    use ed25519_dalek::{Signer, SigningKey};
     use futures::StreamExt;
+    use ring::signature::Ed25519KeyPair;
     use serde_json::json;
     use std::{
         collections::HashMap,
@@ -2783,6 +3161,166 @@ mod tests {
         BASE64.encode(encrypted)
     }
 
+    fn sample_maple_device_request(operation_id: Uuid) -> RegisterMapleDeviceRequest {
+        let identity_public_key =
+            hex::decode("d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737")
+                .unwrap();
+        let unsigned = RegisterMapleDeviceRequest::unsigned_v1(
+            operation_id,
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440003").unwrap(),
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440004").unwrap(),
+            None,
+            1,
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap(),
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440002").unwrap(),
+            BASE64.encode(&identity_public_key),
+            hex::encode(&identity_public_key),
+            7,
+            MapleIrohEndpointAddr::canonical_v1(
+                vec!["https://use1-1.relay.n0.iroh.link./".to_string()],
+                vec!["203.0.113.7:4433".to_string()],
+            )
+            .unwrap(),
+            MapleDevicePlatform::Macos,
+            "MacBook Pro",
+            vec!["agent.host".to_string(), "agent.control".to_string()],
+        );
+        let key = Ed25519KeyPair::from_seed_unchecked(&[17u8; 32]).unwrap();
+        let signature = key.sign(&unsigned.canonical_transcript().unwrap());
+        unsigned.with_signature(BASE64.encode(signature.as_ref()))
+    }
+
+    fn sample_maple_device(request: &RegisterMapleDeviceRequest) -> MapleDevice {
+        let mut capabilities = request.capabilities.clone();
+        capabilities.sort_unstable();
+        MapleDevice {
+            registration_id: Uuid::parse_str("550e8400-e29b-41d4-a716-446655440005").unwrap(),
+            device_id: request.device_id,
+            installation_id: request.installation_id,
+            identity_algorithm: request.identity_algorithm,
+            identity_public_key: request.identity_public_key.clone(),
+            iroh_endpoint_id: request.iroh_endpoint_id.clone(),
+            endpoint_epoch: request.endpoint_epoch,
+            iroh_endpoint_addr: request.iroh_endpoint_addr.clone(),
+            platform: request.platform,
+            display_name: request.display_name.clone(),
+            capabilities,
+            revision: 1,
+        }
+    }
+
+    fn sample_maple_device_registration_response(
+        request: &RegisterMapleDeviceRequest,
+    ) -> MapleDeviceRegistrationResponse {
+        let registration_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440005").unwrap();
+        let mut checkpoint = MapleRevocationStreamCheckpointV1 {
+            artifact_version: MAPLE_PAIRING_ARTIFACT_VERSION,
+            subject_account_id: request.asserted_account_id,
+            subject_project_id: request.asserted_project_id,
+            host: MaplePairingDeviceClaimV1 {
+                registration_id,
+                device_id: request.device_id,
+                installation_id: request.installation_id,
+                identity_algorithm: MaplePairingIdentityAlgorithm::Ed25519,
+                identity_public_key: request.identity_public_key.clone(),
+                endpoint_id: request.iroh_endpoint_id.clone(),
+                endpoint_epoch: request.endpoint_epoch,
+            },
+            security_epoch: request.known_security_epoch,
+            revocation_stream_id: Uuid::parse_str("15151515-1515-4515-8515-151515151515").unwrap(),
+            revocation_stream_generation: 1,
+            last_issued_issuer_sequence: 0,
+            last_acked_issuer_sequence: 0,
+            issuer_key_id: "maple-test-issuer-2026-08-13".to_string(),
+            issuer_signature: String::new(),
+        };
+        let issuer_seed = hex::decode(
+            pairing_fixture()["test_private_seeds_hex"]["issuer"]
+                .as_str()
+                .unwrap(),
+        )
+        .unwrap();
+        let issuer_seed: [u8; 32] = issuer_seed.try_into().unwrap();
+        checkpoint.issuer_signature = BASE64.encode(
+            SigningKey::from_bytes(&issuer_seed)
+                .sign(&checkpoint.canonical_transcript().unwrap())
+                .to_bytes(),
+        );
+        MapleDeviceRegistrationResponse {
+            protocol_version: MAPLE_DEVICE_PROTOCOL_VERSION,
+            operation_id: request.operation_id,
+            registration_id,
+            device_id: request.device_id,
+            revision: 1,
+            accepted_at: chrono::DateTime::parse_from_rfc3339("2026-08-12T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            security_epoch: request.known_security_epoch,
+            revocation_sync: MapleRevocationSyncV1 {
+                security_epoch: request.known_security_epoch,
+                status: MapleRevocationSyncStatusV1::Ready,
+                stream_checkpoint: checkpoint,
+                reset_clear_instruction: None,
+            },
+        }
+    }
+
+    fn pairing_fixture() -> serde_json::Value {
+        serde_json::from_str(include_str!(
+            "../tests/fixtures/maple_pairing_v1_vectors.json"
+        ))
+        .unwrap()
+    }
+
+    fn sample_create_maple_pairing_request() -> CreateMaplePairingRequest {
+        serde_json::from_value(pairing_fixture()["create_request"].clone()).unwrap()
+    }
+
+    fn sample_pairing_issuer_keys() -> MaplePairingIssuerKeySet {
+        MaplePairingIssuerKeySet::from_v1(
+            serde_json::from_value(pairing_fixture()["issuer_keyset"].clone()).unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn response_time_from_pairing_fixture() -> i64 {
+        pairing_fixture()["request_ticket"]["created_at_unix_ms"]
+            .as_i64()
+            .unwrap()
+    }
+
+    fn sample_pending_pairing_response(
+        request: &CreateMaplePairingRequest,
+    ) -> MaplePairingMutationResponse {
+        let ticket: MaplePairRequestTicketV1 =
+            serde_json::from_value(pairing_fixture()["request_ticket"].clone()).unwrap();
+        MaplePairingMutationResponse {
+            protocol_version: MAPLE_PAIRING_PROTOCOL_VERSION,
+            operation_id: request.operation_id,
+            pairing: MaplePairingStatusV1 {
+                pairing_request_id: ticket.pairing_request_id,
+                pair_id: ticket.pair_id,
+                state: MaplePairingState::Pending,
+                revision: 1,
+                pairing_incarnation: ticket.pairing_incarnation,
+                revocation_stream_id: None,
+                revocation_stream_generation: None,
+                direction: request.direction,
+                execution_target_id: request.execution_target_id,
+                controller_registration_id: request.controller_registration_id,
+                host_registration_id: request.host_registration_id,
+                created_at_unix_ms: ticket.created_at_unix_ms,
+                expires_at_unix_ms: ticket.expires_at_unix_ms,
+                approved_at_unix_ms: None,
+                activated_at_unix_ms: None,
+                revoked_at_unix_ms: None,
+                request_ticket: Some(ticket),
+                pair_authorization: None,
+                revocation: None,
+            },
+        }
+    }
+
     fn decrypt_request_body<T: serde::de::DeserializeOwned>(
         request: &Request,
         session_key: &[u8; 32],
@@ -2855,6 +3393,19 @@ mod tests {
         }));
 
         assert_eq!(endpoint, "/v1/conversations?unassigned_project=true");
+    }
+
+    #[test]
+    fn test_build_maple_devices_endpoint_encodes_opaque_cursor() {
+        let endpoint = build_maple_devices_endpoint(Some(&MapleDeviceListParams {
+            cursor: Some("opaque+/cursor==".to_string()),
+            limit: Some(25),
+        }));
+
+        assert_eq!(
+            endpoint,
+            "/protected/maple/devices?cursor=opaque%2B%2Fcursor%3D%3D&limit=25"
+        );
     }
 
     #[test]
@@ -3010,6 +3561,141 @@ mod tests {
     }
 
     #[test]
+    fn maple_security_epoch_stale_error_requires_the_exact_frozen_wire_shape() {
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../tests/fixtures/maple_pairing_v1_vectors.json"
+        ))
+        .unwrap();
+        let stale = fixture["maple_security_epoch_stale_error"].clone();
+        assert!(matches!(
+            classify_api_error(409, serde_json::to_string(&stale).unwrap()),
+            Error::MapleSecurityEpochStale
+        ));
+
+        for body in [
+            json!({
+                "status": 409,
+                "code": "maple_security_epoch_stale",
+                "message": MAPLE_SECURITY_EPOCH_STALE_MESSAGE,
+            }),
+            json!({
+                "status": 409,
+                "code": MAPLE_SECURITY_EPOCH_STALE_CODE,
+                "message": "refresh and retry",
+            }),
+            json!({
+                "status": 400,
+                "code": MAPLE_SECURITY_EPOCH_STALE_CODE,
+                "message": MAPLE_SECURITY_EPOCH_STALE_MESSAGE,
+            }),
+        ] {
+            assert!(matches!(
+                classify_api_error(409, serde_json::to_string(&body).unwrap()),
+                Error::Api { status: 409, .. }
+            ));
+        }
+        assert!(matches!(
+            classify_api_error(400, serde_json::to_string(&stale).unwrap()),
+            Error::Api { status: 400, .. }
+        ));
+    }
+
+    #[test]
+    fn maple_reset_clear_required_error_requires_the_exact_sanitized_wire_shape() {
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../tests/fixtures/maple_pairing_v1_vectors.json"
+        ))
+        .unwrap();
+        let reset_clear = fixture["maple_pairing_reset_clear_required_error"].clone();
+        assert_eq!(reset_clear["status"], 409);
+        assert_eq!(reset_clear["code"], MAPLE_PAIRING_RESET_CLEAR_REQUIRED_CODE);
+        assert_eq!(
+            reset_clear["message"],
+            MAPLE_PAIRING_RESET_CLEAR_REQUIRED_MESSAGE
+        );
+        assert!(matches!(
+            classify_api_error(409, serde_json::to_string(&reset_clear).unwrap()),
+            Error::MaplePairingResetClearRequired
+        ));
+
+        for body in [
+            json!({
+                "status": 409,
+                "code": "maple_pairing_reset_clear_required",
+                "message": MAPLE_PAIRING_RESET_CLEAR_REQUIRED_MESSAGE,
+            }),
+            json!({
+                "status": 409,
+                "code": MAPLE_PAIRING_RESET_CLEAR_REQUIRED_CODE,
+                "message": "host 77777777-7777-4777-8777-777777777777 has reset 93000000-0000-4000-8000-000000000003",
+            }),
+        ] {
+            assert!(matches!(
+                classify_api_error(409, serde_json::to_string(&body).unwrap()),
+                Error::Api { status: 409, .. }
+            ));
+        }
+        assert!(matches!(
+            classify_api_error(400, serde_json::to_string(&reset_clear).unwrap()),
+            Error::Api { status: 400, .. }
+        ));
+    }
+
+    #[test]
+    fn maple_installation_retired_error_is_typed_only_for_sanitized_exact_shape() {
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../tests/fixtures/maple_pairing_v1_vectors.json"
+        ))
+        .unwrap();
+        let retired = fixture["maple_installation_retired_error"].clone();
+        assert_eq!(retired.as_object().unwrap().len(), 3);
+        assert_eq!(retired["status"], 409);
+        assert_eq!(retired["code"], MAPLE_INSTALLATION_RETIRED_CODE);
+        assert_eq!(retired["message"], MAPLE_INSTALLATION_RETIRED_MESSAGE);
+        assert!(matches!(
+            classify_api_error(409, serde_json::to_string(&retired).unwrap()),
+            Error::MapleInstallationRetired
+        ));
+        assert_eq!(
+            Error::MapleInstallationRetired.to_string(),
+            MAPLE_INSTALLATION_RETIRED_MESSAGE
+        );
+
+        for body in [
+            json!({
+                "status": 409,
+                "code": "maple_installation_retired",
+                "message": MAPLE_INSTALLATION_RETIRED_MESSAGE,
+            }),
+            json!({
+                "status": 409,
+                "code": MAPLE_INSTALLATION_RETIRED_CODE,
+                "message": "installation 99999999-9999-4999-8999-999999999999 is retired",
+            }),
+            json!({
+                "status": 409,
+                "code": MAPLE_INSTALLATION_RETIRED_CODE,
+                "message": MAPLE_INSTALLATION_RETIRED_MESSAGE,
+                "installation_instance_id": "99999999-9999-4999-8999-999999999999",
+            }),
+            json!({
+                "status": 400,
+                "code": MAPLE_INSTALLATION_RETIRED_CODE,
+                "message": MAPLE_INSTALLATION_RETIRED_MESSAGE,
+            }),
+        ] {
+            assert!(matches!(
+                classify_api_error(409, serde_json::to_string(&body).unwrap()),
+                Error::Api { status: 409, .. }
+            ));
+        }
+        assert!(matches!(
+            classify_api_error(400, serde_json::to_string(&retired).unwrap()),
+            Error::Api { status: 400, .. }
+        ));
+    }
+
+    #[test]
     fn android_emulator_alias_is_not_a_desktop_mock_bypass() {
         let client = OpenSecretClient::new("http://10.0.2.2:3000");
         if cfg!(target_os = "android") {
@@ -3072,6 +3758,547 @@ mod tests {
         second.unwrap();
         assert_eq!(server_secrets.lock().unwrap().len(), 2);
         assert!(client.get_session_id().unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn register_maple_device_uses_encrypted_protected_endpoint() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let session_id = Uuid::new_v4();
+        let session_key = [61u8; 32];
+        let request = sample_maple_device_request(Uuid::new_v4());
+        let response_receipt = sample_maple_device_registration_response(&request);
+
+        client
+            .session_manager
+            .set_session(session_id, session_key)
+            .unwrap();
+        client
+            .session_manager
+            .set_tokens(
+                "access_token".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/protected/maple/devices/register"))
+            .and(header("authorization", "Bearer access_token"))
+            .and(header("x-session-id", session_id.to_string()))
+            .and(EncryptedJsonBodyMatcher {
+                session_key,
+                expected: serde_json::to_value(&request).unwrap(),
+            })
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &response_receipt)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = client
+            .register_maple_device(&request, &sample_pairing_issuer_keys())
+            .await
+            .unwrap();
+
+        assert_eq!(response.registration_id(), response_receipt.registration_id);
+        assert_eq!(response.device_id(), response_receipt.device_id);
+        assert_eq!(response.security_epoch(), response_receipt.security_epoch);
+    }
+
+    #[tokio::test]
+    async fn register_maple_device_preserves_operation_id_across_auth_retry() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let session_id = Uuid::new_v4();
+        let session_key = [62u8; 32];
+        let operation_id = Uuid::new_v4();
+        let request = sample_maple_device_request(operation_id);
+        let expected_request = serde_json::to_value(&request).unwrap();
+        let response_receipt = sample_maple_device_registration_response(&request);
+
+        client
+            .session_manager
+            .set_session(session_id, session_key)
+            .unwrap();
+        client
+            .session_manager
+            .set_tokens(
+                "expired_access".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/protected/maple/devices/register"))
+            .and(header("authorization", "Bearer expired_access"))
+            .and(EncryptedJsonBodyMatcher {
+                session_key,
+                expected: expected_request.clone(),
+            })
+            .respond_with(
+                ResponseTemplate::new(401).set_body_json(json!({ "message": "jwt expired" })),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/refresh"))
+            .and(MissingHeaderMatcher("authorization"))
+            .and(header("x-session-id", session_id.to_string()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(encrypted_response(
+                &session_key,
+                &json!({
+                    "access_token": "fresh_access",
+                    "refresh_token": "fresh_refresh",
+                }),
+            )))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/protected/maple/devices/register"))
+            .and(header("authorization", "Bearer fresh_access"))
+            .and(EncryptedJsonBodyMatcher {
+                session_key,
+                expected: expected_request,
+            })
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &response_receipt)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = client
+            .register_maple_device(&request, &sample_pairing_issuer_keys())
+            .await
+            .unwrap();
+
+        assert_eq!(response.registration_id(), response_receipt.registration_id);
+        assert_eq!(response.security_epoch(), response_receipt.security_epoch);
+        assert_eq!(request.operation_id, operation_id);
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn create_maple_pairing_uses_exact_encrypted_route_and_verified_receipt() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let session_id = Uuid::new_v4();
+        let session_key = [71u8; 32];
+        let request = sample_create_maple_pairing_request();
+        let response = sample_pending_pairing_response(&request);
+        client
+            .session_manager
+            .set_session(session_id, session_key)
+            .unwrap();
+        client
+            .session_manager
+            .set_tokens(
+                "access_token".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/protected/maple/pairings/request"))
+            .and(header("authorization", "Bearer access_token"))
+            .and(header("x-session-id", session_id.to_string()))
+            .and(EncryptedJsonBodyMatcher {
+                session_key,
+                expected: serde_json::to_value(&request).unwrap(),
+            })
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &response)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let verified = client
+            .create_maple_pairing(
+                &request,
+                &sample_pairing_issuer_keys(),
+                response.pairing.created_at_unix_ms,
+            )
+            .await
+            .unwrap();
+        assert_eq!(verified.operation_id, request.operation_id);
+        assert_eq!(
+            verified.pairing.as_inner().state,
+            MaplePairingState::Pending
+        );
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn create_maple_pairing_replays_exact_body_only_for_stale_session_410() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let stale_session_id = Uuid::new_v4();
+        let stale_session_key = [72u8; 32];
+        let server_secret_key = [73u8; 32];
+        let server_public_key =
+            x25519_dalek::PublicKey::from(&x25519_dalek::StaticSecret::from(server_secret_key));
+        let fresh_session_id = Uuid::new_v4();
+        let fresh_session_key = [74u8; 32];
+        let request = sample_create_maple_pairing_request();
+        let expected_body = serde_json::to_value(&request).unwrap();
+        let response = sample_pending_pairing_response(&request);
+        client
+            .session_manager
+            .set_session(stale_session_id, stale_session_key)
+            .unwrap();
+        client
+            .session_manager
+            .set_tokens(
+                "access_token".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/protected/maple/pairings/request"))
+            .and(header("x-session-id", stale_session_id.to_string()))
+            .and(EncryptedJsonBodyMatcher {
+                session_key: stale_session_key,
+                expected: expected_body.clone(),
+            })
+            .respond_with(ResponseTemplate::new(410).set_body_string("stale session"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(PathPrefixMatcher("/attestation/"))
+            .respond_with(AttestationResponder {
+                server_public_key: server_public_key.to_bytes(),
+            })
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/key_exchange"))
+            .and(MissingHeaderMatcher("authorization"))
+            .respond_with(KeyExchangeResponder {
+                server_secret_key,
+                session_key: fresh_session_key,
+                session_id: fresh_session_id.to_string(),
+            })
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/protected/maple/pairings/request"))
+            .and(header("x-session-id", fresh_session_id.to_string()))
+            .and(EncryptedJsonBodyMatcher {
+                session_key: fresh_session_key,
+                expected: expected_body,
+            })
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&fresh_session_key, &response)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        client
+            .create_maple_pairing(
+                &request,
+                &sample_pairing_issuer_keys(),
+                response.pairing.created_at_unix_ms,
+            )
+            .await
+            .unwrap();
+        assert_eq!(request.operation_id, response.operation_id);
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn create_maple_pairing_never_reattests_or_replays_semantic_400_or_409() {
+        for status in [400, 409] {
+            let mock_server = MockServer::start().await;
+            let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+            let session_id = Uuid::new_v4();
+            let session_key = [75u8; 32];
+            let request = sample_create_maple_pairing_request();
+            client
+                .session_manager
+                .set_session(session_id, session_key)
+                .unwrap();
+            client
+                .session_manager
+                .set_tokens(
+                    "access_token".to_string(),
+                    Some("refresh_token".to_string()),
+                )
+                .unwrap();
+
+            Mock::given(method("POST"))
+                .and(path("/protected/maple/pairings/request"))
+                .and(EncryptedJsonBodyMatcher {
+                    session_key,
+                    expected: serde_json::to_value(&request).unwrap(),
+                })
+                .respond_with(ResponseTemplate::new(status).set_body_string("semantic failure"))
+                .expect(1)
+                .mount(&mock_server)
+                .await;
+
+            let error = client
+                .create_maple_pairing(
+                    &request,
+                    &sample_pairing_issuer_keys(),
+                    response_time_from_pairing_fixture(),
+                )
+                .await
+                .unwrap_err();
+            assert!(matches!(error, Error::Api { status: actual, .. } if actual == status));
+            assert_eq!(
+                request.operation_id,
+                sample_create_maple_pairing_request().operation_id
+            );
+            mock_server.verify().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn list_maple_devices_uses_bounded_cursor_page() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let session_id = Uuid::new_v4();
+        let session_key = [63u8; 32];
+        let request = sample_maple_device_request(Uuid::new_v4());
+        let response = MapleDeviceListResponse {
+            protocol_version: MAPLE_DEVICE_PROTOCOL_VERSION,
+            security_epoch: 1,
+            devices: vec![sample_maple_device(&request)],
+            next_cursor: Some("next-cursor".to_string()),
+            has_more: true,
+        };
+
+        client
+            .session_manager
+            .set_session(session_id, session_key)
+            .unwrap();
+        client
+            .session_manager
+            .set_tokens(
+                "access_token".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        Mock::given(method("GET"))
+            .and(path("/protected/maple/devices"))
+            .and(query_param("cursor", "opaque+/cursor=="))
+            .and(query_param("limit", "25"))
+            .and(header("authorization", "Bearer access_token"))
+            .and(header("x-session-id", session_id.to_string()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &response)),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let listed = client
+            .list_maple_devices(Some(MapleDeviceListParams {
+                cursor: Some("opaque+/cursor==".to_string()),
+                limit: Some(25),
+            }))
+            .await
+            .unwrap();
+
+        assert_eq!(listed, response);
+    }
+
+    #[tokio::test]
+    async fn list_maple_devices_rejects_unbounded_or_empty_page_inputs_locally() {
+        let client = OpenSecretClient::new("http://localhost:3000").unwrap();
+
+        for params in [
+            MapleDeviceListParams {
+                cursor: None,
+                limit: Some(0),
+            },
+            MapleDeviceListParams {
+                cursor: None,
+                limit: Some(MAPLE_DEVICE_LIST_MAX_LIMIT + 1),
+            },
+            MapleDeviceListParams {
+                cursor: Some(String::new()),
+                limit: Some(10),
+            },
+        ] {
+            let error = client.list_maple_devices(Some(params)).await.unwrap_err();
+            assert!(matches!(error, Error::Configuration(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn list_maple_devices_rejects_malformed_or_oversized_server_pages() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let session_id = Uuid::new_v4();
+        let session_key = [64u8; 32];
+        let request = sample_maple_device_request(Uuid::new_v4());
+        let mut malformed = sample_maple_device(&request);
+        malformed.display_name = " untrusted".to_string();
+        let response = MapleDeviceListResponse {
+            protocol_version: MAPLE_DEVICE_PROTOCOL_VERSION,
+            security_epoch: 1,
+            devices: vec![malformed],
+            next_cursor: Some(String::new()),
+            has_more: true,
+        };
+
+        client
+            .session_manager
+            .set_session(session_id, session_key)
+            .unwrap();
+        client
+            .session_manager
+            .set_tokens(
+                "access_token".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        Mock::given(method("GET"))
+            .and(path("/protected/maple/devices"))
+            .and(query_param("limit", "1"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &response)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let error = client
+            .list_maple_devices(Some(MapleDeviceListParams {
+                cursor: None,
+                limit: Some(1),
+            }))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::InvalidResponse(_)));
+    }
+
+    #[tokio::test]
+    async fn list_maple_devices_rejects_duplicate_server_identities() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let session_id = Uuid::new_v4();
+        let session_key = [65u8; 32];
+        let request = sample_maple_device_request(Uuid::new_v4());
+        let device = sample_maple_device(&request);
+        let response = MapleDeviceListResponse {
+            protocol_version: MAPLE_DEVICE_PROTOCOL_VERSION,
+            security_epoch: 1,
+            devices: vec![device.clone(), device],
+            next_cursor: None,
+            has_more: false,
+        };
+
+        client
+            .session_manager
+            .set_session(session_id, session_key)
+            .unwrap();
+        client
+            .session_manager
+            .set_tokens(
+                "access_token".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        Mock::given(method("GET"))
+            .and(path("/protected/maple/devices"))
+            .and(query_param("limit", "2"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &response)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let error = client
+            .list_maple_devices(Some(MapleDeviceListParams {
+                cursor: None,
+                limit: Some(2),
+            }))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::InvalidResponse(_)));
+    }
+
+    #[tokio::test]
+    async fn list_maple_devices_rejects_non_progressing_server_pages() {
+        for (request_cursor, response_cursor, devices) in [
+            (
+                None,
+                Some(
+                    "AAAAAAAAAAEAAAAAAAAAAgMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMD".to_string(),
+                ),
+                Vec::new(),
+            ),
+            (
+                Some(
+                    "AAAAAAAAAAEAAAAAAAAAAgMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMD".to_string(),
+                ),
+                Some(
+                    "AAAAAAAAAAEAAAAAAAAAAgMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMD".to_string(),
+                ),
+                vec![sample_maple_device(&sample_maple_device_request(
+                    Uuid::new_v4(),
+                ))],
+            ),
+        ] {
+            let mock_server = MockServer::start().await;
+            let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+            let session_id = Uuid::new_v4();
+            let session_key = [66u8; 32];
+            client
+                .session_manager
+                .set_session(session_id, session_key)
+                .unwrap();
+            client
+                .session_manager
+                .set_tokens("access_token".to_string(), None)
+                .unwrap();
+            let response = MapleDeviceListResponse {
+                protocol_version: MAPLE_DEVICE_PROTOCOL_VERSION,
+                security_epoch: 1,
+                devices,
+                next_cursor: response_cursor,
+                has_more: true,
+            };
+            Mock::given(method("GET"))
+                .and(path("/protected/maple/devices"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(encrypted_response(&session_key, &response)),
+                )
+                .mount(&mock_server)
+                .await;
+
+            let error = client
+                .list_maple_devices(Some(MapleDeviceListParams {
+                    cursor: request_cursor,
+                    limit: Some(1),
+                }))
+                .await
+                .unwrap_err();
+            assert!(matches!(error, Error::InvalidResponse(_)));
+        }
     }
 
     #[tokio::test]
@@ -5372,7 +6599,7 @@ mod tests {
                 session_key: stale_session_key,
                 expected: json!({ "input": "stale stream" }),
             })
-            .respond_with(ResponseTemplate::new(400).set_body_string("stale session"))
+            .respond_with(ResponseTemplate::new(410).set_body_string("stale session"))
             .expect(1)
             .mount(&mock_server)
             .await;

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -35,6 +35,21 @@ pub enum Error {
     #[error("Invalid response: {0}")]
     InvalidResponse(String),
 
+    #[error("Maple device security epoch is stale; refresh device state and retry.")]
+    MapleSecurityEpochStale,
+
+    #[error("Maple remote access must be cleared on the host before this operation can continue.")]
+    MaplePairingResetClearRequired,
+
+    /// The installation enrollment was permanently retired after its remote
+    /// authority lineage was cleared. The caller must reset local Remote
+    /// enrollment state, generate a fresh installation ID and identity, and
+    /// enroll again; retrying this installation cannot restore authority.
+    #[error(
+        "This Maple installation enrollment is retired; reset Remote access on this device and enroll it again."
+    )]
+    MapleInstallationRetired,
+
     #[error("API error: {status}: {message}")]
     Api { status: u16, message: String },
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3,6 +3,7 @@ mod cbor;
 pub mod client;
 pub mod crypto;
 pub mod error;
+mod pairing;
 pub mod pcr;
 pub mod push;
 pub mod session;
@@ -10,6 +11,7 @@ pub mod types;
 
 pub use client::{InferenceRequest, InferenceResponse, OpenSecretClient, OpenSecretResponseBody};
 pub use error::{Error, Result};
+pub use pairing::*;
 pub use pcr::{Pcr0Environment, Pcr0TrustPolicy};
 pub use push::*;
 pub use types::*;

--- a/rust/src/pairing.rs
+++ b/rust/src/pairing.rs
@@ -1,0 +1,6907 @@
+//! Maple's encrypted, account-scoped remote pairing control-plane contract.
+//!
+//! The service mediates explicit, one-way controller-to-host approval. It does
+//! not participate in the Iroh data path and its artifacts do not become
+//! authority until their issuer signatures have been checked against an
+//! explicitly supplied trusted key set. Private device keys remain owned by
+//! the calling Maple installation and are never accepted by this module.
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use ed25519_dalek::{Signature, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use uuid::Uuid;
+
+use crate::{Error, Result};
+
+pub const MAPLE_PAIRING_PROTOCOL_VERSION: u16 = 1;
+pub const MAPLE_PAIRING_TRANSCRIPT_VERSION: u16 = 1;
+pub const MAPLE_PAIRING_ARTIFACT_VERSION: u16 = 1;
+pub const MAPLE_PAIRING_LIST_DEFAULT_LIMIT: u16 = 25;
+pub const MAPLE_PAIRING_LIST_MAX_LIMIT: u16 = 100;
+pub const MAPLE_PAIRING_CURSOR_MAX_BYTES: usize = 512;
+pub const MAPLE_PAIRING_MAX_TICKET_TTL_MS: i64 = 10 * 60 * 1000;
+pub const MAPLE_PAIRING_MAX_CLOCK_SKEW_MS: i64 = 30 * 1000;
+pub const MAPLE_RESET_CLEAR_MAX_ADMISSIONS: u16 = 128;
+
+const ED25519_PUBLIC_KEY_BYTES: usize = 32;
+const ED25519_SIGNATURE_BYTES: usize = 64;
+const NONCE_BYTES: usize = 32;
+const DIGEST_BYTES: usize = 32;
+const MAX_REASON_CODE_BYTES: usize = 64;
+const MAX_ISSUER_KEY_ID_BYTES: usize = 64;
+const RESET_CLEAR_ADMISSION_SET_DOMAIN: &str = "os.maple-reset-clear-admission-set.v1";
+const RESET_CLEAR_INSTRUCTION_MATERIAL_DOMAIN: &str =
+    "os.maple-reset-clear-instruction-material.v1";
+const RESET_CLEAR_CHAIN_DOMAIN: &str = "os.maple-reset-clear-chain.v1";
+const RESET_CLEAR_REQUIRED_DOMAIN: &str = "os.maple-reset-clear-required.v1";
+
+macro_rules! redacted_debug {
+    ($type:ty) => {
+        impl std::fmt::Debug for $type {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter
+                    .debug_struct(stringify!($type))
+                    .field("authority_material", &"[redacted]")
+                    .finish()
+            }
+        }
+    };
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum MaplePairingDirection {
+    ControllerToHost,
+}
+
+impl MaplePairingDirection {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ControllerToHost => "controller_to_host",
+        }
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum MaplePairingState {
+    Pending,
+    AwaitingHostCommit,
+    Active,
+    Expired,
+    Revoked,
+}
+
+impl MaplePairingState {
+    fn canonical_order(self) -> u8 {
+        match self {
+            Self::Pending => 0,
+            Self::AwaitingHostCommit => 1,
+            Self::Active => 2,
+            Self::Expired => 3,
+            Self::Revoked => 4,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::AwaitingHostCommit => "awaiting_host_commit",
+            Self::Active => "active",
+            Self::Expired => "expired",
+            Self::Revoked => "revoked",
+        }
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum MaplePairingRole {
+    Controller,
+    Host,
+}
+
+impl MaplePairingRole {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Controller => "controller",
+            Self::Host => "host",
+        }
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MaplePairingIdentityAlgorithm {
+    Ed25519,
+}
+
+impl MaplePairingIdentityAlgorithm {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Ed25519 => "ed25519",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CreateMaplePairingRequest {
+    pub protocol_version: u16,
+    pub transcript_version: u16,
+    pub operation_id: Uuid,
+    pub asserted_account_id: Uuid,
+    pub asserted_project_id: Uuid,
+    pub controller_registration_id: Uuid,
+    pub controller_device_id: Uuid,
+    pub controller_installation_id: Uuid,
+    pub controller_endpoint_id: String,
+    pub controller_endpoint_epoch: u64,
+    pub host_registration_id: Uuid,
+    pub host_device_id: Uuid,
+    pub host_installation_id: Uuid,
+    pub host_endpoint_id: String,
+    pub host_endpoint_epoch: u64,
+    pub direction: MaplePairingDirection,
+    pub execution_target_id: Uuid,
+    pub pairing_request_nonce: String,
+    pub protocol_min: u16,
+    pub protocol_max: u16,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ListMaplePairingsRequest {
+    pub protocol_version: u16,
+    pub transcript_version: u16,
+    pub query_id: Uuid,
+    pub asserted_account_id: Uuid,
+    pub asserted_project_id: Uuid,
+    pub actor_registration_id: Uuid,
+    pub role: MaplePairingRole,
+    pub states: Vec<MaplePairingState>,
+    pub cursor: Option<String>,
+    pub limit: Option<u16>,
+    pub signature: String,
+}
+
+impl ListMaplePairingsRequest {
+    pub fn canonical_states(mut states: Vec<MaplePairingState>) -> Result<Vec<MaplePairingState>> {
+        if states.is_empty() {
+            return Err(Error::Configuration(
+                "Maple pairing state filter must not be empty".to_string(),
+            ));
+        }
+        states.sort_by_key(|state| state.canonical_order());
+        if states.windows(2).any(|states| states[0] == states[1]) {
+            return Err(Error::Configuration(
+                "Maple pairing state filter must not contain duplicates".to_string(),
+            ));
+        }
+        Ok(states)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairingStatusRequest {
+    pub protocol_version: u16,
+    pub transcript_version: u16,
+    pub query_id: Uuid,
+    pub asserted_account_id: Uuid,
+    pub asserted_project_id: Uuid,
+    pub actor_registration_id: Uuid,
+    pub pair_id: Uuid,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ApproveMaplePairingRequest {
+    pub protocol_version: u16,
+    pub transcript_version: u16,
+    pub operation_id: Uuid,
+    pub asserted_account_id: Uuid,
+    pub asserted_project_id: Uuid,
+    pub host_registration_id: Uuid,
+    pub pairing_request_id: Uuid,
+    pub pair_id: Uuid,
+    pub expected_pairing_revision: i64,
+    pub pairing_incarnation: u64,
+    pub revocation_stream_id: Uuid,
+    pub revocation_stream_generation: u64,
+    pub request_ticket_digest: String,
+    pub host_approval_nonce: String,
+    pub approved_protocol_min: u16,
+    pub approved_protocol_max: u16,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ConfirmMaplePairingRequest {
+    pub protocol_version: u16,
+    pub transcript_version: u16,
+    pub operation_id: Uuid,
+    pub asserted_account_id: Uuid,
+    pub asserted_project_id: Uuid,
+    pub host_registration_id: Uuid,
+    pub pairing_request_id: Uuid,
+    pub pair_id: Uuid,
+    pub expected_pairing_revision: i64,
+    pub pairing_incarnation: u64,
+    pub pair_authorization_digest: String,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RevokeMaplePairingRequest {
+    pub protocol_version: u16,
+    pub transcript_version: u16,
+    pub operation_id: Uuid,
+    pub asserted_account_id: Uuid,
+    pub asserted_project_id: Uuid,
+    pub actor_registration_id: Uuid,
+    pub actor_role: MaplePairingRole,
+    pub pairing_request_id: Uuid,
+    pub pair_id: Uuid,
+    pub expected_pairing_revision: i64,
+    pub pairing_incarnation: u64,
+    pub revocation_stream_id: Uuid,
+    pub revocation_stream_generation: u64,
+    pub reason_code: String,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ListMaplePairingRevocationsRequest {
+    pub protocol_version: u16,
+    pub transcript_version: u16,
+    pub query_id: Uuid,
+    pub asserted_account_id: Uuid,
+    pub asserted_project_id: Uuid,
+    pub host_registration_id: Uuid,
+    pub revocation_stream_id: Uuid,
+    pub revocation_stream_generation: u64,
+    pub after_issuer_sequence: u64,
+    pub limit: Option<u16>,
+    pub signature: String,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AckMaplePairingRevocationRequest {
+    pub protocol_version: u16,
+    pub transcript_version: u16,
+    pub operation_id: Uuid,
+    pub asserted_account_id: Uuid,
+    pub asserted_project_id: Uuid,
+    pub host_registration_id: Uuid,
+    pub revocation_stream_id: Uuid,
+    pub revocation_stream_generation: u64,
+    pub event_id: Uuid,
+    pub issuer_sequence: u64,
+    pub event_digest: String,
+    pub expected_previous_issuer_sequence: u64,
+    pub signature: String,
+}
+
+impl std::fmt::Debug for AckMaplePairingRevocationRequest {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AckMaplePairingRevocationRequest")
+            .field("protocol_version", &self.protocol_version)
+            .field("transcript_version", &self.transcript_version)
+            .field("issuer_sequence", &self.issuer_sequence)
+            .field(
+                "expected_previous_issuer_sequence",
+                &self.expected_previous_issuer_sequence,
+            )
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairingDeviceClaimV1 {
+    pub registration_id: Uuid,
+    pub device_id: Uuid,
+    pub installation_id: Uuid,
+    pub identity_algorithm: MaplePairingIdentityAlgorithm,
+    pub identity_public_key: String,
+    pub endpoint_id: String,
+    pub endpoint_epoch: u64,
+}
+
+/// Public wire name used by the OpenSecret service. The older SDK-specific
+/// name remains available for source compatibility while the pairing API is
+/// still unreleased.
+pub type MapleDeviceClaimV1 = MaplePairingDeviceClaimV1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairRequestTicketV1 {
+    pub artifact_version: u16,
+    pub subject_account_id: Uuid,
+    pub subject_project_id: Uuid,
+    pub pairing_request_id: Uuid,
+    pub pair_id: Uuid,
+    pub direction: MaplePairingDirection,
+    pub execution_target_id: Uuid,
+    pub controller: MaplePairingDeviceClaimV1,
+    pub host: MaplePairingDeviceClaimV1,
+    pub pairing_request_nonce: String,
+    pub controller_request_operation_id: Uuid,
+    pub controller_request_digest: String,
+    pub controller_request_signature: String,
+    pub pairing_incarnation: u64,
+    pub protocol_min: u16,
+    pub protocol_max: u16,
+    pub created_at_unix_ms: i64,
+    pub expires_at_unix_ms: i64,
+    pub issuer_key_id: String,
+    pub issuer_signature: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairAuthorizationV1 {
+    pub artifact_version: u16,
+    pub subject_account_id: Uuid,
+    pub subject_project_id: Uuid,
+    pub pairing_request_id: Uuid,
+    pub pair_id: Uuid,
+    pub direction: MaplePairingDirection,
+    pub execution_target_id: Uuid,
+    pub controller: MaplePairingDeviceClaimV1,
+    pub host: MaplePairingDeviceClaimV1,
+    pub pairing_request_nonce: String,
+    pub controller_request_operation_id: Uuid,
+    pub controller_request_digest: String,
+    pub controller_request_signature: String,
+    pub request_ticket_digest: String,
+    pub host_approval_operation_id: Uuid,
+    pub host_approval_expected_pairing_revision: i64,
+    pub host_approval_nonce: String,
+    pub host_approval_digest: String,
+    pub host_approval_signature: String,
+    pub pairing_incarnation: u64,
+    pub revocation_stream_id: Uuid,
+    pub revocation_stream_generation: u64,
+    pub protocol_min: u16,
+    pub protocol_max: u16,
+    pub approved_at_unix_ms: i64,
+    pub issuer_key_id: String,
+    pub issuer_signature: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairRevocationV1 {
+    pub artifact_version: u16,
+    pub event_id: Uuid,
+    pub subject_account_id: Uuid,
+    pub subject_project_id: Uuid,
+    pub recipient_host_registration_id: Uuid,
+    pub issuer_sequence: u64,
+    pub revocation_stream_id: Uuid,
+    pub revocation_stream_generation: u64,
+    pub pairing_request_id: Uuid,
+    pub pair_id: Uuid,
+    pub direction: MaplePairingDirection,
+    pub execution_target_id: Uuid,
+    pub controller: MaplePairingDeviceClaimV1,
+    pub host: MaplePairingDeviceClaimV1,
+    pub pairing_incarnation: u64,
+    pub pair_authorization_digest: String,
+    pub revoked_by_registration_id: Uuid,
+    pub revoked_by_role: MaplePairingRole,
+    pub reason_code: String,
+    pub revoked_at_unix_ms: i64,
+    pub issuer_key_id: String,
+    pub issuer_signature: String,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MapleResetClearScopeV1 {
+    AllPairAuthorizationsForAccountProjectHostInstallation,
+}
+
+impl MapleResetClearScopeV1 {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::AllPairAuthorizationsForAccountProjectHostInstallation => {
+                "all_pair_authorizations_for_account_project_host_installation"
+            }
+        }
+    }
+}
+
+/// One private admission-set leaf supplied only to the canonical digest
+/// helper. Reset-clear artifacts expose only the bounded count and digest.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MapleResetClearAdmissionLeafV1 {
+    pub pair_id: Uuid,
+    pub pairing_incarnation: u64,
+    pub pair_authorization_digest: [u8; 32],
+}
+
+impl std::fmt::Debug for MapleResetClearAdmissionLeafV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MapleResetClearAdmissionLeafV1")
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MapleResetClearRequiredV1 {
+    pub artifact_version: u16,
+    pub event_id: Uuid,
+    pub reset_id: Uuid,
+    pub reset_generation: u64,
+    pub cumulative_reset_count: u64,
+    pub source_security_epoch: u64,
+    pub security_epoch: u64,
+    pub subject_account_id: Uuid,
+    pub subject_project_id: Uuid,
+    pub recipient_host_registration_id: Uuid,
+    pub host: MapleDeviceClaimV1,
+    pub issuer_sequence: u64,
+    pub source_revocation_stream_id: Uuid,
+    pub source_revocation_stream_generation: u64,
+    pub revocation_stream_id: Uuid,
+    pub revocation_stream_generation: u64,
+    pub clear_scope: MapleResetClearScopeV1,
+    pub admission_count: u16,
+    pub admission_set_digest: String,
+    pub previous_reset_clear_event_id: Option<Uuid>,
+    pub previous_instruction_material_digest: Option<String>,
+    pub previous_chain_digest: Option<String>,
+    pub reset_at_unix_ms: i64,
+    pub instruction_material_digest: String,
+    pub chain_digest: String,
+    pub issuer_key_id: String,
+    pub issuer_signature: String,
+}
+
+impl std::fmt::Debug for MapleResetClearRequiredV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MapleResetClearRequiredV1")
+            .field("artifact_version", &self.artifact_version)
+            .field("reset_generation", &self.reset_generation)
+            .field("cumulative_reset_count", &self.cumulative_reset_count)
+            .field("source_security_epoch", &self.source_security_epoch)
+            .field("security_epoch", &self.security_epoch)
+            .field("admission_count", &self.admission_count)
+            .field(
+                "has_previous_reset",
+                &self.previous_reset_clear_event_id.is_some(),
+            )
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+#[non_exhaustive]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "event_type", content = "event", rename_all = "snake_case")]
+pub enum MapleRevocationStreamEventV1 {
+    PairRevocation(MaplePairRevocationV1),
+    ResetClearRequired(MapleResetClearRequiredV1),
+}
+
+impl std::fmt::Debug for MapleRevocationStreamEventV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let event_type = match self {
+            Self::PairRevocation(_) => "pair_revocation",
+            Self::ResetClearRequired(_) => "reset_clear_required",
+        };
+        formatter
+            .debug_struct("MapleRevocationStreamEventV1")
+            .field("event_type", &event_type)
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MapleRevocationSyncStatusV1 {
+    Ready,
+    RevocationsPending,
+    ResetClearRequired,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MapleRevocationSyncV1 {
+    pub security_epoch: u64,
+    pub status: MapleRevocationSyncStatusV1,
+    pub stream_checkpoint: MapleRevocationStreamCheckpointV1,
+    pub reset_clear_instruction: Option<MapleResetClearRequiredV1>,
+}
+
+impl std::fmt::Debug for MapleRevocationSyncV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MapleRevocationSyncV1")
+            .field("security_epoch", &self.security_epoch)
+            .field("status", &self.status)
+            .field(
+                "has_reset_clear_instruction",
+                &self.reset_clear_instruction.is_some(),
+            )
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairingStatusV1 {
+    pub pairing_request_id: Uuid,
+    pub pair_id: Uuid,
+    pub state: MaplePairingState,
+    pub revision: i64,
+    pub pairing_incarnation: u64,
+    pub revocation_stream_id: Option<Uuid>,
+    pub revocation_stream_generation: Option<u64>,
+    pub direction: MaplePairingDirection,
+    pub execution_target_id: Uuid,
+    pub controller_registration_id: Uuid,
+    pub host_registration_id: Uuid,
+    pub created_at_unix_ms: i64,
+    pub expires_at_unix_ms: i64,
+    pub approved_at_unix_ms: Option<i64>,
+    pub activated_at_unix_ms: Option<i64>,
+    pub revoked_at_unix_ms: Option<i64>,
+    pub request_ticket: Option<MaplePairRequestTicketV1>,
+    pub pair_authorization: Option<MaplePairAuthorizationV1>,
+    pub revocation: Option<MaplePairRevocationV1>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairingMutationResponse {
+    pub protocol_version: u16,
+    pub operation_id: Uuid,
+    pub pairing: MaplePairingStatusV1,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairingListResponse {
+    pub protocol_version: u16,
+    pub query_id: Uuid,
+    pub role: MaplePairingRole,
+    pub pairings: Vec<MaplePairingStatusV1>,
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairingStatusResponse {
+    pub protocol_version: u16,
+    pub query_id: Uuid,
+    pub pairing: MaplePairingStatusV1,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairingRevocationListResponse {
+    pub protocol_version: u16,
+    pub query_id: Uuid,
+    pub revocation_sync: MapleRevocationSyncV1,
+    pub events: Vec<MapleRevocationStreamEventV1>,
+    pub next_after_issuer_sequence: u64,
+    pub has_more: bool,
+}
+
+impl std::fmt::Debug for MaplePairingRevocationListResponse {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MaplePairingRevocationListResponse")
+            .field("protocol_version", &self.protocol_version)
+            .field("event_count", &self.events.len())
+            .field("has_more", &self.has_more)
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+/// Wire receipt for one accepted revocation acknowledgement operation.
+///
+/// Its signed checkpoint is bound to the operation at acceptance time. It is
+/// not a current readiness snapshot: an exact operation replay can return this
+/// historical receipt after newer revocations have been issued.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairingRevocationAckResponse {
+    pub protocol_version: u16,
+    pub operation_id: Uuid,
+    pub host_registration_id: Uuid,
+    pub stream_checkpoint: MapleRevocationStreamCheckpointV1,
+    pub event_id: Uuid,
+    pub issuer_sequence: u64,
+    pub last_acked_issuer_sequence: u64,
+    pub accepted_at_unix_ms: i64,
+}
+
+impl std::fmt::Debug for MaplePairingRevocationAckResponse {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MaplePairingRevocationAckResponse")
+            .field("protocol_version", &self.protocol_version)
+            .field("issuer_sequence", &self.issuer_sequence)
+            .field(
+                "last_acked_issuer_sequence",
+                &self.last_acked_issuer_sequence,
+            )
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MapleRevocationStreamCheckpointV1 {
+    pub artifact_version: u16,
+    pub subject_account_id: Uuid,
+    pub subject_project_id: Uuid,
+    pub host: MaplePairingDeviceClaimV1,
+    pub security_epoch: u64,
+    pub revocation_stream_id: Uuid,
+    pub revocation_stream_generation: u64,
+    pub last_issued_issuer_sequence: u64,
+    pub last_acked_issuer_sequence: u64,
+    pub issuer_key_id: String,
+    pub issuer_signature: String,
+}
+
+impl std::fmt::Debug for MapleRevocationStreamCheckpointV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MapleRevocationStreamCheckpointV1")
+            .field("artifact_version", &self.artifact_version)
+            .field("security_epoch", &self.security_epoch)
+            .field(
+                "last_issued_issuer_sequence",
+                &self.last_issued_issuer_sequence,
+            )
+            .field(
+                "last_acked_issuer_sequence",
+                &self.last_acked_issuer_sequence,
+            )
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+/// Opaque approval request prepared from a verified ticket and a durably
+/// reconciled host revocation namespace. Only this type is accepted by the SDK
+/// approval transport.
+#[derive(Clone)]
+pub struct PreparedMaplePairingApprovalV1 {
+    request: ApproveMaplePairingRequest,
+}
+
+redacted_debug!(PreparedMaplePairingApprovalV1);
+
+impl PreparedMaplePairingApprovalV1 {
+    pub fn as_inner(&self) -> &ApproveMaplePairingRequest {
+        &self.request
+    }
+
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        self.request.canonical_transcript()
+    }
+
+    pub fn with_signature(mut self, signature: impl Into<String>) -> Self {
+        self.request.signature = signature.into();
+        self
+    }
+}
+
+/// Opaque confirmation request prepared only after a verified host status and
+/// caller-asserted durable local authorization commit.
+#[derive(Clone)]
+pub struct PreparedMaplePairingHostCommitV1 {
+    request: ConfirmMaplePairingRequest,
+}
+
+redacted_debug!(PreparedMaplePairingHostCommitV1);
+
+impl PreparedMaplePairingHostCommitV1 {
+    pub fn as_inner(&self) -> &ConfirmMaplePairingRequest {
+        &self.request
+    }
+
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        self.request.canonical_transcript()
+    }
+
+    pub fn with_signature(mut self, signature: impl Into<String>) -> Self {
+        self.request.signature = signature.into();
+        self
+    }
+}
+
+/// Opaque ACK request prepared only from a revocation bound to the host's
+/// verified authorization and durably reconciled namespace after local apply.
+#[derive(Clone)]
+pub struct PreparedMaplePairingRevocationAckV1 {
+    request: AckMaplePairingRevocationRequest,
+}
+
+redacted_debug!(PreparedMaplePairingRevocationAckV1);
+
+impl PreparedMaplePairingRevocationAckV1 {
+    pub fn as_inner(&self) -> &AckMaplePairingRevocationRequest {
+        &self.request
+    }
+
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        self.request.canonical_transcript()
+    }
+
+    pub fn with_signature(mut self, signature: impl Into<String>) -> Self {
+        self.request.signature = signature.into();
+        self
+    }
+}
+
+/// Explicitly supplied trust anchors for OpenSecret pairing artifacts.
+///
+/// Constructing this set never fetches or derives trust from an artifact. Key
+/// rotation is an application/configuration concern and unknown key IDs fail
+/// closed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairingIssuerKeyV1 {
+    pub key_id: String,
+    pub algorithm: MaplePairingIdentityAlgorithm,
+    pub public_key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MaplePairingIssuerKeySetV1 {
+    pub version: u16,
+    pub keys: Vec<MaplePairingIssuerKeyV1>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MaplePairingIssuerKeySet {
+    keys: HashMap<String, [u8; ED25519_PUBLIC_KEY_BYTES]>,
+}
+
+/// Signing abstraction used by literal cross-implementation vector tests and
+/// trusted service integrations. Ordinary SDK clients only need the public
+/// [`MaplePairingIssuerKeySet`] verifier.
+pub trait MaplePairingIssuer: Send + Sync {
+    fn key_id(&self) -> &str;
+    fn public_key_bytes(&self) -> [u8; ED25519_PUBLIC_KEY_BYTES];
+    fn sign(&self, transcript: &[u8]) -> Result<[u8; ED25519_SIGNATURE_BYTES]>;
+}
+
+impl MaplePairingIssuerKeySet {
+    pub fn from_v1(keyset: MaplePairingIssuerKeySetV1) -> Result<Self> {
+        if keyset.version != 1 || keyset.keys.is_empty() {
+            return Err(Error::Configuration(
+                "Unsupported or empty Maple pairing issuer key set".to_string(),
+            ));
+        }
+        let mut previous_key_id: Option<&str> = None;
+        let mut trusted = HashMap::with_capacity(keyset.keys.len());
+        let mut public_keys = HashSet::with_capacity(keyset.keys.len());
+        for key in &keyset.keys {
+            validate_token(&key.key_id, MAX_ISSUER_KEY_ID_BYTES, "issuer key ID")?;
+            if previous_key_id.is_some_and(|previous| previous >= key.key_id.as_str()) {
+                return Err(Error::Configuration(
+                    "Maple pairing issuer keys must have unique ascending key IDs".to_string(),
+                ));
+            }
+            previous_key_id = Some(&key.key_id);
+            let public_key = decode_exact_base64(
+                &key.public_key,
+                ED25519_PUBLIC_KEY_BYTES,
+                "Maple pairing issuer public key",
+                ErrorClass::Configuration,
+            )?;
+            let public_key: [u8; ED25519_PUBLIC_KEY_BYTES] = public_key
+                .try_into()
+                .expect("exact public-key length was checked");
+            VerifyingKey::from_bytes(&public_key).map_err(|_| {
+                Error::Configuration(
+                    "Maple pairing issuer public key is not a valid Ed25519 point".to_string(),
+                )
+            })?;
+            if !public_keys.insert(public_key) {
+                return Err(Error::Configuration(
+                    "Maple pairing issuer public keys must be unique".to_string(),
+                ));
+            }
+            trusted.insert(key.key_id.clone(), public_key);
+        }
+        Ok(Self { keys: trusted })
+    }
+
+    pub fn new<I, S>(keys: I) -> Result<Self>
+    where
+        I: IntoIterator<Item = (S, [u8; ED25519_PUBLIC_KEY_BYTES])>,
+        S: Into<String>,
+    {
+        let mut trusted = HashMap::new();
+        let mut public_keys = HashSet::new();
+        for (key_id, public_key) in keys {
+            let key_id = key_id.into();
+            validate_token(&key_id, MAX_ISSUER_KEY_ID_BYTES, "issuer key ID")?;
+            VerifyingKey::from_bytes(&public_key).map_err(|_| {
+                Error::Configuration(
+                    "Maple pairing issuer public key is not a valid Ed25519 point".to_string(),
+                )
+            })?;
+            if !public_keys.insert(public_key) {
+                return Err(Error::Configuration(
+                    "Maple pairing issuer public keys must be unique".to_string(),
+                ));
+            }
+            if trusted.insert(key_id, public_key).is_some() {
+                return Err(Error::Configuration(
+                    "Maple pairing issuer key IDs must be unique".to_string(),
+                ));
+            }
+        }
+        if trusted.is_empty() {
+            return Err(Error::Configuration(
+                "Maple pairing trust set must not be empty".to_string(),
+            ));
+        }
+        Ok(Self { keys: trusted })
+    }
+
+    fn verify(&self, key_id: &str, transcript: &[u8], signature: &str) -> Result<()> {
+        let public_key = self.keys.get(key_id).ok_or_else(|| {
+            Error::InvalidResponse(
+                "Maple pairing artifact uses an untrusted issuer key".to_string(),
+            )
+        })?;
+        let signature = decode_exact_base64(
+            signature,
+            ED25519_SIGNATURE_BYTES,
+            "Maple pairing issuer signature",
+            ErrorClass::InvalidResponse,
+        )?;
+        let signature: [u8; ED25519_SIGNATURE_BYTES] = signature
+            .try_into()
+            .expect("exact signature length was checked");
+        let public_key = VerifyingKey::from_bytes(public_key).map_err(|_| {
+            Error::InvalidResponse(
+                "Maple pairing artifact issuer key is not a valid Ed25519 point".to_string(),
+            )
+        })?;
+        public_key
+            .verify_strict(transcript, &Signature::from_bytes(&signature))
+            .map_err(|_| {
+                Error::InvalidResponse(
+                    "Maple pairing artifact issuer signature does not verify".to_string(),
+                )
+            })
+    }
+}
+
+impl TryFrom<MaplePairingIssuerKeySetV1> for MaplePairingIssuerKeySet {
+    type Error = Error;
+
+    fn try_from(value: MaplePairingIssuerKeySetV1) -> Result<Self> {
+        Self::from_v1(value)
+    }
+}
+
+fn validate_protocol_header(protocol_version: u16, transcript_version: u16) -> Result<()> {
+    if protocol_version != MAPLE_PAIRING_PROTOCOL_VERSION
+        || transcript_version != MAPLE_PAIRING_TRANSCRIPT_VERSION
+    {
+        return Err(Error::Configuration(
+            "Unsupported Maple pairing protocol or transcript version".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_non_nil(ids: &[(&str, Uuid)]) -> Result<()> {
+    if let Some((name, _)) = ids.iter().find(|(_, id)| id.is_nil()) {
+        return Err(Error::Configuration(format!(
+            "Maple pairing {name} must not be nil"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_hex_key(value: &str, field_name: &str, class: ErrorClass) -> Result<[u8; 32]> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(class.error(format!(
+            "{field_name} must be canonical lowercase 32-byte hex"
+        )));
+    }
+    let decoded: [u8; 32] = hex::decode(value)
+        .map_err(|_| class.error(format!("{field_name} is invalid hex")))?
+        .try_into()
+        .map_err(|_| class.error(format!("{field_name} must contain 32 bytes")))?;
+    VerifyingKey::from_bytes(&decoded).map_err(|_| {
+        class.error(format!(
+            "{field_name} must encode a valid Ed25519 public-key point"
+        ))
+    })?;
+    Ok(decoded)
+}
+
+fn validate_token(value: &str, max_len: usize, field_name: &str) -> Result<()> {
+    if value.is_empty()
+        || value.len() > max_len
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'.' | b'_' | b':' | b'-')
+        })
+    {
+        return Err(Error::Configuration(format!(
+            "Maple pairing {field_name} must be a 1 to {max_len} byte lowercase token"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_response_token(value: &str, max_len: usize, field_name: &str) -> Result<()> {
+    if value.is_empty()
+        || value.len() > max_len
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'.' | b'_' | b':' | b'-')
+        })
+    {
+        return Err(Error::InvalidResponse(format!(
+            "Maple pairing {field_name} must be a 1 to {max_len} byte lowercase token"
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum ErrorClass {
+    Configuration,
+    InvalidResponse,
+}
+
+impl ErrorClass {
+    fn error(self, message: String) -> Error {
+        match self {
+            Self::Configuration => Error::Configuration(message),
+            Self::InvalidResponse => Error::InvalidResponse(message),
+        }
+    }
+}
+
+fn decode_exact_base64(
+    value: &str,
+    expected_len: usize,
+    field_name: &str,
+    class: ErrorClass,
+) -> Result<Vec<u8>> {
+    let decoded = BASE64
+        .decode(value)
+        .map_err(|_| class.error(format!("{field_name} must be standard base64")))?;
+    if decoded.len() != expected_len || BASE64.encode(&decoded) != value {
+        return Err(class.error(format!(
+            "{field_name} must be canonical padded standard base64 encoding {expected_len} bytes"
+        )));
+    }
+    Ok(decoded)
+}
+
+fn validate_cursor(cursor: Option<&str>) -> Result<()> {
+    if cursor.is_some_and(|cursor| {
+        cursor.is_empty() || cursor.len() > MAPLE_PAIRING_CURSOR_MAX_BYTES || !cursor.is_ascii()
+    }) {
+        return Err(Error::Configuration(format!(
+            "Maple pairing cursor must contain 1 to {MAPLE_PAIRING_CURSOR_MAX_BYTES} bytes"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_limit(limit: Option<u16>) -> Result<u16> {
+    let limit = limit.unwrap_or(MAPLE_PAIRING_LIST_DEFAULT_LIMIT);
+    if limit == 0 || limit > MAPLE_PAIRING_LIST_MAX_LIMIT {
+        return Err(Error::Configuration(format!(
+            "Maple pairing page limit must be between 1 and {MAPLE_PAIRING_LIST_MAX_LIMIT}"
+        )));
+    }
+    Ok(limit)
+}
+
+fn verify_device_signature(
+    public_key: &[u8; 32],
+    transcript: &[u8],
+    signature: &str,
+) -> Result<()> {
+    let signature = decode_exact_base64(
+        signature,
+        ED25519_SIGNATURE_BYTES,
+        "Maple pairing request signature",
+        ErrorClass::Configuration,
+    )?;
+    let signature: [u8; ED25519_SIGNATURE_BYTES] = signature
+        .try_into()
+        .expect("exact signature length was checked");
+    let public_key = VerifyingKey::from_bytes(public_key).map_err(|_| {
+        Error::Configuration(
+            "Maple pairing request public key is not a valid Ed25519 point".to_string(),
+        )
+    })?;
+    public_key
+        .verify_strict(transcript, &Signature::from_bytes(&signature))
+        .map_err(|_| {
+            Error::Configuration(
+                "Maple pairing request signature does not verify for its transcript".to_string(),
+            )
+        })
+}
+
+#[derive(Default)]
+struct CanonicalBytes {
+    bytes: Vec<u8>,
+}
+
+impl CanonicalBytes {
+    fn new(domain: &str) -> Self {
+        let mut canonical = Self::default();
+        canonical.append_str(domain);
+        canonical
+    }
+
+    fn append_str(&mut self, value: &str) -> &mut Self {
+        self.append_field(b's', value.as_bytes())
+    }
+
+    fn append_bytes(&mut self, value: &[u8]) -> &mut Self {
+        self.append_field(b'b', value)
+    }
+
+    fn append_u16(&mut self, value: u16) -> &mut Self {
+        self.append_field(b'j', &value.to_be_bytes())
+    }
+
+    fn append_u64(&mut self, value: u64) -> &mut Self {
+        self.append_field(b'L', &value.to_be_bytes())
+    }
+
+    fn append_i64(&mut self, value: i64) -> &mut Self {
+        self.append_field(b'l', &value.to_be_bytes())
+    }
+
+    fn append_bool(&mut self, value: bool) -> &mut Self {
+        self.append_field(b'?', &[u8::from(value)])
+    }
+
+    fn append_uuid(&mut self, value: Uuid) -> &mut Self {
+        self.append_field(b'u', value.as_bytes())
+    }
+
+    fn append_field(&mut self, tag: u8, value: &[u8]) -> &mut Self {
+        let length = u32::try_from(value.len()).expect("bounded Maple pairing canonical field");
+        self.bytes.push(tag);
+        self.bytes.extend_from_slice(&length.to_be_bytes());
+        self.bytes.extend_from_slice(value);
+        self
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+fn sha256_base64(bytes: &[u8]) -> String {
+    BASE64.encode(Sha256::digest(bytes))
+}
+
+fn validate_versioned_request(protocol_version: u16, transcript_version: u16) -> Result<()> {
+    validate_protocol_header(protocol_version, transcript_version)
+}
+
+fn validate_positive_revision(revision: i64) -> Result<()> {
+    if revision <= 0 || revision == i64::MAX {
+        return Err(Error::Configuration(
+            "Maple pairing expected revision must be positive and incrementable".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_incarnation(incarnation: u64) -> Result<()> {
+    if incarnation == 0 || incarnation > i64::MAX as u64 {
+        return Err(Error::Configuration(
+            "Maple pairing incarnation must be nonzero and supported by the service".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_revocation_stream(stream_id: Uuid, generation: u64, class: ErrorClass) -> Result<()> {
+    if stream_id.is_nil() || generation == 0 || generation > i64::MAX as u64 {
+        return Err(class.error(
+            "Maple revocation stream requires a non-nil ID and supported nonzero generation"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_protocol_range(minimum: u16, maximum: u16) -> Result<()> {
+    if minimum == 0 || minimum > maximum {
+        return Err(Error::Configuration(
+            "Maple pairing protocol range must be nonzero and ordered".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_timestamp(timestamp: i64, field_name: &str, class: ErrorClass) -> Result<()> {
+    if timestamp <= 0 {
+        return Err(class.error(format!(
+            "Maple pairing {field_name} must be positive Unix milliseconds"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_device_claim(
+    claim: &MaplePairingDeviceClaimV1,
+    class: ErrorClass,
+) -> Result<([u8; 32], [u8; 32])> {
+    if claim.registration_id.is_nil() || claim.device_id.is_nil() || claim.installation_id.is_nil()
+    {
+        return Err(
+            class.error("Maple pairing artifact device claim contains a nil ID".to_string())
+        );
+    }
+    if claim.endpoint_epoch > i64::MAX as u64 {
+        return Err(class.error("Maple pairing artifact endpoint epoch is unsupported".to_string()));
+    }
+    let identity_key = decode_exact_base64(
+        &claim.identity_public_key,
+        ED25519_PUBLIC_KEY_BYTES,
+        "Maple pairing artifact identity public key",
+        class,
+    )?;
+    let identity_key: [u8; 32] = identity_key
+        .try_into()
+        .expect("exact key length was checked");
+    VerifyingKey::from_bytes(&identity_key).map_err(|_| {
+        class.error("Maple pairing artifact identity key is not a valid Ed25519 point".to_string())
+    })?;
+    let endpoint_key = validate_hex_key(
+        &claim.endpoint_id,
+        "Maple pairing artifact endpoint ID",
+        class,
+    )?;
+    // Maple pairing v1 intentionally uses the same durable Ed25519 key as the
+    // installation's Iroh endpoint identity. A separately hardware-backed
+    // companion proof key remains a future hardening option, not a v1 field.
+    if identity_key != endpoint_key {
+        return Err(class.error(
+            "Maple pairing artifact identity public key must match its Iroh endpoint ID"
+                .to_string(),
+        ));
+    }
+    Ok((identity_key, endpoint_key))
+}
+
+fn validate_directed_device_claims(
+    controller: &MaplePairingDeviceClaimV1,
+    host: &MaplePairingDeviceClaimV1,
+    execution_target_id: Uuid,
+    class: ErrorClass,
+) -> Result<()> {
+    if controller.registration_id == host.registration_id
+        || controller.device_id == host.device_id
+        || controller.installation_id == host.installation_id
+        || controller.identity_public_key == host.identity_public_key
+        || controller.endpoint_id == host.endpoint_id
+        || execution_target_id != host.registration_id
+    {
+        return Err(class.error(
+            "Maple pairing must bind two distinct installations in one controller-to-host direction"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn device_claim_is_same_identity_at_or_before(
+    historical: &MaplePairingDeviceClaimV1,
+    current: &MaplePairingDeviceClaimV1,
+) -> bool {
+    historical.registration_id == current.registration_id
+        && historical.device_id == current.device_id
+        && historical.installation_id == current.installation_id
+        && historical.identity_algorithm == current.identity_algorithm
+        && historical.identity_public_key == current.identity_public_key
+        && historical.endpoint_id == current.endpoint_id
+        && historical.endpoint_epoch <= current.endpoint_epoch
+}
+
+fn append_device_claim(
+    canonical: &mut CanonicalBytes,
+    claim: &MaplePairingDeviceClaimV1,
+    class: ErrorClass,
+) -> Result<()> {
+    let (identity_key, endpoint_key) = validate_device_claim(claim, class)?;
+    canonical
+        .append_uuid(claim.registration_id)
+        .append_uuid(claim.device_id)
+        .append_uuid(claim.installation_id)
+        .append_str(claim.identity_algorithm.as_str())
+        .append_bytes(&identity_key)
+        .append_bytes(&endpoint_key)
+        .append_u64(claim.endpoint_epoch);
+    Ok(())
+}
+
+fn validate_reset_counter(value: u64, field_name: &str, class: ErrorClass) -> Result<()> {
+    if value == 0 || value > i64::MAX as u64 {
+        return Err(class.error(format!(
+            "Maple reset-clear {field_name} must be nonzero and supported by the service"
+        )));
+    }
+    Ok(())
+}
+
+fn decode_digest_for_class(value: &str, field_name: &str, class: ErrorClass) -> Result<Vec<u8>> {
+    decode_exact_base64(value, DIGEST_BYTES, field_name, class)
+}
+
+/// Canonicalizes the complete private admission set used to derive the public
+/// reset-clear count and digest. Leaves are sorted by their canonical tuple;
+/// duplicate tuples fail closed.
+pub fn reset_clear_admission_set_transcript(
+    artifact_version: u16,
+    admissions: &[MapleResetClearAdmissionLeafV1],
+) -> Result<Vec<u8>> {
+    if artifact_version != MAPLE_PAIRING_ARTIFACT_VERSION {
+        return Err(Error::Configuration(
+            "Unsupported Maple reset-clear artifact version".to_string(),
+        ));
+    }
+    let admission_count = u16::try_from(admissions.len()).map_err(|_| {
+        Error::Configuration("Maple reset-clear admission count is unsupported".to_string())
+    })?;
+    if admission_count > MAPLE_RESET_CLEAR_MAX_ADMISSIONS {
+        return Err(Error::Configuration(format!(
+            "Maple reset-clear admission set supports at most {MAPLE_RESET_CLEAR_MAX_ADMISSIONS} leaves"
+        )));
+    }
+    let mut canonical_leaves = Vec::with_capacity(admissions.len());
+    for admission in admissions {
+        if admission.pair_id.is_nil() {
+            return Err(Error::Configuration(
+                "Maple reset-clear admission leaves require non-nil pair IDs".to_string(),
+            ));
+        }
+        validate_incarnation(admission.pairing_incarnation)?;
+        canonical_leaves.push(admission.clone());
+    }
+    canonical_leaves.sort_unstable();
+    if canonical_leaves.windows(2).any(|pair| pair[0] == pair[1]) {
+        return Err(Error::Configuration(
+            "Maple reset-clear admission leaves must be unique".to_string(),
+        ));
+    }
+
+    let mut canonical = CanonicalBytes::new(RESET_CLEAR_ADMISSION_SET_DOMAIN);
+    canonical
+        .append_u16(artifact_version)
+        .append_u16(admission_count);
+    for admission in canonical_leaves {
+        canonical
+            .append_uuid(admission.pair_id)
+            .append_u64(admission.pairing_incarnation)
+            .append_bytes(&admission.pair_authorization_digest);
+    }
+    Ok(canonical.into_bytes())
+}
+
+pub fn reset_clear_admission_set_digest(
+    artifact_version: u16,
+    admissions: &[MapleResetClearAdmissionLeafV1],
+) -> Result<[u8; 32]> {
+    Ok(Sha256::digest(reset_clear_admission_set_transcript(
+        artifact_version,
+        admissions,
+    )?)
+    .into())
+}
+
+fn validate_reset_clear_material_fields(
+    reset: &MapleResetClearRequiredV1,
+    class: ErrorClass,
+) -> Result<()> {
+    if reset.artifact_version != MAPLE_PAIRING_ARTIFACT_VERSION {
+        return Err(class.error("Unsupported Maple reset-clear artifact version".to_string()));
+    }
+    for (name, id) in [
+        ("event ID", reset.event_id),
+        ("reset ID", reset.reset_id),
+        ("subject account ID", reset.subject_account_id),
+        ("subject project ID", reset.subject_project_id),
+        (
+            "recipient host registration ID",
+            reset.recipient_host_registration_id,
+        ),
+        (
+            "source revocation stream ID",
+            reset.source_revocation_stream_id,
+        ),
+        ("revocation stream ID", reset.revocation_stream_id),
+    ] {
+        if id.is_nil() {
+            return Err(class.error(format!("Maple reset-clear {name} must not be nil")));
+        }
+    }
+    validate_reset_counter(reset.reset_generation, "generation", class)?;
+    validate_reset_counter(reset.cumulative_reset_count, "cumulative count", class)?;
+    validate_reset_counter(reset.source_security_epoch, "source security epoch", class)?;
+    validate_reset_counter(reset.security_epoch, "security epoch", class)?;
+    if reset.reset_generation != reset.cumulative_reset_count
+        || reset.source_security_epoch.checked_add(1) != Some(reset.security_epoch)
+    {
+        return Err(class.error(
+            "Maple reset-clear generation/count or security-epoch progression is invalid"
+                .to_string(),
+        ));
+    }
+    validate_device_claim(&reset.host, class)?;
+    if reset.recipient_host_registration_id != reset.host.registration_id {
+        return Err(
+            class.error("Maple reset-clear recipient does not match its host claim".to_string())
+        );
+    }
+    validate_revocation_stream(
+        reset.source_revocation_stream_id,
+        reset.source_revocation_stream_generation,
+        class,
+    )?;
+    validate_revocation_stream(
+        reset.revocation_stream_id,
+        reset.revocation_stream_generation,
+        class,
+    )?;
+    if reset.revocation_stream_id == reset.source_revocation_stream_id
+        || reset.source_revocation_stream_generation.checked_add(1)
+            != Some(reset.revocation_stream_generation)
+    {
+        return Err(class.error(
+            "Maple reset-clear target revocation namespace must be fresh and advance exactly once"
+                .to_string(),
+        ));
+    }
+    if reset.issuer_sequence != 1 {
+        return Err(class.error(
+            "Maple reset-clear instruction must be event sequence 1 in its target namespace"
+                .to_string(),
+        ));
+    }
+    if reset.admission_count > MAPLE_RESET_CLEAR_MAX_ADMISSIONS {
+        return Err(class.error(format!(
+            "Maple reset-clear admission count exceeds {MAPLE_RESET_CLEAR_MAX_ADMISSIONS}"
+        )));
+    }
+    decode_digest_for_class(
+        &reset.admission_set_digest,
+        "Maple reset-clear admission-set digest",
+        class,
+    )?;
+    if reset.reset_at_unix_ms < 0 {
+        return Err(class.error(
+            "Maple reset-clear reset time must be nonnegative Unix milliseconds".to_string(),
+        ));
+    }
+
+    let predecessor_fields = [
+        reset.previous_reset_clear_event_id.is_some(),
+        reset.previous_instruction_material_digest.is_some(),
+        reset.previous_chain_digest.is_some(),
+    ];
+    let predecessor_present = predecessor_fields.iter().all(|present| *present);
+    if predecessor_fields.iter().any(|present| *present) && !predecessor_present {
+        return Err(class.error(
+            "Maple reset-clear predecessor fields must be all present or all absent".to_string(),
+        ));
+    }
+    if reset.reset_generation == 1 {
+        if predecessor_present {
+            return Err(
+                class.error("Maple reset-clear genesis must not contain a predecessor".to_string())
+            );
+        }
+    } else if !predecessor_present {
+        return Err(class.error(
+            "Maple reset-clear successor must contain its complete predecessor commitment"
+                .to_string(),
+        ));
+    }
+    if let Some(event_id) = reset.previous_reset_clear_event_id {
+        if event_id.is_nil() || event_id == reset.event_id {
+            return Err(
+                class.error("Maple reset-clear predecessor event ID is invalid".to_string())
+            );
+        }
+    }
+    if let Some(digest) = &reset.previous_instruction_material_digest {
+        decode_digest_for_class(
+            digest,
+            "Maple reset-clear previous instruction-material digest",
+            class,
+        )?;
+    }
+    if let Some(digest) = &reset.previous_chain_digest {
+        decode_digest_for_class(digest, "Maple reset-clear previous chain digest", class)?;
+    }
+    Ok(())
+}
+
+fn append_reset_clear_instruction_material_fields(
+    canonical: &mut CanonicalBytes,
+    reset: &MapleResetClearRequiredV1,
+    class: ErrorClass,
+) -> Result<()> {
+    validate_reset_clear_material_fields(reset, class)?;
+    let admission_set_digest = decode_digest_for_class(
+        &reset.admission_set_digest,
+        "Maple reset-clear admission-set digest",
+        class,
+    )?;
+    canonical
+        .append_u16(reset.artifact_version)
+        .append_uuid(reset.event_id)
+        .append_uuid(reset.reset_id)
+        .append_u64(reset.reset_generation)
+        .append_u64(reset.cumulative_reset_count)
+        .append_u64(reset.source_security_epoch)
+        .append_u64(reset.security_epoch)
+        .append_uuid(reset.subject_account_id)
+        .append_uuid(reset.subject_project_id)
+        .append_uuid(reset.recipient_host_registration_id);
+    append_device_claim(canonical, &reset.host, class)?;
+    canonical
+        .append_u64(reset.issuer_sequence)
+        .append_uuid(reset.source_revocation_stream_id)
+        .append_u64(reset.source_revocation_stream_generation)
+        .append_uuid(reset.revocation_stream_id)
+        .append_u64(reset.revocation_stream_generation)
+        .append_str(reset.clear_scope.as_str())
+        .append_u16(reset.admission_count)
+        .append_bytes(&admission_set_digest)
+        .append_bool(reset.previous_reset_clear_event_id.is_some());
+    if let (Some(previous_event_id), Some(previous_material_digest), Some(previous_chain_digest)) = (
+        reset.previous_reset_clear_event_id,
+        reset.previous_instruction_material_digest.as_ref(),
+        reset.previous_chain_digest.as_ref(),
+    ) {
+        canonical
+            .append_uuid(previous_event_id)
+            .append_bytes(&decode_digest_for_class(
+                previous_material_digest,
+                "Maple reset-clear previous instruction-material digest",
+                class,
+            )?)
+            .append_bytes(&decode_digest_for_class(
+                previous_chain_digest,
+                "Maple reset-clear previous chain digest",
+                class,
+            )?);
+    }
+    canonical.append_i64(reset.reset_at_unix_ms);
+    Ok(())
+}
+
+pub fn reset_clear_instruction_material_transcript(
+    reset: &MapleResetClearRequiredV1,
+) -> Result<Vec<u8>> {
+    let mut canonical = CanonicalBytes::new(RESET_CLEAR_INSTRUCTION_MATERIAL_DOMAIN);
+    append_reset_clear_instruction_material_fields(
+        &mut canonical,
+        reset,
+        ErrorClass::InvalidResponse,
+    )?;
+    Ok(canonical.into_bytes())
+}
+
+pub fn reset_clear_chain_transcript(reset: &MapleResetClearRequiredV1) -> Result<Vec<u8>> {
+    validate_reset_clear_material_fields(reset, ErrorClass::InvalidResponse)?;
+    let instruction_material_digest = decode_digest_for_class(
+        &reset.instruction_material_digest,
+        "Maple reset-clear instruction-material digest",
+        ErrorClass::InvalidResponse,
+    )?;
+    let mut canonical = CanonicalBytes::new(RESET_CLEAR_CHAIN_DOMAIN);
+    canonical
+        .append_u16(reset.artifact_version)
+        .append_bool(reset.previous_reset_clear_event_id.is_some());
+    if let (
+        Some(previous_chain_digest),
+        Some(previous_event_id),
+        Some(previous_instruction_material_digest),
+    ) = (
+        reset.previous_chain_digest.as_ref(),
+        reset.previous_reset_clear_event_id,
+        reset.previous_instruction_material_digest.as_ref(),
+    ) {
+        canonical
+            .append_bytes(&decode_digest_for_class(
+                previous_chain_digest,
+                "Maple reset-clear previous chain digest",
+                ErrorClass::InvalidResponse,
+            )?)
+            .append_uuid(previous_event_id)
+            .append_bytes(&decode_digest_for_class(
+                previous_instruction_material_digest,
+                "Maple reset-clear previous instruction-material digest",
+                ErrorClass::InvalidResponse,
+            )?);
+    }
+    canonical
+        .append_uuid(reset.reset_id)
+        .append_uuid(reset.event_id)
+        .append_u64(reset.reset_generation)
+        .append_bytes(&instruction_material_digest)
+        .append_u64(reset.cumulative_reset_count);
+    Ok(canonical.into_bytes())
+}
+
+pub fn reset_clear_required_transcript(reset: &MapleResetClearRequiredV1) -> Result<Vec<u8>> {
+    validate_reset_clear_unsigned(reset)?;
+    let instruction_material_digest = decode_digest_for_class(
+        &reset.instruction_material_digest,
+        "Maple reset-clear instruction-material digest",
+        ErrorClass::InvalidResponse,
+    )?;
+    let chain_digest = decode_digest_for_class(
+        &reset.chain_digest,
+        "Maple reset-clear chain digest",
+        ErrorClass::InvalidResponse,
+    )?;
+    let mut canonical = CanonicalBytes::new(RESET_CLEAR_REQUIRED_DOMAIN);
+    append_reset_clear_instruction_material_fields(
+        &mut canonical,
+        reset,
+        ErrorClass::InvalidResponse,
+    )?;
+    canonical
+        .append_bytes(&instruction_material_digest)
+        .append_u64(reset.cumulative_reset_count)
+        .append_bytes(&chain_digest)
+        .append_str(&reset.issuer_key_id);
+    Ok(canonical.into_bytes())
+}
+
+fn validate_reset_clear_unsigned(reset: &MapleResetClearRequiredV1) -> Result<()> {
+    validate_reset_clear_material_fields(reset, ErrorClass::InvalidResponse)?;
+    validate_response_token(
+        &reset.issuer_key_id,
+        MAX_ISSUER_KEY_ID_BYTES,
+        "reset-clear issuer key ID",
+    )?;
+    decode_digest_for_class(
+        &reset.instruction_material_digest,
+        "Maple reset-clear instruction-material digest",
+        ErrorClass::InvalidResponse,
+    )?;
+    decode_digest_for_class(
+        &reset.chain_digest,
+        "Maple reset-clear chain digest",
+        ErrorClass::InvalidResponse,
+    )?;
+    let material_digest = sha256_base64(&reset_clear_instruction_material_transcript(reset)?);
+    if reset.instruction_material_digest != material_digest {
+        return Err(Error::InvalidResponse(
+            "Maple reset-clear instruction-material digest does not match its fields".to_string(),
+        ));
+    }
+    let chain_digest = sha256_base64(&reset_clear_chain_transcript(reset)?);
+    if reset.chain_digest != chain_digest {
+        return Err(Error::InvalidResponse(
+            "Maple reset-clear chain digest does not match its fields".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_request_signature(
+    public_key: &[u8; 32],
+    transcript: &[u8],
+    signature: &str,
+) -> Result<()> {
+    verify_device_signature(public_key, transcript, signature)
+}
+
+impl CreateMaplePairingRequest {
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        validate_versioned_request(self.protocol_version, self.transcript_version)?;
+        validate_non_nil(&[
+            ("operation ID", self.operation_id),
+            ("asserted account ID", self.asserted_account_id),
+            ("asserted project ID", self.asserted_project_id),
+            (
+                "controller registration ID",
+                self.controller_registration_id,
+            ),
+            ("controller device ID", self.controller_device_id),
+            (
+                "controller installation ID",
+                self.controller_installation_id,
+            ),
+            ("host registration ID", self.host_registration_id),
+            ("host device ID", self.host_device_id),
+            ("host installation ID", self.host_installation_id),
+            ("execution target ID", self.execution_target_id),
+        ])?;
+        if self.execution_target_id != self.host_registration_id {
+            return Err(Error::Configuration(
+                "Maple pairing execution target must equal the host registration ID".to_string(),
+            ));
+        }
+        if self.controller_registration_id == self.host_registration_id
+            || self.controller_device_id == self.host_device_id
+            || self.controller_installation_id == self.host_installation_id
+            || self.controller_endpoint_id == self.host_endpoint_id
+        {
+            return Err(Error::Configuration(
+                "Maple pairing controller and host must be distinct installations".to_string(),
+            ));
+        }
+        if self.controller_endpoint_epoch > i64::MAX as u64
+            || self.host_endpoint_epoch > i64::MAX as u64
+        {
+            return Err(Error::Configuration(
+                "Maple pairing endpoint epoch is unsupported".to_string(),
+            ));
+        }
+        validate_protocol_range(self.protocol_min, self.protocol_max)?;
+        let controller_endpoint = validate_hex_key(
+            &self.controller_endpoint_id,
+            "Maple pairing controller endpoint ID",
+            ErrorClass::Configuration,
+        )?;
+        let host_endpoint = validate_hex_key(
+            &self.host_endpoint_id,
+            "Maple pairing host endpoint ID",
+            ErrorClass::Configuration,
+        )?;
+        let nonce = decode_exact_base64(
+            &self.pairing_request_nonce,
+            NONCE_BYTES,
+            "Maple pairing request nonce",
+            ErrorClass::Configuration,
+        )?;
+        let mut canonical = CanonicalBytes::new("os.maple-pair-request.v1");
+        canonical
+            .append_u16(self.protocol_version)
+            .append_u16(self.transcript_version)
+            .append_uuid(self.asserted_account_id)
+            .append_uuid(self.asserted_project_id)
+            .append_uuid(self.operation_id)
+            .append_uuid(self.controller_registration_id)
+            .append_uuid(self.controller_device_id)
+            .append_uuid(self.controller_installation_id)
+            .append_bytes(&controller_endpoint)
+            .append_u64(self.controller_endpoint_epoch)
+            .append_uuid(self.host_registration_id)
+            .append_uuid(self.host_device_id)
+            .append_uuid(self.host_installation_id)
+            .append_bytes(&host_endpoint)
+            .append_u64(self.host_endpoint_epoch)
+            .append_str(self.direction.as_str())
+            .append_uuid(self.execution_target_id)
+            .append_bytes(&nonce)
+            .append_u16(self.protocol_min)
+            .append_u16(self.protocol_max);
+        Ok(canonical.into_bytes())
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        let transcript = self.canonical_transcript()?;
+        let controller_key = validate_hex_key(
+            &self.controller_endpoint_id,
+            "Maple pairing controller endpoint ID",
+            ErrorClass::Configuration,
+        )?;
+        validate_request_signature(&controller_key, &transcript, &self.signature)
+    }
+
+    pub fn transcript_digest(&self) -> Result<String> {
+        Ok(sha256_base64(&self.canonical_transcript()?))
+    }
+}
+
+impl ListMaplePairingsRequest {
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        validate_versioned_request(self.protocol_version, self.transcript_version)?;
+        validate_non_nil(&[
+            ("query ID", self.query_id),
+            ("asserted account ID", self.asserted_account_id),
+            ("asserted project ID", self.asserted_project_id),
+            ("actor registration ID", self.actor_registration_id),
+        ])?;
+        let states = Self::canonical_states(self.states.clone())?;
+        if states != self.states {
+            return Err(Error::Configuration(
+                "Maple pairing states must use canonical enum order".to_string(),
+            ));
+        }
+        validate_cursor(self.cursor.as_deref())?;
+        let effective_limit = validate_limit(self.limit)?;
+        let mut canonical = CanonicalBytes::new("os.maple-pair-list.v1");
+        canonical
+            .append_u16(self.protocol_version)
+            .append_u16(self.transcript_version)
+            .append_uuid(self.asserted_account_id)
+            .append_uuid(self.asserted_project_id)
+            .append_uuid(self.query_id)
+            .append_uuid(self.actor_registration_id)
+            .append_str(self.role.as_str())
+            .append_u16(states.len() as u16);
+        for state in states {
+            canonical.append_str(state.as_str());
+        }
+        canonical.append_bool(self.cursor.is_some());
+        if let Some(cursor) = &self.cursor {
+            canonical.append_str(cursor);
+        }
+        canonical.append_u16(effective_limit);
+        Ok(canonical.into_bytes())
+    }
+
+    pub fn validate_with_signing_key(&self, public_key: &[u8; 32]) -> Result<()> {
+        validate_request_signature(public_key, &self.canonical_transcript()?, &self.signature)
+    }
+}
+
+impl MaplePairingStatusRequest {
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        validate_versioned_request(self.protocol_version, self.transcript_version)?;
+        validate_non_nil(&[
+            ("query ID", self.query_id),
+            ("asserted account ID", self.asserted_account_id),
+            ("asserted project ID", self.asserted_project_id),
+            ("actor registration ID", self.actor_registration_id),
+            ("pair ID", self.pair_id),
+        ])?;
+        let mut canonical = CanonicalBytes::new("os.maple-pair-status.v1");
+        canonical
+            .append_u16(self.protocol_version)
+            .append_u16(self.transcript_version)
+            .append_uuid(self.asserted_account_id)
+            .append_uuid(self.asserted_project_id)
+            .append_uuid(self.query_id)
+            .append_uuid(self.actor_registration_id)
+            .append_uuid(self.pair_id);
+        Ok(canonical.into_bytes())
+    }
+
+    pub fn validate_with_signing_key(&self, public_key: &[u8; 32]) -> Result<()> {
+        validate_request_signature(public_key, &self.canonical_transcript()?, &self.signature)
+    }
+}
+
+impl ApproveMaplePairingRequest {
+    /// Builds an unsigned v1 approval from a currently valid issuer-verified
+    /// request ticket.
+    ///
+    /// Pairing v1 does not permit protocol narrowing: the approved range is
+    /// copied exactly from the controller's ticket. The host-signed approval
+    /// also binds the namespace obtained from signed discovery and reconciled
+    /// to durable local admission state. The caller owns the host private key
+    /// and must attach its signature separately.
+    pub fn unsigned_v1_from_verified_ticket(
+        operation_id: Uuid,
+        host_approval_nonce: impl Into<String>,
+        ticket: &VerifiedMaplePairRequestTicketV1,
+        revocation_stream: &DurablyReconciledMapleRevocationStreamV1,
+    ) -> Result<PreparedMaplePairingApprovalV1> {
+        let ticket = ticket.as_inner();
+        let checkpoint = revocation_stream.as_inner();
+        if checkpoint.subject_account_id != ticket.subject_account_id
+            || checkpoint.subject_project_id != ticket.subject_project_id
+            || !device_claim_is_same_identity_at_or_before(&ticket.host, &checkpoint.host)
+        {
+            return Err(Error::Configuration(
+                "Maple approval revocation stream does not match the verified host ticket"
+                    .to_string(),
+            ));
+        }
+        let request = Self {
+            protocol_version: MAPLE_PAIRING_PROTOCOL_VERSION,
+            transcript_version: MAPLE_PAIRING_TRANSCRIPT_VERSION,
+            operation_id,
+            asserted_account_id: ticket.subject_account_id,
+            asserted_project_id: ticket.subject_project_id,
+            host_registration_id: ticket.host.registration_id,
+            pairing_request_id: ticket.pairing_request_id,
+            pair_id: ticket.pair_id,
+            expected_pairing_revision: 1,
+            pairing_incarnation: ticket.pairing_incarnation,
+            revocation_stream_id: checkpoint.revocation_stream_id,
+            revocation_stream_generation: checkpoint.revocation_stream_generation,
+            request_ticket_digest: ticket.transcript_digest()?,
+            host_approval_nonce: host_approval_nonce.into(),
+            approved_protocol_min: ticket.protocol_min,
+            approved_protocol_max: ticket.protocol_max,
+            signature: String::new(),
+        };
+        request.canonical_transcript()?;
+        Ok(PreparedMaplePairingApprovalV1 { request })
+    }
+
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        validate_versioned_request(self.protocol_version, self.transcript_version)?;
+        validate_non_nil(&[
+            ("operation ID", self.operation_id),
+            ("asserted account ID", self.asserted_account_id),
+            ("asserted project ID", self.asserted_project_id),
+            ("host registration ID", self.host_registration_id),
+            ("pairing request ID", self.pairing_request_id),
+            ("pair ID", self.pair_id),
+        ])?;
+        validate_positive_revision(self.expected_pairing_revision)?;
+        validate_incarnation(self.pairing_incarnation)?;
+        validate_revocation_stream(
+            self.revocation_stream_id,
+            self.revocation_stream_generation,
+            ErrorClass::Configuration,
+        )?;
+        validate_protocol_range(self.approved_protocol_min, self.approved_protocol_max)?;
+        let ticket_digest = decode_exact_base64(
+            &self.request_ticket_digest,
+            DIGEST_BYTES,
+            "Maple pairing request ticket digest",
+            ErrorClass::Configuration,
+        )?;
+        let approval_nonce = decode_exact_base64(
+            &self.host_approval_nonce,
+            NONCE_BYTES,
+            "Maple pairing host approval nonce",
+            ErrorClass::Configuration,
+        )?;
+        let mut canonical = CanonicalBytes::new("os.maple-pair-approval.v1");
+        canonical
+            .append_u16(self.protocol_version)
+            .append_u16(self.transcript_version)
+            .append_uuid(self.asserted_account_id)
+            .append_uuid(self.asserted_project_id)
+            .append_uuid(self.operation_id)
+            .append_uuid(self.host_registration_id)
+            .append_uuid(self.pairing_request_id)
+            .append_uuid(self.pair_id)
+            .append_i64(self.expected_pairing_revision)
+            .append_u64(self.pairing_incarnation)
+            .append_uuid(self.revocation_stream_id)
+            .append_u64(self.revocation_stream_generation)
+            .append_bytes(&ticket_digest)
+            .append_bytes(&approval_nonce)
+            .append_u16(self.approved_protocol_min)
+            .append_u16(self.approved_protocol_max);
+        Ok(canonical.into_bytes())
+    }
+
+    pub fn validate_with_signing_key(&self, public_key: &[u8; 32]) -> Result<()> {
+        validate_request_signature(public_key, &self.canonical_transcript()?, &self.signature)
+    }
+
+    pub fn transcript_digest(&self) -> Result<String> {
+        Ok(sha256_base64(&self.canonical_transcript()?))
+    }
+}
+
+impl ConfirmMaplePairingRequest {
+    /// Builds the unsigned host-commit request after the caller has durably
+    /// promoted its local approval record.
+    ///
+    /// The verified authorization supplies the exact pair lineage and digest;
+    /// this constructor does not persist anything and deliberately does not
+    /// send or auto-confirm. The caller must sign the returned prepared value's
+    /// canonical transcript with the host installation key, attach it through
+    /// `PreparedMaplePairingHostCommitV1::with_signature`, and invoke
+    /// `OpenSecretClient::confirm_maple_pairing` separately.
+    pub fn unsigned_v1_after_durable_commit(
+        operation_id: Uuid,
+        ready: &HostCommitReadyMaplePairAuthorizationV1,
+    ) -> Result<PreparedMaplePairingHostCommitV1> {
+        let authorization = ready.authorization().as_inner();
+        let request = Self {
+            protocol_version: MAPLE_PAIRING_PROTOCOL_VERSION,
+            transcript_version: MAPLE_PAIRING_TRANSCRIPT_VERSION,
+            operation_id,
+            asserted_account_id: authorization.subject_account_id,
+            asserted_project_id: authorization.subject_project_id,
+            host_registration_id: authorization.host.registration_id,
+            pairing_request_id: authorization.pairing_request_id,
+            pair_id: authorization.pair_id,
+            expected_pairing_revision: ready.expected_pairing_revision(),
+            pairing_incarnation: authorization.pairing_incarnation,
+            pair_authorization_digest: authorization.transcript_digest()?,
+            signature: String::new(),
+        };
+        request.canonical_transcript()?;
+        Ok(PreparedMaplePairingHostCommitV1 { request })
+    }
+
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        validate_versioned_request(self.protocol_version, self.transcript_version)?;
+        validate_non_nil(&[
+            ("operation ID", self.operation_id),
+            ("asserted account ID", self.asserted_account_id),
+            ("asserted project ID", self.asserted_project_id),
+            ("host registration ID", self.host_registration_id),
+            ("pairing request ID", self.pairing_request_id),
+            ("pair ID", self.pair_id),
+        ])?;
+        validate_positive_revision(self.expected_pairing_revision)?;
+        validate_incarnation(self.pairing_incarnation)?;
+        let authorization_digest = decode_exact_base64(
+            &self.pair_authorization_digest,
+            DIGEST_BYTES,
+            "Maple pair authorization digest",
+            ErrorClass::Configuration,
+        )?;
+        let mut canonical = CanonicalBytes::new("os.maple-pair-host-commit.v1");
+        canonical
+            .append_u16(self.protocol_version)
+            .append_u16(self.transcript_version)
+            .append_uuid(self.asserted_account_id)
+            .append_uuid(self.asserted_project_id)
+            .append_uuid(self.operation_id)
+            .append_uuid(self.host_registration_id)
+            .append_uuid(self.pairing_request_id)
+            .append_uuid(self.pair_id)
+            .append_i64(self.expected_pairing_revision)
+            .append_u64(self.pairing_incarnation)
+            .append_bytes(&authorization_digest);
+        Ok(canonical.into_bytes())
+    }
+
+    pub fn validate_with_signing_key(&self, public_key: &[u8; 32]) -> Result<()> {
+        validate_request_signature(public_key, &self.canonical_transcript()?, &self.signature)
+    }
+}
+
+impl RevokeMaplePairingRequest {
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        validate_versioned_request(self.protocol_version, self.transcript_version)?;
+        validate_non_nil(&[
+            ("operation ID", self.operation_id),
+            ("asserted account ID", self.asserted_account_id),
+            ("asserted project ID", self.asserted_project_id),
+            ("actor registration ID", self.actor_registration_id),
+            ("pairing request ID", self.pairing_request_id),
+            ("pair ID", self.pair_id),
+        ])?;
+        validate_positive_revision(self.expected_pairing_revision)?;
+        validate_incarnation(self.pairing_incarnation)?;
+        validate_revocation_stream(
+            self.revocation_stream_id,
+            self.revocation_stream_generation,
+            ErrorClass::Configuration,
+        )?;
+        validate_token(
+            &self.reason_code,
+            MAX_REASON_CODE_BYTES,
+            "revocation reason code",
+        )?;
+        let mut canonical = CanonicalBytes::new("os.maple-pair-revocation-request.v1");
+        canonical
+            .append_u16(self.protocol_version)
+            .append_u16(self.transcript_version)
+            .append_uuid(self.asserted_account_id)
+            .append_uuid(self.asserted_project_id)
+            .append_uuid(self.operation_id)
+            .append_uuid(self.actor_registration_id)
+            .append_str(self.actor_role.as_str())
+            .append_uuid(self.pairing_request_id)
+            .append_uuid(self.pair_id)
+            .append_i64(self.expected_pairing_revision)
+            .append_u64(self.pairing_incarnation)
+            .append_uuid(self.revocation_stream_id)
+            .append_u64(self.revocation_stream_generation)
+            .append_str(&self.reason_code);
+        Ok(canonical.into_bytes())
+    }
+
+    pub fn validate_with_signing_key(&self, public_key: &[u8; 32]) -> Result<()> {
+        validate_request_signature(public_key, &self.canonical_transcript()?, &self.signature)
+    }
+}
+
+impl ListMaplePairingRevocationsRequest {
+    /// Builds an unsigned, signed-discovery request for the host's current
+    /// revocation namespace. Nil/zero values are valid only for this exact
+    /// `after=0` discovery sentinel.
+    pub fn unsigned_v1_discovery(
+        query_id: Uuid,
+        asserted_account_id: Uuid,
+        asserted_project_id: Uuid,
+        host_registration_id: Uuid,
+        limit: Option<u16>,
+    ) -> Result<Self> {
+        let request = Self {
+            protocol_version: MAPLE_PAIRING_PROTOCOL_VERSION,
+            transcript_version: MAPLE_PAIRING_TRANSCRIPT_VERSION,
+            query_id,
+            asserted_account_id,
+            asserted_project_id,
+            host_registration_id,
+            revocation_stream_id: Uuid::nil(),
+            revocation_stream_generation: 0,
+            after_issuer_sequence: 0,
+            limit,
+            signature: String::new(),
+        };
+        request.canonical_transcript()?;
+        Ok(request)
+    }
+
+    /// Builds an unsigned established-stream page request from the exact
+    /// namespace the host has already reconciled to durable admission state.
+    pub fn unsigned_v1_from_reconciled_stream(
+        query_id: Uuid,
+        after_issuer_sequence: u64,
+        limit: Option<u16>,
+        revocation_stream: &DurablyReconciledMapleRevocationStreamV1,
+    ) -> Result<Self> {
+        let checkpoint = revocation_stream.as_inner();
+        let request = Self {
+            protocol_version: MAPLE_PAIRING_PROTOCOL_VERSION,
+            transcript_version: MAPLE_PAIRING_TRANSCRIPT_VERSION,
+            query_id,
+            asserted_account_id: checkpoint.subject_account_id,
+            asserted_project_id: checkpoint.subject_project_id,
+            host_registration_id: checkpoint.host.registration_id,
+            revocation_stream_id: checkpoint.revocation_stream_id,
+            revocation_stream_generation: checkpoint.revocation_stream_generation,
+            after_issuer_sequence,
+            limit,
+            signature: String::new(),
+        };
+        request.canonical_transcript()?;
+        Ok(request)
+    }
+
+    pub fn with_signature(mut self, signature: impl Into<String>) -> Self {
+        self.signature = signature.into();
+        self
+    }
+
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        validate_versioned_request(self.protocol_version, self.transcript_version)?;
+        validate_non_nil(&[
+            ("query ID", self.query_id),
+            ("asserted account ID", self.asserted_account_id),
+            ("asserted project ID", self.asserted_project_id),
+            ("host registration ID", self.host_registration_id),
+        ])?;
+        let discovery = self.revocation_stream_id.is_nil()
+            && self.revocation_stream_generation == 0
+            && self.after_issuer_sequence == 0;
+        if !discovery {
+            validate_revocation_stream(
+                self.revocation_stream_id,
+                self.revocation_stream_generation,
+                ErrorClass::Configuration,
+            )?;
+        }
+        if (self.revocation_stream_id.is_nil() || self.revocation_stream_generation == 0)
+            && !discovery
+        {
+            return Err(Error::Configuration(
+                "Maple revocation discovery requires the exact nil/zero/after-zero sentinel"
+                    .to_string(),
+            ));
+        }
+        if self.after_issuer_sequence > i64::MAX as u64 {
+            return Err(Error::Configuration(
+                "Maple revocation pagination cursor exceeds the service sequence range".to_string(),
+            ));
+        }
+        let effective_limit = validate_limit(self.limit)?;
+        let mut canonical = CanonicalBytes::new("os.maple-pair-revocation-list.v1");
+        canonical
+            .append_u16(self.protocol_version)
+            .append_u16(self.transcript_version)
+            .append_uuid(self.asserted_account_id)
+            .append_uuid(self.asserted_project_id)
+            .append_uuid(self.query_id)
+            .append_uuid(self.host_registration_id)
+            .append_uuid(self.revocation_stream_id)
+            .append_u64(self.revocation_stream_generation)
+            .append_u64(self.after_issuer_sequence)
+            .append_u16(effective_limit);
+        Ok(canonical.into_bytes())
+    }
+
+    pub fn validate_with_signing_key(&self, public_key: &[u8; 32]) -> Result<()> {
+        validate_request_signature(public_key, &self.canonical_transcript()?, &self.signature)
+    }
+}
+
+impl AckMaplePairingRevocationRequest {
+    /// Builds an unsigned acknowledgement after the caller durably commits the
+    /// verified revocation to the host allowlist.
+    ///
+    /// This constructor performs no storage and no network request. The caller
+    /// must attach a host signature and submit it explicitly.
+    pub fn unsigned_v1_after_durable_commit(
+        operation_id: Uuid,
+        expected_previous_issuer_sequence: u64,
+        revocation: &VerifiedMaplePairRevocationV1,
+    ) -> Result<PreparedMaplePairingRevocationAckV1> {
+        let revocation = revocation.as_inner();
+        let request = Self {
+            protocol_version: MAPLE_PAIRING_PROTOCOL_VERSION,
+            transcript_version: MAPLE_PAIRING_TRANSCRIPT_VERSION,
+            operation_id,
+            asserted_account_id: revocation.subject_account_id,
+            asserted_project_id: revocation.subject_project_id,
+            host_registration_id: revocation.recipient_host_registration_id,
+            revocation_stream_id: revocation.revocation_stream_id,
+            revocation_stream_generation: revocation.revocation_stream_generation,
+            event_id: revocation.event_id,
+            issuer_sequence: revocation.issuer_sequence,
+            event_digest: revocation.transcript_digest()?,
+            expected_previous_issuer_sequence,
+            signature: String::new(),
+        };
+        request.canonical_transcript()?;
+        Ok(PreparedMaplePairingRevocationAckV1 { request })
+    }
+
+    /// Builds a scope-clear ACK only after the caller explicitly promoted the
+    /// verified latest reset head following an atomic durable full-scope local
+    /// admission clear.
+    ///
+    /// The returned prepared request may be cloned only for byte-identical
+    /// retries with the same operation ID. The service authoritatively rejects
+    /// a stale head through its checkpoint compare-and-swap and applies
+    /// operation-id idempotency; the SDK does not claim process-global
+    /// uniqueness for a signed artifact that can be fetched and verified
+    /// again.
+    pub fn unsigned_v1_after_durable_reset_clear(
+        operation_id: Uuid,
+        reset_clear: DurablyClearedMapleResetClearRequiredV1,
+    ) -> Result<PreparedMaplePairingRevocationAckV1> {
+        let reset = reset_clear.as_inner();
+        let request = Self {
+            protocol_version: MAPLE_PAIRING_PROTOCOL_VERSION,
+            transcript_version: MAPLE_PAIRING_TRANSCRIPT_VERSION,
+            operation_id,
+            asserted_account_id: reset.subject_account_id,
+            asserted_project_id: reset.subject_project_id,
+            host_registration_id: reset.recipient_host_registration_id,
+            revocation_stream_id: reset.revocation_stream_id,
+            revocation_stream_generation: reset.revocation_stream_generation,
+            event_id: reset.event_id,
+            issuer_sequence: 1,
+            event_digest: reset.event_digest()?,
+            expected_previous_issuer_sequence: 0,
+            signature: String::new(),
+        };
+        request.canonical_transcript()?;
+        Ok(PreparedMaplePairingRevocationAckV1 { request })
+    }
+
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        validate_versioned_request(self.protocol_version, self.transcript_version)?;
+        validate_non_nil(&[
+            ("operation ID", self.operation_id),
+            ("asserted account ID", self.asserted_account_id),
+            ("asserted project ID", self.asserted_project_id),
+            ("host registration ID", self.host_registration_id),
+            ("event ID", self.event_id),
+        ])?;
+        if self.issuer_sequence == 0
+            || self.issuer_sequence > i64::MAX as u64
+            || self.expected_previous_issuer_sequence > i64::MAX as u64
+            || self.expected_previous_issuer_sequence.checked_add(1) != Some(self.issuer_sequence)
+        {
+            return Err(Error::Configuration(
+                "Maple revocation acknowledgement sequence must immediately follow its durable predecessor"
+                    .to_string(),
+            ));
+        }
+        validate_revocation_stream(
+            self.revocation_stream_id,
+            self.revocation_stream_generation,
+            ErrorClass::Configuration,
+        )?;
+        let event_digest = decode_exact_base64(
+            &self.event_digest,
+            DIGEST_BYTES,
+            "Maple pairing revocation event digest",
+            ErrorClass::Configuration,
+        )?;
+        let mut canonical = CanonicalBytes::new("os.maple-pair-revocation-ack.v1");
+        canonical
+            .append_u16(self.protocol_version)
+            .append_u16(self.transcript_version)
+            .append_uuid(self.asserted_account_id)
+            .append_uuid(self.asserted_project_id)
+            .append_uuid(self.operation_id)
+            .append_uuid(self.host_registration_id)
+            .append_uuid(self.revocation_stream_id)
+            .append_u64(self.revocation_stream_generation)
+            .append_uuid(self.event_id)
+            .append_u64(self.issuer_sequence)
+            .append_bytes(&event_digest)
+            .append_u64(self.expected_previous_issuer_sequence);
+        Ok(canonical.into_bytes())
+    }
+
+    pub fn validate_with_signing_key(&self, public_key: &[u8; 32]) -> Result<()> {
+        validate_request_signature(public_key, &self.canonical_transcript()?, &self.signature)
+    }
+}
+
+impl MapleRevocationStreamCheckpointV1 {
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        self.validate_fields()?;
+        let mut canonical = CanonicalBytes::new("os.maple-revocation-stream-checkpoint.v1");
+        canonical
+            .append_u16(self.artifact_version)
+            .append_uuid(self.subject_account_id)
+            .append_uuid(self.subject_project_id);
+        append_device_claim(&mut canonical, &self.host, ErrorClass::InvalidResponse)?;
+        canonical
+            .append_u64(self.security_epoch)
+            .append_uuid(self.revocation_stream_id)
+            .append_u64(self.revocation_stream_generation)
+            .append_u64(self.last_issued_issuer_sequence)
+            .append_u64(self.last_acked_issuer_sequence)
+            .append_str(&self.issuer_key_id);
+        Ok(canonical.into_bytes())
+    }
+
+    pub fn transcript_digest(&self) -> Result<String> {
+        Ok(sha256_base64(&self.canonical_transcript()?))
+    }
+
+    pub fn verify(
+        &self,
+        issuers: &MaplePairingIssuerKeySet,
+    ) -> Result<VerifiedMapleRevocationStreamCheckpointV1> {
+        let transcript = self.canonical_transcript()?;
+        issuers.verify(&self.issuer_key_id, &transcript, &self.issuer_signature)?;
+        Ok(VerifiedMapleRevocationStreamCheckpointV1(self.clone()))
+    }
+
+    fn validate_fields(&self) -> Result<()> {
+        if self.artifact_version != MAPLE_PAIRING_ARTIFACT_VERSION
+            || self.subject_account_id.is_nil()
+            || self.subject_project_id.is_nil()
+            || self.security_epoch == 0
+            || self.security_epoch > i64::MAX as u64
+            || self.last_issued_issuer_sequence > i64::MAX as u64
+            || self.last_acked_issuer_sequence > self.last_issued_issuer_sequence
+        {
+            return Err(Error::InvalidResponse(
+                "Maple revocation stream checkpoint contains invalid scope or sequence fields"
+                    .to_string(),
+            ));
+        }
+        validate_device_claim(&self.host, ErrorClass::InvalidResponse)?;
+        validate_revocation_stream(
+            self.revocation_stream_id,
+            self.revocation_stream_generation,
+            ErrorClass::InvalidResponse,
+        )?;
+        validate_response_token(
+            &self.issuer_key_id,
+            MAX_ISSUER_KEY_ID_BYTES,
+            "issuer key ID",
+        )
+    }
+}
+
+impl MapleResetClearRequiredV1 {
+    /// Validates the complete reset-clear shape and both locally recomputable
+    /// SHA-256 commitments. Issuer trust is checked separately by `verify`.
+    pub fn validate(&self) -> Result<()> {
+        validate_reset_clear_unsigned(self)?;
+        decode_exact_base64(
+            &self.issuer_signature,
+            ED25519_SIGNATURE_BYTES,
+            "Maple reset-clear issuer signature",
+            ErrorClass::InvalidResponse,
+        )?;
+        Ok(())
+    }
+
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        reset_clear_required_transcript(self)
+    }
+
+    pub fn event_digest(&self) -> Result<String> {
+        Ok(sha256_base64(&self.canonical_transcript()?))
+    }
+
+    pub fn verify(
+        &self,
+        issuers: &MaplePairingIssuerKeySet,
+    ) -> Result<VerifiedMapleResetClearRequiredV1> {
+        let transcript = self.canonical_transcript()?;
+        issuers.verify(&self.issuer_key_id, &transcript, &self.issuer_signature)?;
+        Ok(VerifiedMapleResetClearRequiredV1(self.clone()))
+    }
+
+    pub fn verify_against_checkpoint(
+        &self,
+        issuers: &MaplePairingIssuerKeySet,
+        checkpoint: &VerifiedMapleRevocationStreamCheckpointV1,
+    ) -> Result<VerifiedLatestMapleResetClearRequiredV1> {
+        self.verify(issuers)?.bind_to_checkpoint(checkpoint)
+    }
+}
+
+pub fn sign_reset_clear_required(
+    mut instruction: MapleResetClearRequiredV1,
+    issuer: &dyn MaplePairingIssuer,
+) -> Result<MapleResetClearRequiredV1> {
+    instruction.instruction_material_digest.clear();
+    instruction.chain_digest.clear();
+    instruction.issuer_key_id.clear();
+    instruction.issuer_signature.clear();
+
+    let material_digest =
+        Sha256::digest(reset_clear_instruction_material_transcript(&instruction)?);
+    instruction.instruction_material_digest = BASE64.encode(material_digest);
+    let chain_digest = Sha256::digest(reset_clear_chain_transcript(&instruction)?);
+    instruction.chain_digest = BASE64.encode(chain_digest);
+    instruction.issuer_key_id = issuer.key_id().to_string();
+    validate_response_token(
+        &instruction.issuer_key_id,
+        MAX_ISSUER_KEY_ID_BYTES,
+        "reset-clear issuer key ID",
+    )?;
+    let expected_public_key = issuer.public_key_bytes();
+    if VerifyingKey::from_bytes(&expected_public_key).is_err() {
+        return Err(Error::Configuration(
+            "Maple reset-clear issuer public key is invalid".to_string(),
+        ));
+    }
+    instruction.issuer_signature =
+        BASE64.encode(issuer.sign(&instruction.canonical_transcript()?)?);
+    instruction.validate()?;
+    Ok(instruction)
+}
+
+impl MapleRevocationStreamEventV1 {
+    pub fn issuer_sequence(&self) -> u64 {
+        match self {
+            Self::PairRevocation(event) => event.issuer_sequence,
+            Self::ResetClearRequired(event) => event.issuer_sequence,
+        }
+    }
+
+    pub fn event_id(&self) -> Uuid {
+        match self {
+            Self::PairRevocation(event) => event.event_id,
+            Self::ResetClearRequired(event) => event.event_id,
+        }
+    }
+
+    pub fn event_digest(&self) -> Result<String> {
+        match self {
+            Self::PairRevocation(event) => event.transcript_digest(),
+            Self::ResetClearRequired(event) => event.event_digest(),
+        }
+    }
+
+    pub fn verify(
+        &self,
+        issuers: &MaplePairingIssuerKeySet,
+    ) -> Result<VerifiedMapleRevocationStreamEventV1> {
+        match self {
+            Self::PairRevocation(event) => Ok(
+                VerifiedMapleRevocationStreamEventV1::PairRevocation(event.verify_issuer(issuers)?),
+            ),
+            Self::ResetClearRequired(event) => Ok(
+                VerifiedMapleRevocationStreamEventV1::ResetClearRequired(event.verify(issuers)?),
+            ),
+        }
+    }
+}
+
+impl MapleRevocationSyncV1 {
+    pub fn validate(&self) -> Result<()> {
+        validate_reset_counter(
+            self.security_epoch,
+            "sync security epoch",
+            ErrorClass::InvalidResponse,
+        )?;
+        self.stream_checkpoint.validate_fields()?;
+        if self.security_epoch != self.stream_checkpoint.security_epoch {
+            return Err(Error::InvalidResponse(
+                "Maple revocation sync security epoch does not match its checkpoint".to_string(),
+            ));
+        }
+        match (self.status, self.reset_clear_instruction.as_ref()) {
+            (MapleRevocationSyncStatusV1::Ready, None)
+                if self.stream_checkpoint.last_issued_issuer_sequence
+                    == self.stream_checkpoint.last_acked_issuer_sequence => {}
+            (MapleRevocationSyncStatusV1::RevocationsPending, None)
+                if self.stream_checkpoint.last_issued_issuer_sequence
+                    > self.stream_checkpoint.last_acked_issuer_sequence => {}
+            (MapleRevocationSyncStatusV1::ResetClearRequired, Some(reset))
+                if self.stream_checkpoint.last_issued_issuer_sequence == 1
+                    && self.stream_checkpoint.last_acked_issuer_sequence == 0 =>
+            {
+                reset.validate()?;
+                if reset.security_epoch != self.security_epoch
+                    || reset.subject_account_id != self.stream_checkpoint.subject_account_id
+                    || reset.subject_project_id != self.stream_checkpoint.subject_project_id
+                    || reset.recipient_host_registration_id
+                        != self.stream_checkpoint.host.registration_id
+                    || !device_claim_is_same_identity_at_or_before(
+                        &reset.host,
+                        &self.stream_checkpoint.host,
+                    )
+                    || reset.revocation_stream_id != self.stream_checkpoint.revocation_stream_id
+                    || reset.revocation_stream_generation
+                        != self.stream_checkpoint.revocation_stream_generation
+                {
+                    return Err(Error::InvalidResponse(
+                        "Maple reset-clear sync does not match its target checkpoint".to_string(),
+                    ));
+                }
+            }
+            _ => {
+                return Err(Error::InvalidResponse(
+                    "Maple revocation sync status, checkpoint, and reset instruction disagree"
+                        .to_string(),
+                ))
+            }
+        }
+        Ok(())
+    }
+
+    pub fn verify(
+        &self,
+        issuers: &MaplePairingIssuerKeySet,
+    ) -> Result<VerifiedMapleRevocationSyncV1> {
+        self.validate()?;
+        let checkpoint = self.stream_checkpoint.verify(issuers)?;
+        let reset_clear_instruction = self
+            .reset_clear_instruction
+            .as_ref()
+            .map(|reset| reset.verify_against_checkpoint(issuers, &checkpoint))
+            .transpose()?;
+        Ok(VerifiedMapleRevocationSyncV1 {
+            sync: self.clone(),
+            checkpoint,
+            reset_clear_instruction,
+        })
+    }
+
+    /// Verifies this sync against the exact accepted registration request and
+    /// receipt identity. The authenticated account/project remain server-owned;
+    /// these signed values are stale-state and response-binding preconditions.
+    pub fn verify_against_registration(
+        &self,
+        request: &crate::types::RegisterMapleDeviceRequest,
+        registration_id: Uuid,
+        response_security_epoch: u64,
+        issuers: &MaplePairingIssuerKeySet,
+    ) -> Result<VerifiedMapleRevocationSyncV1> {
+        let verified = self.verify(issuers)?;
+        let checkpoint = verified.checkpoint.as_inner();
+        let identity_algorithm_matches = matches!(
+            (
+                request.identity_algorithm,
+                checkpoint.host.identity_algorithm
+            ),
+            (
+                crate::types::MapleDeviceIdentityAlgorithm::Ed25519,
+                MaplePairingIdentityAlgorithm::Ed25519
+            )
+        );
+        if registration_id.is_nil()
+            || response_security_epoch != request.known_security_epoch
+            || self.security_epoch != response_security_epoch
+            || checkpoint.subject_account_id != request.asserted_account_id
+            || checkpoint.subject_project_id != request.asserted_project_id
+            || checkpoint.host.registration_id != registration_id
+            || checkpoint.host.device_id != request.device_id
+            || checkpoint.host.installation_id != request.installation_id
+            || !identity_algorithm_matches
+            || checkpoint.host.identity_public_key != request.identity_public_key
+            || checkpoint.host.endpoint_id != request.iroh_endpoint_id
+            || checkpoint.host.endpoint_epoch != request.endpoint_epoch
+        {
+            return Err(Error::InvalidResponse(
+                "Maple revocation sync does not bind the accepted device registration".to_string(),
+            ));
+        }
+        Ok(verified)
+    }
+}
+
+impl MaplePairRequestTicketV1 {
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        self.validate_fields()?;
+        let request_nonce = decode_exact_base64(
+            &self.pairing_request_nonce,
+            NONCE_BYTES,
+            "Maple pairing artifact request nonce",
+            ErrorClass::InvalidResponse,
+        )?;
+        let request_digest = decode_exact_base64(
+            &self.controller_request_digest,
+            DIGEST_BYTES,
+            "Maple pairing controller request digest",
+            ErrorClass::InvalidResponse,
+        )?;
+        let request_signature = decode_exact_base64(
+            &self.controller_request_signature,
+            ED25519_SIGNATURE_BYTES,
+            "Maple pairing controller request signature",
+            ErrorClass::InvalidResponse,
+        )?;
+        let mut canonical = CanonicalBytes::new("os.maple-pair-request-ticket.v1");
+        canonical
+            .append_u16(self.artifact_version)
+            .append_uuid(self.subject_account_id)
+            .append_uuid(self.subject_project_id)
+            .append_uuid(self.pairing_request_id)
+            .append_uuid(self.pair_id)
+            .append_str(self.direction.as_str())
+            .append_uuid(self.execution_target_id);
+        append_device_claim(
+            &mut canonical,
+            &self.controller,
+            ErrorClass::InvalidResponse,
+        )?;
+        append_device_claim(&mut canonical, &self.host, ErrorClass::InvalidResponse)?;
+        canonical
+            .append_bytes(&request_nonce)
+            .append_uuid(self.controller_request_operation_id)
+            .append_bytes(&request_digest)
+            .append_bytes(&request_signature)
+            .append_u64(self.pairing_incarnation)
+            .append_u16(self.protocol_min)
+            .append_u16(self.protocol_max)
+            .append_i64(self.created_at_unix_ms)
+            .append_i64(self.expires_at_unix_ms)
+            .append_str(&self.issuer_key_id);
+        Ok(canonical.into_bytes())
+    }
+
+    pub fn transcript_digest(&self) -> Result<String> {
+        Ok(sha256_base64(&self.canonical_transcript()?))
+    }
+
+    pub fn verify_at(
+        &self,
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+        max_clock_skew_ms: i64,
+        max_ticket_ttl_ms: i64,
+    ) -> Result<VerifiedMaplePairRequestTicketV1> {
+        if trusted_now_unix_ms <= 0 {
+            return Err(Error::Configuration(
+                "Maple pairing ticket verification requires a positive trusted current time"
+                    .to_string(),
+            ));
+        }
+        if !(0..=MAPLE_PAIRING_MAX_CLOCK_SKEW_MS).contains(&max_clock_skew_ms) {
+            return Err(Error::Configuration(format!(
+                "Maple pairing clock skew must be between 0 and {MAPLE_PAIRING_MAX_CLOCK_SKEW_MS} milliseconds"
+            )));
+        }
+        if !(1..=MAPLE_PAIRING_MAX_TICKET_TTL_MS).contains(&max_ticket_ttl_ms) {
+            return Err(Error::Configuration(format!(
+                "Maple pairing ticket TTL must be between 1 and {MAPLE_PAIRING_MAX_TICKET_TTL_MS} milliseconds"
+            )));
+        }
+        self.verify_signatures(issuers)?;
+        if self
+            .expires_at_unix_ms
+            .checked_sub(self.created_at_unix_ms)
+            .is_none_or(|ttl| ttl > max_ticket_ttl_ms)
+            || self
+                .created_at_unix_ms
+                .checked_sub(max_clock_skew_ms)
+                .is_none_or(|earliest| trusted_now_unix_ms < earliest)
+            || self
+                .expires_at_unix_ms
+                .checked_add(max_clock_skew_ms)
+                .is_none_or(|latest| trusted_now_unix_ms >= latest)
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing request ticket is outside its trusted time window".to_string(),
+            ));
+        }
+        Ok(VerifiedMaplePairRequestTicketV1(self.clone()))
+    }
+
+    fn verify_signatures(&self, issuers: &MaplePairingIssuerKeySet) -> Result<()> {
+        let transcript = self.canonical_transcript()?;
+        self.verify_controller_request()?;
+        issuers.verify(&self.issuer_key_id, &transcript, &self.issuer_signature)
+    }
+
+    fn validate_fields(&self) -> Result<()> {
+        if self.artifact_version != MAPLE_PAIRING_ARTIFACT_VERSION {
+            return Err(Error::InvalidResponse(
+                "Unsupported Maple pairing request-ticket artifact version".to_string(),
+            ));
+        }
+        if self.subject_account_id.is_nil()
+            || self.subject_project_id.is_nil()
+            || self.pairing_request_id.is_nil()
+            || self.pair_id.is_nil()
+            || self.execution_target_id.is_nil()
+            || self.controller_request_operation_id.is_nil()
+            || self.execution_target_id != self.host.registration_id
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing request ticket contains invalid identity bindings".to_string(),
+            ));
+        }
+        validate_device_claim(&self.controller, ErrorClass::InvalidResponse)?;
+        validate_device_claim(&self.host, ErrorClass::InvalidResponse)?;
+        validate_directed_device_claims(
+            &self.controller,
+            &self.host,
+            self.execution_target_id,
+            ErrorClass::InvalidResponse,
+        )?;
+        if self.pairing_incarnation == 0 || self.pairing_incarnation > i64::MAX as u64 {
+            return Err(Error::InvalidResponse(
+                "Maple pairing request ticket has an invalid incarnation".to_string(),
+            ));
+        }
+        if self.protocol_min == 0 || self.protocol_min > self.protocol_max {
+            return Err(Error::InvalidResponse(
+                "Maple pairing request ticket has an invalid protocol range".to_string(),
+            ));
+        }
+        validate_timestamp(
+            self.created_at_unix_ms,
+            "created timestamp",
+            ErrorClass::InvalidResponse,
+        )?;
+        validate_timestamp(
+            self.expires_at_unix_ms,
+            "expiry timestamp",
+            ErrorClass::InvalidResponse,
+        )?;
+        if self.expires_at_unix_ms <= self.created_at_unix_ms {
+            return Err(Error::InvalidResponse(
+                "Maple pairing request ticket expiry must follow creation".to_string(),
+            ));
+        }
+        if self
+            .expires_at_unix_ms
+            .checked_sub(self.created_at_unix_ms)
+            .is_none_or(|ttl| ttl > MAPLE_PAIRING_MAX_TICKET_TTL_MS)
+        {
+            return Err(Error::InvalidResponse(format!(
+                "Maple pairing request ticket lifetime exceeds {MAPLE_PAIRING_MAX_TICKET_TTL_MS} milliseconds"
+            )));
+        }
+        validate_response_token(
+            &self.issuer_key_id,
+            MAX_ISSUER_KEY_ID_BYTES,
+            "issuer key ID",
+        )?;
+        Ok(())
+    }
+
+    fn controller_request(&self) -> CreateMaplePairingRequest {
+        CreateMaplePairingRequest {
+            protocol_version: MAPLE_PAIRING_PROTOCOL_VERSION,
+            transcript_version: MAPLE_PAIRING_TRANSCRIPT_VERSION,
+            operation_id: self.controller_request_operation_id,
+            asserted_account_id: self.subject_account_id,
+            asserted_project_id: self.subject_project_id,
+            controller_registration_id: self.controller.registration_id,
+            controller_device_id: self.controller.device_id,
+            controller_installation_id: self.controller.installation_id,
+            controller_endpoint_id: self.controller.endpoint_id.clone(),
+            controller_endpoint_epoch: self.controller.endpoint_epoch,
+            host_registration_id: self.host.registration_id,
+            host_device_id: self.host.device_id,
+            host_installation_id: self.host.installation_id,
+            host_endpoint_id: self.host.endpoint_id.clone(),
+            host_endpoint_epoch: self.host.endpoint_epoch,
+            direction: self.direction,
+            execution_target_id: self.execution_target_id,
+            pairing_request_nonce: self.pairing_request_nonce.clone(),
+            protocol_min: self.protocol_min,
+            protocol_max: self.protocol_max,
+            signature: self.controller_request_signature.clone(),
+        }
+    }
+
+    fn verify_controller_request(&self) -> Result<()> {
+        let request = self.controller_request();
+        let transcript = request
+            .canonical_transcript()
+            .map_err(configuration_as_invalid_response)?;
+        if sha256_base64(&transcript) != self.controller_request_digest {
+            return Err(Error::InvalidResponse(
+                "Maple pairing request ticket controller digest does not match its claims"
+                    .to_string(),
+            ));
+        }
+        let controller_key =
+            validate_device_claim(&self.controller, ErrorClass::InvalidResponse)?.0;
+        let signature = decode_exact_base64(
+            &self.controller_request_signature,
+            ED25519_SIGNATURE_BYTES,
+            "Maple pairing controller request signature",
+            ErrorClass::InvalidResponse,
+        )?;
+        let signature: [u8; ED25519_SIGNATURE_BYTES] = signature
+            .try_into()
+            .expect("exact signature length was checked");
+        let controller_key = VerifyingKey::from_bytes(&controller_key).map_err(|_| {
+            Error::InvalidResponse(
+                "Maple pairing controller key is not a valid Ed25519 point".to_string(),
+            )
+        })?;
+        controller_key
+            .verify_strict(&transcript, &Signature::from_bytes(&signature))
+            .map_err(|_| {
+                Error::InvalidResponse(
+                    "Maple pairing controller request signature does not verify".to_string(),
+                )
+            })
+    }
+}
+
+fn configuration_as_invalid_response(error: Error) -> Error {
+    match error {
+        Error::Configuration(message) => Error::InvalidResponse(message),
+        other => other,
+    }
+}
+
+impl MaplePairAuthorizationV1 {
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        self.validate_fields()?;
+        let request_nonce =
+            decode_response_bytes(&self.pairing_request_nonce, NONCE_BYTES, "request nonce")?;
+        let request_digest = decode_response_bytes(
+            &self.controller_request_digest,
+            DIGEST_BYTES,
+            "controller request digest",
+        )?;
+        let request_signature = decode_response_bytes(
+            &self.controller_request_signature,
+            ED25519_SIGNATURE_BYTES,
+            "controller request signature",
+        )?;
+        let ticket_digest = decode_response_bytes(
+            &self.request_ticket_digest,
+            DIGEST_BYTES,
+            "request ticket digest",
+        )?;
+        let approval_nonce = decode_response_bytes(
+            &self.host_approval_nonce,
+            NONCE_BYTES,
+            "host approval nonce",
+        )?;
+        let approval_digest = decode_response_bytes(
+            &self.host_approval_digest,
+            DIGEST_BYTES,
+            "host approval digest",
+        )?;
+        let approval_signature = decode_response_bytes(
+            &self.host_approval_signature,
+            ED25519_SIGNATURE_BYTES,
+            "host approval signature",
+        )?;
+        let mut canonical = CanonicalBytes::new("os.maple-pair-authorization.v1");
+        canonical
+            .append_u16(self.artifact_version)
+            .append_uuid(self.subject_account_id)
+            .append_uuid(self.subject_project_id)
+            .append_uuid(self.pairing_request_id)
+            .append_uuid(self.pair_id)
+            .append_str(self.direction.as_str())
+            .append_uuid(self.execution_target_id);
+        append_device_claim(
+            &mut canonical,
+            &self.controller,
+            ErrorClass::InvalidResponse,
+        )?;
+        append_device_claim(&mut canonical, &self.host, ErrorClass::InvalidResponse)?;
+        canonical
+            .append_bytes(&request_nonce)
+            .append_uuid(self.controller_request_operation_id)
+            .append_bytes(&request_digest)
+            .append_bytes(&request_signature)
+            .append_bytes(&ticket_digest)
+            .append_uuid(self.host_approval_operation_id)
+            .append_i64(self.host_approval_expected_pairing_revision)
+            .append_bytes(&approval_nonce)
+            .append_bytes(&approval_digest)
+            .append_bytes(&approval_signature)
+            .append_u64(self.pairing_incarnation)
+            .append_uuid(self.revocation_stream_id)
+            .append_u64(self.revocation_stream_generation)
+            .append_u16(self.protocol_min)
+            .append_u16(self.protocol_max)
+            .append_i64(self.approved_at_unix_ms)
+            .append_str(&self.issuer_key_id);
+        Ok(canonical.into_bytes())
+    }
+
+    pub fn transcript_digest(&self) -> Result<String> {
+        Ok(sha256_base64(&self.canonical_transcript()?))
+    }
+
+    /// Verifies the issuer, both embedded device proofs, and the exact signed
+    /// request ticket that this authorization approves.
+    ///
+    /// An issuer signature alone is insufficient for the authority wrapper:
+    /// callers must supply the ticket so `request_ticket_digest` and every pair
+    /// claim are checked before this value can be used to construct a host
+    /// commit.
+    pub fn verify_against_ticket(
+        &self,
+        issuers: &MaplePairingIssuerKeySet,
+        ticket: &MaplePairRequestTicketV1,
+    ) -> Result<VerifiedMaplePairAuthorizationV1> {
+        // Validate the ticket at the issuer-signed approval time. This rejects
+        // authorizations issued outside the request window while preserving
+        // restart recovery after the ticket later expires.
+        ticket.verify_at(
+            issuers,
+            self.approved_at_unix_ms,
+            MAPLE_PAIRING_MAX_CLOCK_SKEW_MS,
+            MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+        )?;
+        self.verify_signatures(issuers)?;
+        self.validate_ticket_binding(ticket)?;
+        Ok(VerifiedMaplePairAuthorizationV1(self.clone()))
+    }
+
+    fn verify_signatures(&self, issuers: &MaplePairingIssuerKeySet) -> Result<()> {
+        let transcript = self.canonical_transcript()?;
+        self.verify_controller_request()?;
+        self.verify_host_approval()?;
+        issuers.verify(&self.issuer_key_id, &transcript, &self.issuer_signature)
+    }
+
+    fn validate_ticket_binding(&self, ticket: &MaplePairRequestTicketV1) -> Result<()> {
+        if self.subject_account_id != ticket.subject_account_id
+            || self.subject_project_id != ticket.subject_project_id
+            || self.pairing_request_id != ticket.pairing_request_id
+            || self.pair_id != ticket.pair_id
+            || self.direction != ticket.direction
+            || self.execution_target_id != ticket.execution_target_id
+            || self.controller != ticket.controller
+            || self.host != ticket.host
+            || self.pairing_request_nonce != ticket.pairing_request_nonce
+            || self.controller_request_operation_id != ticket.controller_request_operation_id
+            || self.controller_request_digest != ticket.controller_request_digest
+            || self.controller_request_signature != ticket.controller_request_signature
+            || self.pairing_incarnation != ticket.pairing_incarnation
+            || self.protocol_min != ticket.protocol_min
+            || self.protocol_max != ticket.protocol_max
+            || self.request_ticket_digest != ticket.transcript_digest()?
+            || self.approved_at_unix_ms < ticket.created_at_unix_ms
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pair authorization does not match its issuer-verified request ticket"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_fields(&self) -> Result<()> {
+        if self.artifact_version != MAPLE_PAIRING_ARTIFACT_VERSION
+            || self.subject_account_id.is_nil()
+            || self.subject_project_id.is_nil()
+            || self.pairing_request_id.is_nil()
+            || self.pair_id.is_nil()
+            || self.execution_target_id.is_nil()
+            || self.controller_request_operation_id.is_nil()
+            || self.host_approval_operation_id.is_nil()
+            || self.execution_target_id != self.host.registration_id
+            || self.host_approval_expected_pairing_revision != 1
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pair authorization contains invalid identity or revision bindings"
+                    .to_string(),
+            ));
+        }
+        validate_device_claim(&self.controller, ErrorClass::InvalidResponse)?;
+        validate_device_claim(&self.host, ErrorClass::InvalidResponse)?;
+        validate_directed_device_claims(
+            &self.controller,
+            &self.host,
+            self.execution_target_id,
+            ErrorClass::InvalidResponse,
+        )?;
+        if self.pairing_incarnation == 0
+            || self.pairing_incarnation > i64::MAX as u64
+            || self.protocol_min == 0
+            || self.protocol_min > self.protocol_max
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pair authorization has an invalid incarnation or protocol range".to_string(),
+            ));
+        }
+        validate_revocation_stream(
+            self.revocation_stream_id,
+            self.revocation_stream_generation,
+            ErrorClass::InvalidResponse,
+        )?;
+        validate_timestamp(
+            self.approved_at_unix_ms,
+            "approval timestamp",
+            ErrorClass::InvalidResponse,
+        )?;
+        validate_response_token(
+            &self.issuer_key_id,
+            MAX_ISSUER_KEY_ID_BYTES,
+            "issuer key ID",
+        )?;
+        Ok(())
+    }
+
+    fn controller_request(&self) -> CreateMaplePairingRequest {
+        CreateMaplePairingRequest {
+            protocol_version: MAPLE_PAIRING_PROTOCOL_VERSION,
+            transcript_version: MAPLE_PAIRING_TRANSCRIPT_VERSION,
+            operation_id: self.controller_request_operation_id,
+            asserted_account_id: self.subject_account_id,
+            asserted_project_id: self.subject_project_id,
+            controller_registration_id: self.controller.registration_id,
+            controller_device_id: self.controller.device_id,
+            controller_installation_id: self.controller.installation_id,
+            controller_endpoint_id: self.controller.endpoint_id.clone(),
+            controller_endpoint_epoch: self.controller.endpoint_epoch,
+            host_registration_id: self.host.registration_id,
+            host_device_id: self.host.device_id,
+            host_installation_id: self.host.installation_id,
+            host_endpoint_id: self.host.endpoint_id.clone(),
+            host_endpoint_epoch: self.host.endpoint_epoch,
+            direction: self.direction,
+            execution_target_id: self.execution_target_id,
+            pairing_request_nonce: self.pairing_request_nonce.clone(),
+            protocol_min: self.protocol_min,
+            protocol_max: self.protocol_max,
+            signature: self.controller_request_signature.clone(),
+        }
+    }
+
+    fn verify_controller_request(&self) -> Result<()> {
+        let request = self.controller_request();
+        let transcript = request
+            .canonical_transcript()
+            .map_err(configuration_as_invalid_response)?;
+        if sha256_base64(&transcript) != self.controller_request_digest {
+            return Err(Error::InvalidResponse(
+                "Maple pair authorization controller digest mismatch".to_string(),
+            ));
+        }
+        verify_embedded_signature(
+            &self.controller,
+            &transcript,
+            &self.controller_request_signature,
+            "controller request",
+        )
+    }
+
+    fn verify_host_approval(&self) -> Result<()> {
+        let approval = ApproveMaplePairingRequest {
+            protocol_version: MAPLE_PAIRING_PROTOCOL_VERSION,
+            transcript_version: MAPLE_PAIRING_TRANSCRIPT_VERSION,
+            operation_id: self.host_approval_operation_id,
+            asserted_account_id: self.subject_account_id,
+            asserted_project_id: self.subject_project_id,
+            host_registration_id: self.host.registration_id,
+            pairing_request_id: self.pairing_request_id,
+            pair_id: self.pair_id,
+            expected_pairing_revision: self.host_approval_expected_pairing_revision,
+            pairing_incarnation: self.pairing_incarnation,
+            revocation_stream_id: self.revocation_stream_id,
+            revocation_stream_generation: self.revocation_stream_generation,
+            request_ticket_digest: self.request_ticket_digest.clone(),
+            host_approval_nonce: self.host_approval_nonce.clone(),
+            approved_protocol_min: self.protocol_min,
+            approved_protocol_max: self.protocol_max,
+            signature: self.host_approval_signature.clone(),
+        };
+        let transcript = approval
+            .canonical_transcript()
+            .map_err(configuration_as_invalid_response)?;
+        if sha256_base64(&transcript) != self.host_approval_digest {
+            return Err(Error::InvalidResponse(
+                "Maple pair authorization host approval digest mismatch".to_string(),
+            ));
+        }
+        verify_embedded_signature(
+            &self.host,
+            &transcript,
+            &self.host_approval_signature,
+            "host approval",
+        )
+    }
+}
+
+fn decode_response_bytes(value: &str, length: usize, field: &str) -> Result<Vec<u8>> {
+    decode_exact_base64(
+        value,
+        length,
+        &format!("Maple pairing {field}"),
+        ErrorClass::InvalidResponse,
+    )
+}
+
+fn verify_embedded_signature(
+    claim: &MaplePairingDeviceClaimV1,
+    transcript: &[u8],
+    signature: &str,
+    label: &str,
+) -> Result<()> {
+    let public_key = validate_device_claim(claim, ErrorClass::InvalidResponse)?.0;
+    let signature = decode_response_bytes(signature, ED25519_SIGNATURE_BYTES, label)?;
+    let signature: [u8; ED25519_SIGNATURE_BYTES] = signature
+        .try_into()
+        .expect("exact signature length was checked");
+    let public_key = VerifyingKey::from_bytes(&public_key).map_err(|_| {
+        Error::InvalidResponse(format!(
+            "Maple pairing {label} key is not a valid Ed25519 point"
+        ))
+    })?;
+    public_key
+        .verify_strict(transcript, &Signature::from_bytes(&signature))
+        .map_err(|_| {
+            Error::InvalidResponse(format!("Maple pairing {label} signature does not verify"))
+        })
+}
+
+impl MaplePairRevocationV1 {
+    pub fn canonical_transcript(&self) -> Result<Vec<u8>> {
+        self.validate_fields()?;
+        let authorization_digest = self.authorization_digest_bytes()?;
+        let mut canonical = CanonicalBytes::new("os.maple-pair-revocation.v1");
+        canonical
+            .append_u16(self.artifact_version)
+            .append_uuid(self.event_id)
+            .append_uuid(self.subject_account_id)
+            .append_uuid(self.subject_project_id)
+            .append_uuid(self.recipient_host_registration_id)
+            .append_u64(self.issuer_sequence)
+            .append_uuid(self.revocation_stream_id)
+            .append_u64(self.revocation_stream_generation)
+            .append_uuid(self.pairing_request_id)
+            .append_uuid(self.pair_id)
+            .append_str(self.direction.as_str())
+            .append_uuid(self.execution_target_id);
+        append_device_claim(
+            &mut canonical,
+            &self.controller,
+            ErrorClass::InvalidResponse,
+        )?;
+        append_device_claim(&mut canonical, &self.host, ErrorClass::InvalidResponse)?;
+        canonical
+            .append_u64(self.pairing_incarnation)
+            .append_bytes(&authorization_digest)
+            .append_uuid(self.revoked_by_registration_id)
+            .append_str(self.revoked_by_role.as_str())
+            .append_str(&self.reason_code)
+            .append_i64(self.revoked_at_unix_ms)
+            .append_str(&self.issuer_key_id);
+        Ok(canonical.into_bytes())
+    }
+
+    pub fn transcript_digest(&self) -> Result<String> {
+        Ok(sha256_base64(&self.canonical_transcript()?))
+    }
+
+    /// Verifies the issuer signature and structural event claims, but does not
+    /// yet make the event safe to durably apply or acknowledge.
+    ///
+    /// Revocation pages cannot prove that `pair_authorization_digest` matches
+    /// the host's durable authorization. Call
+    /// [`IssuerVerifiedMaplePairRevocationV1::bind_to_authorization`] with the
+    /// host's ticket-bound authorization before updating an allowlist.
+    pub fn verify_issuer(
+        &self,
+        issuers: &MaplePairingIssuerKeySet,
+    ) -> Result<IssuerVerifiedMaplePairRevocationV1> {
+        let transcript = self.canonical_transcript()?;
+        issuers.verify(&self.issuer_key_id, &transcript, &self.issuer_signature)?;
+        Ok(IssuerVerifiedMaplePairRevocationV1(self.clone()))
+    }
+
+    pub fn verify_against_authorization(
+        &self,
+        issuers: &MaplePairingIssuerKeySet,
+        authorization: &VerifiedMaplePairAuthorizationV1,
+        revocation_stream: &DurablyReconciledMapleRevocationStreamV1,
+    ) -> Result<VerifiedMaplePairRevocationV1> {
+        self.verify_issuer(issuers)?
+            .bind_to_authorization(authorization, revocation_stream)
+    }
+
+    fn validate_authorization_binding(
+        &self,
+        authorization: &MaplePairAuthorizationV1,
+    ) -> Result<()> {
+        if self.pair_authorization_digest != authorization.transcript_digest()?
+            || self.subject_account_id != authorization.subject_account_id
+            || self.subject_project_id != authorization.subject_project_id
+            || self.pairing_request_id != authorization.pairing_request_id
+            || self.pair_id != authorization.pair_id
+            || self.direction != authorization.direction
+            || self.execution_target_id != authorization.execution_target_id
+            || self.controller != authorization.controller
+            || self.host != authorization.host
+            || self.pairing_incarnation != authorization.pairing_incarnation
+            || self.revocation_stream_id != authorization.revocation_stream_id
+            || self.revocation_stream_generation != authorization.revocation_stream_generation
+            || self.revoked_at_unix_ms < authorization.approved_at_unix_ms
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pair revocation does not match the host's verified authorization"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_fields(&self) -> Result<()> {
+        if self.artifact_version != MAPLE_PAIRING_ARTIFACT_VERSION
+            || self.event_id.is_nil()
+            || self.subject_account_id.is_nil()
+            || self.subject_project_id.is_nil()
+            || self.recipient_host_registration_id.is_nil()
+            || self.issuer_sequence == 0
+            || self.issuer_sequence > i64::MAX as u64
+            || self.pairing_request_id.is_nil()
+            || self.pair_id.is_nil()
+            || self.execution_target_id.is_nil()
+            || self.revoked_by_registration_id.is_nil()
+            || self.execution_target_id != self.host.registration_id
+            || self.recipient_host_registration_id != self.host.registration_id
+            || !matches!(
+                (self.revoked_by_role, self.revoked_by_registration_id),
+                (MaplePairingRole::Controller, registration) if registration == self.controller.registration_id
+            ) && !matches!(
+                (self.revoked_by_role, self.revoked_by_registration_id),
+                (MaplePairingRole::Host, registration) if registration == self.host.registration_id
+            )
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pair revocation contains invalid identity or sequence bindings".to_string(),
+            ));
+        }
+        validate_device_claim(&self.controller, ErrorClass::InvalidResponse)?;
+        validate_device_claim(&self.host, ErrorClass::InvalidResponse)?;
+        validate_directed_device_claims(
+            &self.controller,
+            &self.host,
+            self.execution_target_id,
+            ErrorClass::InvalidResponse,
+        )?;
+        if self.pairing_incarnation == 0 || self.pairing_incarnation > i64::MAX as u64 {
+            return Err(Error::InvalidResponse(
+                "Maple pair revocation has an invalid pairing incarnation".to_string(),
+            ));
+        }
+        validate_revocation_stream(
+            self.revocation_stream_id,
+            self.revocation_stream_generation,
+            ErrorClass::InvalidResponse,
+        )?;
+        validate_response_token(
+            &self.reason_code,
+            MAX_REASON_CODE_BYTES,
+            "revocation reason code",
+        )?;
+        validate_response_token(
+            &self.issuer_key_id,
+            MAX_ISSUER_KEY_ID_BYTES,
+            "issuer key ID",
+        )?;
+        validate_timestamp(
+            self.revoked_at_unix_ms,
+            "revocation timestamp",
+            ErrorClass::InvalidResponse,
+        )
+    }
+
+    fn authorization_digest_bytes(&self) -> Result<Vec<u8>> {
+        let digest = decode_response_bytes(
+            &self.pair_authorization_digest,
+            DIGEST_BYTES,
+            "pair authorization digest",
+        )?;
+        if digest.iter().all(|byte| *byte == 0) {
+            return Err(Error::InvalidResponse(
+                "Maple pair revocation contains an all-zero authorization digest".to_string(),
+            ));
+        }
+        Ok(digest)
+    }
+}
+
+#[derive(Clone)]
+pub struct VerifiedMaplePairRequestTicketV1(MaplePairRequestTicketV1);
+
+redacted_debug!(VerifiedMaplePairRequestTicketV1);
+
+impl VerifiedMaplePairRequestTicketV1 {
+    pub fn as_inner(&self) -> &MaplePairRequestTicketV1 {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> MaplePairRequestTicketV1 {
+        self.0
+    }
+}
+
+#[derive(Clone)]
+pub struct VerifiedMapleRevocationStreamCheckpointV1(MapleRevocationStreamCheckpointV1);
+
+redacted_debug!(VerifiedMapleRevocationStreamCheckpointV1);
+
+impl VerifiedMapleRevocationStreamCheckpointV1 {
+    pub fn as_inner(&self) -> &MapleRevocationStreamCheckpointV1 {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> MapleRevocationStreamCheckpointV1 {
+        self.0
+    }
+
+    pub fn namespace_matches(&self, stream_id: Uuid, generation: u64) -> bool {
+        self.0.revocation_stream_id == stream_id
+            && self.0.revocation_stream_generation == generation
+    }
+
+    /// Compares this signed checkpoint with the exact namespace loaded from
+    /// the host's durable account-scoped admission store.
+    ///
+    /// Lower generations and same-generation/different-ID checkpoints fail
+    /// closed. Missing or higher generations produce a reset-required plan;
+    /// generation jumps are valid because destructive resets can consume
+    /// namespace generations without ever issuing an admission.
+    pub fn plan_durable_transition(
+        self,
+        installed: Option<MapleInstalledRevocationStreamNamespaceV1>,
+    ) -> Result<MapleRevocationStreamTransitionV1> {
+        let requires_admission_reset = match installed {
+            None => true,
+            Some(installed)
+                if installed.subject_account_id != self.0.subject_account_id
+                    || installed.subject_project_id != self.0.subject_project_id
+                    || installed.host_registration_id != self.0.host.registration_id =>
+            {
+                return Err(Error::Configuration(
+                    "Maple durable revocation namespace belongs to a different account or host"
+                        .to_string(),
+                ));
+            }
+            Some(installed) if self.0.security_epoch < installed.security_epoch => {
+                return Err(Error::InvalidResponse(
+                    "Maple revocation stream checkpoint security epoch is older than durable state"
+                        .to_string(),
+                ));
+            }
+            Some(installed) if self.0.security_epoch > installed.security_epoch => {
+                return Err(Error::InvalidResponse(
+                    "Maple revocation stream security epoch advanced without a verified reset-clear transition"
+                        .to_string(),
+                ));
+            }
+            Some(installed)
+                if self.0.revocation_stream_generation < installed.revocation_stream_generation =>
+            {
+                return Err(Error::InvalidResponse(
+                    "Maple revocation stream checkpoint generation is older than durable state"
+                        .to_string(),
+                ));
+            }
+            Some(installed)
+                if self.0.revocation_stream_generation
+                    == installed.revocation_stream_generation =>
+            {
+                if self.0.revocation_stream_id != installed.revocation_stream_id {
+                    return Err(Error::InvalidResponse(
+                        "Maple revocation stream ID changed without a generation increase"
+                            .to_string(),
+                    ));
+                }
+                false
+            }
+            Some(_) => true,
+        };
+        Ok(MapleRevocationStreamTransitionV1 {
+            checkpoint: self.0,
+            requires_admission_reset,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct VerifiedMapleResetClearRequiredV1(MapleResetClearRequiredV1);
+
+redacted_debug!(VerifiedMapleResetClearRequiredV1);
+
+impl VerifiedMapleResetClearRequiredV1 {
+    pub fn as_inner(&self) -> &MapleResetClearRequiredV1 {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> MapleResetClearRequiredV1 {
+        self.0
+    }
+
+    pub fn event_digest(&self) -> Result<String> {
+        self.0.event_digest()
+    }
+
+    /// Verifies the full recursive link from an already issuer-verified
+    /// predecessor. Genesis artifacts are verified directly by their issuer;
+    /// each successor must advance exactly once while retaining the exact full
+    /// host claim and authority scope. Even a valid endpoint-epoch refresh is
+    /// forbidden until the predecessor clear has been durably acknowledged.
+    pub fn verify_successor_of(
+        &self,
+        predecessor: &VerifiedMapleResetClearRequiredV1,
+    ) -> Result<()> {
+        let current = &self.0;
+        let previous = &predecessor.0;
+        if previous.reset_generation.checked_add(1) != Some(current.reset_generation)
+            || previous.cumulative_reset_count.checked_add(1)
+                != Some(current.cumulative_reset_count)
+            || current.source_security_epoch != previous.security_epoch
+            || current.subject_account_id != previous.subject_account_id
+            || current.subject_project_id != previous.subject_project_id
+            || current.recipient_host_registration_id != previous.recipient_host_registration_id
+            || current.host != previous.host
+            || current.source_revocation_stream_id != previous.revocation_stream_id
+            || current.source_revocation_stream_generation != previous.revocation_stream_generation
+            || current.previous_reset_clear_event_id != Some(previous.event_id)
+            || current.previous_instruction_material_digest.as_deref()
+                != Some(previous.instruction_material_digest.as_str())
+            || current.previous_chain_digest.as_deref() != Some(previous.chain_digest.as_str())
+            || current.reset_at_unix_ms < previous.reset_at_unix_ms
+            || current.reset_id == previous.reset_id
+            || current.event_id == previous.event_id
+        {
+            return Err(Error::InvalidResponse(
+                "Maple reset-clear successor does not extend the verified predecessor exactly"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn bind_to_checkpoint(
+        self,
+        checkpoint: &VerifiedMapleRevocationStreamCheckpointV1,
+    ) -> Result<VerifiedLatestMapleResetClearRequiredV1> {
+        let reset = &self.0;
+        let checkpoint = checkpoint.as_inner();
+        if reset.subject_account_id != checkpoint.subject_account_id
+            || reset.subject_project_id != checkpoint.subject_project_id
+            || reset.recipient_host_registration_id != checkpoint.host.registration_id
+            || !device_claim_is_same_identity_at_or_before(&reset.host, &checkpoint.host)
+            || reset.security_epoch != checkpoint.security_epoch
+            || reset.revocation_stream_id != checkpoint.revocation_stream_id
+            || reset.revocation_stream_generation != checkpoint.revocation_stream_generation
+            || reset.issuer_sequence != 1
+            || checkpoint.last_issued_issuer_sequence != 1
+            || checkpoint.last_acked_issuer_sequence != 0
+        {
+            return Err(Error::InvalidResponse(
+                "Maple reset-clear instruction is not the pending head of its verified checkpoint"
+                    .to_string(),
+            ));
+        }
+        Ok(VerifiedLatestMapleResetClearRequiredV1(self.0))
+    }
+
+    /// Binds an issuer-verified retained reset-clear event to a signed
+    /// checkpoint without treating it as a currently actionable clear
+    /// instruction. Historical reset events always occupy sequence 1 of their
+    /// target namespace, which may already be acknowledged or followed by
+    /// ordinary revocations.
+    pub fn verify_historical_against_checkpoint(
+        &self,
+        checkpoint: &VerifiedMapleRevocationStreamCheckpointV1,
+    ) -> Result<()> {
+        let reset = &self.0;
+        let checkpoint = checkpoint.as_inner();
+        if reset.subject_account_id != checkpoint.subject_account_id
+            || reset.subject_project_id != checkpoint.subject_project_id
+            || reset.recipient_host_registration_id != checkpoint.host.registration_id
+            || !device_claim_is_same_identity_at_or_before(&reset.host, &checkpoint.host)
+            || reset.security_epoch != checkpoint.security_epoch
+            || reset.revocation_stream_id != checkpoint.revocation_stream_id
+            || reset.revocation_stream_generation != checkpoint.revocation_stream_generation
+            || reset.issuer_sequence != 1
+            || reset.issuer_sequence > checkpoint.last_issued_issuer_sequence
+            || reset.issuer_sequence > checkpoint.last_acked_issuer_sequence
+        {
+            return Err(Error::InvalidResponse(
+                "Maple reset-clear history event does not belong to its verified checkpoint"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Issuer-verified reset-clear instruction bound to the exact signed pending
+/// checkpoint head. Only this latest-head wrapper can be promoted after the
+/// caller's durable full-scope local admission clear.
+///
+/// This capability is intentionally not `Clone`. It must be moved out of its
+/// verified response and is consumed even when the durable-clear callback
+/// fails; after a failure, fetch and verify current signed sync state again
+/// before retrying. Process-wide replay safety remains enforced by the
+/// service's single-head checkpoint compare-and-swap and operation-id
+/// idempotency, because signed wire artifacts can always be deserialized and
+/// verified again.
+///
+/// ```compile_fail
+/// use opensecret::VerifiedLatestMapleResetClearRequiredV1;
+///
+/// fn duplicate_latest(latest: VerifiedLatestMapleResetClearRequiredV1) {
+///     let _duplicate = latest.clone();
+/// }
+/// ```
+pub struct VerifiedLatestMapleResetClearRequiredV1(MapleResetClearRequiredV1);
+
+redacted_debug!(VerifiedLatestMapleResetClearRequiredV1);
+
+impl VerifiedLatestMapleResetClearRequiredV1 {
+    pub fn as_inner(&self) -> &MapleResetClearRequiredV1 {
+        &self.0
+    }
+
+    /// Invokes the caller's durable admission-store transaction for the exact
+    /// verified latest head and promotes it only when that transaction returns
+    /// success. The callback must atomically remove every admission in the
+    /// artifact's full account/project/host-installation scope and persist the
+    /// target epoch/namespace before returning.
+    ///
+    /// This deliberately accepts neither a boolean nor a raw/deserialized
+    /// receipt. The only SDK path to an ACK-ready wrapper passes the complete
+    /// verified instruction through an explicit storage callback.
+    pub fn after_durable_full_scope_admission_clear<F>(
+        self,
+        clear_and_commit: F,
+    ) -> Result<DurablyClearedMapleResetClearRequiredV1>
+    where
+        F: FnOnce(&MapleResetClearRequiredV1) -> Result<()>,
+    {
+        clear_and_commit(&self.0)?;
+        Ok(DurablyClearedMapleResetClearRequiredV1(self.0))
+    }
+}
+
+pub struct DurablyClearedMapleResetClearRequiredV1(MapleResetClearRequiredV1);
+
+redacted_debug!(DurablyClearedMapleResetClearRequiredV1);
+
+impl DurablyClearedMapleResetClearRequiredV1 {
+    pub fn as_inner(&self) -> &MapleResetClearRequiredV1 {
+        &self.0
+    }
+}
+
+#[derive(Clone)]
+pub enum VerifiedMapleRevocationStreamEventV1 {
+    PairRevocation(IssuerVerifiedMaplePairRevocationV1),
+    ResetClearRequired(VerifiedMapleResetClearRequiredV1),
+}
+
+impl std::fmt::Debug for VerifiedMapleRevocationStreamEventV1 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let event_type = match self {
+            Self::PairRevocation(_) => "pair_revocation",
+            Self::ResetClearRequired(_) => "reset_clear_required",
+        };
+        formatter
+            .debug_struct("VerifiedMapleRevocationStreamEventV1")
+            .field("event_type", &event_type)
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+impl VerifiedMapleRevocationStreamEventV1 {
+    pub fn issuer_sequence(&self) -> u64 {
+        match self {
+            Self::PairRevocation(event) => event.as_inner().issuer_sequence,
+            Self::ResetClearRequired(event) => event.as_inner().issuer_sequence,
+        }
+    }
+
+    pub fn event_id(&self) -> Uuid {
+        match self {
+            Self::PairRevocation(event) => event.as_inner().event_id,
+            Self::ResetClearRequired(event) => event.as_inner().event_id,
+        }
+    }
+
+    pub fn event_digest(&self) -> Result<String> {
+        match self {
+            Self::PairRevocation(event) => event.as_inner().transcript_digest(),
+            Self::ResetClearRequired(event) => event.event_digest(),
+        }
+    }
+}
+
+pub struct VerifiedMapleRevocationSyncV1 {
+    sync: MapleRevocationSyncV1,
+    checkpoint: VerifiedMapleRevocationStreamCheckpointV1,
+    reset_clear_instruction: Option<VerifiedLatestMapleResetClearRequiredV1>,
+}
+
+redacted_debug!(VerifiedMapleRevocationSyncV1);
+
+impl VerifiedMapleRevocationSyncV1 {
+    pub fn as_inner(&self) -> &MapleRevocationSyncV1 {
+        &self.sync
+    }
+
+    pub fn into_inner(self) -> MapleRevocationSyncV1 {
+        self.sync
+    }
+
+    pub fn checkpoint(&self) -> &VerifiedMapleRevocationStreamCheckpointV1 {
+        &self.checkpoint
+    }
+
+    pub fn has_reset_clear_instruction(&self) -> bool {
+        self.reset_clear_instruction.is_some()
+    }
+
+    /// Consumes the verified sync state and extracts its actionable pending
+    /// reset-clear capability, if present. A borrowed sync view never exposes
+    /// that capability.
+    pub fn into_reset_clear_instruction(self) -> Option<VerifiedLatestMapleResetClearRequiredV1> {
+        self.reset_clear_instruction
+    }
+}
+
+/// Registration receipt whose signed security synchronization state has been
+/// verified against the caller's exact signed request and explicit issuer
+/// trust anchors. Private fields prevent an unverified network DTO from being
+/// mistaken for authority-bearing state.
+pub struct VerifiedRegisterMapleDeviceResponseV1 {
+    response: crate::types::MapleDeviceRegistrationResponse,
+    revocation_sync: VerifiedMapleRevocationSyncV1,
+}
+
+redacted_debug!(VerifiedRegisterMapleDeviceResponseV1);
+
+impl VerifiedRegisterMapleDeviceResponseV1 {
+    pub(crate) fn new(
+        response: crate::types::MapleDeviceRegistrationResponse,
+        revocation_sync: VerifiedMapleRevocationSyncV1,
+    ) -> Self {
+        Self {
+            response,
+            revocation_sync,
+        }
+    }
+
+    pub fn registration_id(&self) -> Uuid {
+        self.response.registration_id
+    }
+
+    pub fn device_id(&self) -> Uuid {
+        self.response.device_id
+    }
+
+    pub fn revision(&self) -> i64 {
+        self.response.revision
+    }
+
+    pub fn accepted_at(&self) -> chrono::DateTime<chrono::Utc> {
+        self.response.accepted_at
+    }
+
+    pub fn security_epoch(&self) -> u64 {
+        self.response.security_epoch
+    }
+
+    pub fn revocation_sync(&self) -> &VerifiedMapleRevocationSyncV1 {
+        &self.revocation_sync
+    }
+
+    pub fn has_reset_clear_plan(&self) -> bool {
+        self.revocation_sync.has_reset_clear_instruction()
+    }
+
+    /// Consumes the verified registration receipt and extracts its actionable
+    /// pending reset-clear capability, if present.
+    pub fn into_reset_clear_plan(self) -> Option<VerifiedLatestMapleResetClearRequiredV1> {
+        self.revocation_sync.into_reset_clear_instruction()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct MapleInstalledRevocationStreamNamespaceV1 {
+    pub subject_account_id: Uuid,
+    pub subject_project_id: Uuid,
+    pub host_registration_id: Uuid,
+    pub security_epoch: u64,
+    pub revocation_stream_id: Uuid,
+    pub revocation_stream_generation: u64,
+}
+
+redacted_debug!(MapleInstalledRevocationStreamNamespaceV1);
+
+impl MapleInstalledRevocationStreamNamespaceV1 {
+    pub fn new(
+        subject_account_id: Uuid,
+        subject_project_id: Uuid,
+        host_registration_id: Uuid,
+        security_epoch: u64,
+        revocation_stream_id: Uuid,
+        revocation_stream_generation: u64,
+    ) -> Result<Self> {
+        validate_non_nil(&[
+            ("subject account ID", subject_account_id),
+            ("subject project ID", subject_project_id),
+            ("host registration ID", host_registration_id),
+        ])?;
+        validate_revocation_stream(
+            revocation_stream_id,
+            revocation_stream_generation,
+            ErrorClass::Configuration,
+        )?;
+        validate_reset_counter(
+            security_epoch,
+            "installed security epoch",
+            ErrorClass::Configuration,
+        )?;
+        Ok(Self {
+            subject_account_id,
+            subject_project_id,
+            host_registration_id,
+            security_epoch,
+            revocation_stream_id,
+            revocation_stream_generation,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct MapleRevocationStreamTransitionV1 {
+    checkpoint: MapleRevocationStreamCheckpointV1,
+    requires_admission_reset: bool,
+}
+
+redacted_debug!(MapleRevocationStreamTransitionV1);
+
+impl MapleRevocationStreamTransitionV1 {
+    pub fn checkpoint(&self) -> &MapleRevocationStreamCheckpointV1 {
+        &self.checkpoint
+    }
+
+    pub fn requires_admission_reset(&self) -> bool {
+        self.requires_admission_reset
+    }
+
+    /// Promotes the checkpoint after the caller durably commits this plan.
+    ///
+    /// When [`Self::requires_admission_reset`] is true, the transaction MUST
+    /// clear every prior admission for this account and host, install the new
+    /// namespace, and reset its cursor to zero before this call. An unchanged
+    /// namespace must still preserve monotonic durable checkpoint/cursor state.
+    /// The SDK deliberately performs no storage and cannot auto-ack this step.
+    pub fn after_durable_commit(self) -> DurablyReconciledMapleRevocationStreamV1 {
+        DurablyReconciledMapleRevocationStreamV1(self.checkpoint)
+    }
+}
+
+/// A signed host-account revocation namespace that the caller explicitly
+/// attests it has reconciled with durable local admission state.
+#[derive(Clone)]
+pub struct DurablyReconciledMapleRevocationStreamV1(MapleRevocationStreamCheckpointV1);
+
+redacted_debug!(DurablyReconciledMapleRevocationStreamV1);
+
+impl DurablyReconciledMapleRevocationStreamV1 {
+    pub fn as_inner(&self) -> &MapleRevocationStreamCheckpointV1 {
+        &self.0
+    }
+
+    fn validate_authorization(&self, authorization: &MaplePairAuthorizationV1) -> Result<()> {
+        if self.0.subject_account_id != authorization.subject_account_id
+            || self.0.subject_project_id != authorization.subject_project_id
+            || !device_claim_is_same_identity_at_or_before(&authorization.host, &self.0.host)
+            || self.0.revocation_stream_id != authorization.revocation_stream_id
+            || self.0.revocation_stream_generation != authorization.revocation_stream_generation
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pair authorization does not match the durably reconciled revocation stream"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_revocation(&self, revocation: &MaplePairRevocationV1) -> Result<()> {
+        if self.0.subject_account_id != revocation.subject_account_id
+            || self.0.subject_project_id != revocation.subject_project_id
+            || !device_claim_is_same_identity_at_or_before(&revocation.host, &self.0.host)
+            || self.0.revocation_stream_id != revocation.revocation_stream_id
+            || self.0.revocation_stream_generation != revocation.revocation_stream_generation
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pair revocation does not match the durably reconciled revocation stream"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct VerifiedMaplePairAuthorizationV1(MaplePairAuthorizationV1);
+
+redacted_debug!(VerifiedMaplePairAuthorizationV1);
+
+impl VerifiedMaplePairAuthorizationV1 {
+    pub fn as_inner(&self) -> &MaplePairAuthorizationV1 {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> MaplePairAuthorizationV1 {
+        self.0
+    }
+
+    pub fn transcript_digest(&self) -> Result<String> {
+        self.0.transcript_digest()
+    }
+}
+
+/// An awaiting-host-commit authorization whose status revision and host role
+/// were verified. This is the only input accepted by the manual confirm
+/// constructor, preventing active or revoked historical artifacts from being
+/// reinstalled and reconfirmed.
+#[derive(Clone)]
+pub struct HostCommitReadyMaplePairAuthorizationV1 {
+    authorization: VerifiedMaplePairAuthorizationV1,
+    expected_pairing_revision: i64,
+}
+
+redacted_debug!(HostCommitReadyMaplePairAuthorizationV1);
+
+impl HostCommitReadyMaplePairAuthorizationV1 {
+    pub fn authorization(&self) -> &VerifiedMaplePairAuthorizationV1 {
+        &self.authorization
+    }
+
+    pub fn expected_pairing_revision(&self) -> i64 {
+        self.expected_pairing_revision
+    }
+}
+
+#[derive(Clone)]
+pub struct IssuerVerifiedMaplePairRevocationV1(MaplePairRevocationV1);
+
+redacted_debug!(IssuerVerifiedMaplePairRevocationV1);
+
+impl IssuerVerifiedMaplePairRevocationV1 {
+    pub fn as_inner(&self) -> &MaplePairRevocationV1 {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> MaplePairRevocationV1 {
+        self.0
+    }
+
+    /// Binds an issuer-verified event to the host's ticket-bound durable pair
+    /// authorization. Only the resulting wrapper may construct an ACK.
+    pub fn bind_to_authorization(
+        &self,
+        authorization: &VerifiedMaplePairAuthorizationV1,
+        revocation_stream: &DurablyReconciledMapleRevocationStreamV1,
+    ) -> Result<VerifiedMaplePairRevocationV1> {
+        revocation_stream.validate_authorization(authorization.as_inner())?;
+        revocation_stream.validate_revocation(&self.0)?;
+        self.0
+            .validate_authorization_binding(authorization.as_inner())?;
+        Ok(VerifiedMaplePairRevocationV1(self.0.clone()))
+    }
+}
+
+#[derive(Clone)]
+pub struct VerifiedMaplePairRevocationV1(MaplePairRevocationV1);
+
+redacted_debug!(VerifiedMaplePairRevocationV1);
+
+impl VerifiedMaplePairRevocationV1 {
+    pub fn as_inner(&self) -> &MaplePairRevocationV1 {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> MaplePairRevocationV1 {
+        self.0
+    }
+
+    pub fn transcript_digest(&self) -> Result<String> {
+        self.0.transcript_digest()
+    }
+}
+
+#[derive(Clone)]
+pub struct VerifiedMaplePairingStatusV1 {
+    status: MaplePairingStatusV1,
+}
+
+redacted_debug!(VerifiedMaplePairingStatusV1);
+
+impl VerifiedMaplePairingStatusV1 {
+    pub fn as_inner(&self) -> &MaplePairingStatusV1 {
+        &self.status
+    }
+
+    pub fn into_inner(self) -> MaplePairingStatusV1 {
+        self.status
+    }
+
+    /// Returns the authorization only after the enclosing status verifier has
+    /// bound it to the status's issuer-verified request ticket.
+    pub fn pair_authorization(&self) -> Option<VerifiedMaplePairAuthorizationV1> {
+        self.status.pair_authorization.clone().map(|authorization| {
+            // Construction of `Self` already verified and bound this artifact
+            // to the status ticket; the opaque wrapper cannot be forged by an
+            // SDK caller.
+            VerifiedMaplePairAuthorizationV1(authorization)
+        })
+    }
+
+    /// Returns a host-commit-ready authorization only for a verified host view
+    /// in `awaiting_host_commit` state whose namespace matches the host's
+    /// durably reconciled revocation stream.
+    pub fn host_commit_ready_authorization(
+        &self,
+        revocation_stream: &DurablyReconciledMapleRevocationStreamV1,
+    ) -> Option<HostCommitReadyMaplePairAuthorizationV1> {
+        if self.status.state != MaplePairingState::AwaitingHostCommit || self.status.revision != 2 {
+            return None;
+        }
+        self.pair_authorization().and_then(|authorization| {
+            revocation_stream
+                .validate_authorization(authorization.as_inner())
+                .ok()?;
+            Some(HostCommitReadyMaplePairAuthorizationV1 {
+                authorization,
+                expected_pairing_revision: self.status.revision,
+            })
+        })
+    }
+}
+
+impl MaplePairingStatusV1 {
+    pub(crate) fn verify(
+        &self,
+        issuers: &MaplePairingIssuerKeySet,
+        expected_role: MaplePairingRole,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingStatusV1> {
+        if trusted_now_unix_ms <= 0 {
+            return Err(Error::Configuration(
+                "Maple pairing status verification requires a positive trusted current time"
+                    .to_string(),
+            ));
+        }
+        if self.pairing_request_id.is_nil()
+            || self.pair_id.is_nil()
+            || self.revision <= 0
+            || self.pairing_incarnation == 0
+            || self.pairing_incarnation > i64::MAX as u64
+            || self.execution_target_id.is_nil()
+            || self.controller_registration_id.is_nil()
+            || self.host_registration_id.is_nil()
+            || self.execution_target_id != self.host_registration_id
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing status contains invalid identity, revision, or incarnation fields"
+                    .to_string(),
+            ));
+        }
+        self.validate_revocation_stream_shape()?;
+        validate_timestamp(
+            self.created_at_unix_ms,
+            "created timestamp",
+            ErrorClass::InvalidResponse,
+        )?;
+        validate_timestamp(
+            self.expires_at_unix_ms,
+            "expiry timestamp",
+            ErrorClass::InvalidResponse,
+        )?;
+        if self.expires_at_unix_ms <= self.created_at_unix_ms {
+            return Err(Error::InvalidResponse(
+                "Maple pairing status expiry must follow creation".to_string(),
+            ));
+        }
+
+        let ticket = self.request_ticket.as_ref().ok_or_else(|| {
+            Error::InvalidResponse(
+                "Maple pairing participant status omitted its request ticket".to_string(),
+            )
+        })?;
+        match self.state {
+            MaplePairingState::Pending => {
+                ticket.verify_at(
+                    issuers,
+                    trusted_now_unix_ms,
+                    MAPLE_PAIRING_MAX_CLOCK_SKEW_MS,
+                    MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+                )?;
+            }
+            MaplePairingState::Expired => {
+                ticket.verify_signatures(issuers)?;
+                if trusted_now_unix_ms
+                    .checked_add(MAPLE_PAIRING_MAX_CLOCK_SKEW_MS)
+                    .is_none_or(|latest| latest < ticket.expires_at_unix_ms)
+                {
+                    return Err(Error::InvalidResponse(
+                        "Maple pairing was labeled expired before its signed expiry window"
+                            .to_string(),
+                    ));
+                }
+            }
+            MaplePairingState::AwaitingHostCommit
+            | MaplePairingState::Active
+            | MaplePairingState::Revoked => ticket.verify_signatures(issuers)?,
+        }
+        self.validate_ticket_binding(ticket)?;
+
+        match self.state {
+            MaplePairingState::Pending | MaplePairingState::Expired => {
+                let expected_revision = if self.state == MaplePairingState::Pending {
+                    1
+                } else {
+                    2
+                };
+                if self.revision != expected_revision {
+                    return Err(Error::InvalidResponse(
+                        "Maple pending or expired pairing status has an invalid state revision"
+                            .to_string(),
+                    ));
+                }
+                if self.pair_authorization.is_some()
+                    || self.revocation.is_some()
+                    || self.approved_at_unix_ms.is_some()
+                    || self.activated_at_unix_ms.is_some()
+                    || self.revoked_at_unix_ms.is_some()
+                {
+                    return Err(Error::InvalidResponse(
+                        "Maple pending or expired pairing status contains later-state artifacts"
+                            .to_string(),
+                    ));
+                }
+            }
+            MaplePairingState::AwaitingHostCommit => {
+                if self.revision != 2
+                    || self.approved_at_unix_ms.is_none()
+                    || self.activated_at_unix_ms.is_some()
+                    || self.revocation.is_some()
+                    || self.revoked_at_unix_ms.is_some()
+                {
+                    return Err(Error::InvalidResponse(
+                        "Maple awaiting-host-commit status has inconsistent lifecycle fields"
+                            .to_string(),
+                    ));
+                }
+                match expected_role {
+                    MaplePairingRole::Host => self.verify_authorization(issuers)?,
+                    MaplePairingRole::Controller if self.pair_authorization.is_none() => {}
+                    MaplePairingRole::Controller => {
+                        return Err(Error::InvalidResponse(
+                            "Maple controller status exposed a pre-commit pair authorization"
+                                .to_string(),
+                        ));
+                    }
+                }
+                if self
+                    .approved_at_unix_ms
+                    .is_some_and(|approved| approved < self.created_at_unix_ms)
+                {
+                    return Err(Error::InvalidResponse(
+                        "Maple pairing approval precedes the signed request creation".to_string(),
+                    ));
+                }
+            }
+            MaplePairingState::Active => {
+                self.verify_authorization(issuers)?;
+                if self.revision != 3
+                    || self.approved_at_unix_ms.is_none()
+                    || self.activated_at_unix_ms.is_none()
+                    || self.revocation.is_some()
+                    || self.revoked_at_unix_ms.is_some()
+                {
+                    return Err(Error::InvalidResponse(
+                        "Maple active pairing status has inconsistent lifecycle fields".to_string(),
+                    ));
+                }
+                if self
+                    .approved_at_unix_ms
+                    .zip(self.activated_at_unix_ms)
+                    .is_none_or(|(approved, activated)| {
+                        approved < self.created_at_unix_ms || activated < approved
+                    })
+                {
+                    return Err(Error::InvalidResponse(
+                        "Maple pairing active lifecycle timestamps are out of order".to_string(),
+                    ));
+                }
+            }
+            MaplePairingState::Revoked => {
+                let revocation = self.revocation.as_ref().ok_or_else(|| {
+                    Error::InvalidResponse(
+                        "Maple revoked status omitted its revocation artifact".to_string(),
+                    )
+                })?;
+                revocation.verify_issuer(issuers)?;
+                let valid_revision = match (self.activated_at_unix_ms, expected_role) {
+                    (Some(_), _) => {
+                        self.verify_authorization(issuers)?;
+                        self.validate_revocation_binding(revocation)?;
+                        self.revision == 4
+                    }
+                    (None, MaplePairingRole::Host) => {
+                        self.verify_authorization(issuers)?;
+                        self.validate_revocation_binding(revocation)?;
+                        self.revision == 3
+                    }
+                    (None, MaplePairingRole::Controller) if self.pair_authorization.is_none() => {
+                        self.validate_redacted_revocation_binding(ticket, revocation)?;
+                        self.revision == 3
+                    }
+                    (None, MaplePairingRole::Controller) => {
+                        return Err(Error::InvalidResponse(
+                            "Maple controller status exposed a pre-commit pair authorization"
+                                .to_string(),
+                        ));
+                    }
+                };
+                if !valid_revision
+                    || self.approved_at_unix_ms.is_none()
+                    || self.revoked_at_unix_ms.is_none()
+                {
+                    return Err(Error::InvalidResponse(
+                        "Maple revoked pairing status omitted lifecycle timestamps".to_string(),
+                    ));
+                }
+                let approved = self.approved_at_unix_ms.expect("checked above");
+                let revoked = self.revoked_at_unix_ms.expect("checked above");
+                if approved < self.created_at_unix_ms
+                    || revoked < approved
+                    || self
+                        .activated_at_unix_ms
+                        .is_some_and(|activated| activated < approved || revoked < activated)
+                {
+                    return Err(Error::InvalidResponse(
+                        "Maple pairing revoked lifecycle timestamps are out of order".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(VerifiedMaplePairingStatusV1 {
+            status: self.clone(),
+        })
+    }
+
+    fn validate_ticket_binding(&self, ticket: &MaplePairRequestTicketV1) -> Result<()> {
+        if ticket.pairing_request_id != self.pairing_request_id
+            || ticket.pair_id != self.pair_id
+            || ticket.pairing_incarnation != self.pairing_incarnation
+            || ticket.direction != self.direction
+            || ticket.execution_target_id != self.execution_target_id
+            || ticket.controller.registration_id != self.controller_registration_id
+            || ticket.host.registration_id != self.host_registration_id
+            || ticket.created_at_unix_ms != self.created_at_unix_ms
+            || ticket.expires_at_unix_ms != self.expires_at_unix_ms
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing status does not match its signed request ticket".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_revocation_stream_shape(&self) -> Result<()> {
+        let namespace = match (self.revocation_stream_id, self.revocation_stream_generation) {
+            (Some(stream_id), Some(generation)) => {
+                validate_revocation_stream(stream_id, generation, ErrorClass::InvalidResponse)?;
+                Some((stream_id, generation))
+            }
+            (None, None) => None,
+            _ => {
+                return Err(Error::InvalidResponse(
+                    "Maple pairing status contains a partial revocation namespace".to_string(),
+                ));
+            }
+        };
+        let required = matches!(
+            self.state,
+            MaplePairingState::AwaitingHostCommit
+                | MaplePairingState::Active
+                | MaplePairingState::Revoked
+        );
+        if namespace.is_some() != required {
+            return Err(Error::InvalidResponse(
+                "Maple pairing status revocation namespace does not match its lifecycle state"
+                    .to_string(),
+            ));
+        }
+        if let (Some((stream_id, generation)), Some(authorization)) =
+            (namespace, self.pair_authorization.as_ref())
+        {
+            if authorization.revocation_stream_id != stream_id
+                || authorization.revocation_stream_generation != generation
+            {
+                return Err(Error::InvalidResponse(
+                    "Maple pairing status namespace does not match its authorization".to_string(),
+                ));
+            }
+        }
+        if let (Some((stream_id, generation)), Some(revocation)) =
+            (namespace, self.revocation.as_ref())
+        {
+            if revocation.revocation_stream_id != stream_id
+                || revocation.revocation_stream_generation != generation
+            {
+                return Err(Error::InvalidResponse(
+                    "Maple pairing status namespace does not match its revocation".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Validates a controller-visible precommit revocation after the service
+    /// has intentionally redacted the not-yet-active pair authorization.
+    ///
+    /// The issuer-signed authorization digest remains an opaque lineage
+    /// commitment here; this path cannot produce pairing or ACK authority.
+    fn validate_redacted_revocation_binding(
+        &self,
+        ticket: &MaplePairRequestTicketV1,
+        revocation: &MaplePairRevocationV1,
+    ) -> Result<()> {
+        revocation.authorization_digest_bytes()?;
+        if revocation.subject_account_id != ticket.subject_account_id
+            || revocation.subject_project_id != ticket.subject_project_id
+            || revocation.recipient_host_registration_id != self.host_registration_id
+            || revocation.pairing_request_id != self.pairing_request_id
+            || revocation.pairing_request_id != ticket.pairing_request_id
+            || revocation.pair_id != self.pair_id
+            || revocation.pair_id != ticket.pair_id
+            || revocation.pairing_incarnation != self.pairing_incarnation
+            || revocation.pairing_incarnation != ticket.pairing_incarnation
+            || revocation.direction != self.direction
+            || revocation.direction != ticket.direction
+            || revocation.execution_target_id != self.execution_target_id
+            || revocation.execution_target_id != ticket.execution_target_id
+            || revocation.controller != ticket.controller
+            || revocation.host != ticket.host
+            || Some(revocation.revocation_stream_id) != self.revocation_stream_id
+            || Some(revocation.revocation_stream_generation) != self.revocation_stream_generation
+            || Some(revocation.revoked_at_unix_ms) != self.revoked_at_unix_ms
+        {
+            return Err(Error::InvalidResponse(
+                "Maple controller pre-commit revocation does not match its signed request ticket"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn verify_authorization(&self, issuers: &MaplePairingIssuerKeySet) -> Result<()> {
+        let authorization = self.pair_authorization.as_ref().ok_or_else(|| {
+            Error::InvalidResponse(
+                "Maple pairing status omitted its pair authorization".to_string(),
+            )
+        })?;
+        let ticket = self.request_ticket.as_ref().ok_or_else(|| {
+            Error::InvalidResponse("Missing Maple pairing request ticket".to_string())
+        })?;
+        authorization.verify_against_ticket(issuers, ticket)?;
+        if authorization.pairing_request_id != self.pairing_request_id
+            || authorization.pair_id != self.pair_id
+            || authorization.pairing_incarnation != self.pairing_incarnation
+            || authorization.direction != self.direction
+            || authorization.execution_target_id != self.execution_target_id
+            || Some(authorization.revocation_stream_id) != self.revocation_stream_id
+            || Some(authorization.revocation_stream_generation) != self.revocation_stream_generation
+            || Some(authorization.approved_at_unix_ms) != self.approved_at_unix_ms
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing status does not match its signed pair authorization".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_revocation_binding(&self, revocation: &MaplePairRevocationV1) -> Result<()> {
+        let authorization = self
+            .pair_authorization
+            .as_ref()
+            .ok_or_else(|| Error::InvalidResponse("Missing pair authorization".to_string()))?;
+        let authorization_digest = authorization.transcript_digest()?;
+        if revocation.subject_account_id != authorization.subject_account_id
+            || revocation.subject_project_id != authorization.subject_project_id
+            || revocation.recipient_host_registration_id != self.host_registration_id
+            || revocation.pairing_request_id != self.pairing_request_id
+            || revocation.pair_id != self.pair_id
+            || revocation.pairing_incarnation != self.pairing_incarnation
+            || revocation.direction != self.direction
+            || revocation.execution_target_id != self.execution_target_id
+            || revocation.controller != authorization.controller
+            || revocation.host != authorization.host
+            || revocation.revocation_stream_id != authorization.revocation_stream_id
+            || revocation.revocation_stream_generation != authorization.revocation_stream_generation
+            || revocation.pair_authorization_digest != authorization_digest
+            || Some(revocation.revoked_at_unix_ms) != self.revoked_at_unix_ms
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing status does not match its signed revocation".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct VerifiedMaplePairingMutationResponse {
+    pub protocol_version: u16,
+    pub operation_id: Uuid,
+    pub pairing: VerifiedMaplePairingStatusV1,
+}
+
+redacted_debug!(VerifiedMaplePairingMutationResponse);
+
+#[derive(Clone)]
+pub struct VerifiedMaplePairingListResponse {
+    pub protocol_version: u16,
+    pub query_id: Uuid,
+    pub role: MaplePairingRole,
+    pub pairings: Vec<VerifiedMaplePairingStatusV1>,
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
+}
+
+redacted_debug!(VerifiedMaplePairingListResponse);
+
+#[derive(Clone)]
+pub struct VerifiedMaplePairingStatusResponse {
+    pub protocol_version: u16,
+    pub query_id: Uuid,
+    pub pairing: VerifiedMaplePairingStatusV1,
+}
+
+redacted_debug!(VerifiedMaplePairingStatusResponse);
+
+pub struct VerifiedMaplePairingRevocationListResponse {
+    pub protocol_version: u16,
+    pub query_id: Uuid,
+    /// Signed current security epoch, status, namespace checkpoint, and any
+    /// pending latest reset-clear head.
+    pub revocation_sync: VerifiedMapleRevocationSyncV1,
+    /// Events whose issuer signatures and page sequence are verified. Each
+    /// pair revocation must still be bound to the host's local ticket-bound
+    /// authorization before durable apply; reset-clear ACK construction
+    /// additionally requires the durable full-scope-clear wrapper.
+    pub events: Vec<VerifiedMapleRevocationStreamEventV1>,
+    pub next_after_issuer_sequence: u64,
+    pub has_more: bool,
+}
+
+impl VerifiedMaplePairingRevocationListResponse {
+    pub fn has_reset_clear_instruction(&self) -> bool {
+        self.revocation_sync.has_reset_clear_instruction()
+    }
+
+    /// Consumes the verified page and extracts its actionable pending
+    /// reset-clear capability, if present. Historical reset events remain in
+    /// `events` only as read-only verified history and cannot use this path.
+    pub fn into_reset_clear_instruction(self) -> Option<VerifiedLatestMapleResetClearRequiredV1> {
+        self.revocation_sync.into_reset_clear_instruction()
+    }
+}
+
+impl std::fmt::Debug for VerifiedMaplePairingRevocationListResponse {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("VerifiedMaplePairingRevocationListResponse")
+            .field("protocol_version", &self.protocol_version)
+            .field("event_count", &self.events.len())
+            .field("has_more", &self.has_more)
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+/// Verified operation receipt for one exact revocation acknowledgement.
+///
+/// This proves that the submitted operation was accepted with the returned
+/// event/cursor values. It deliberately does not expose its signed checkpoint
+/// as [`VerifiedMapleRevocationStreamCheckpointV1`]: an idempotent replay may
+/// return a historical receipt after current state has advanced. Fetch and
+/// verify a fresh registration or revocation-list sync before deciding
+/// readiness or installing a current durable namespace.
+///
+/// ```compile_fail
+/// use opensecret::VerifiedMaplePairingRevocationAckResponse;
+///
+/// fn install_receipt_as_current(receipt: VerifiedMaplePairingRevocationAckResponse) {
+///     let _transition = receipt.stream_checkpoint.plan_durable_transition(None);
+/// }
+/// ```
+#[derive(Clone)]
+pub struct VerifiedMaplePairingRevocationAckResponse {
+    protocol_version: u16,
+    operation_id: Uuid,
+    host_registration_id: Uuid,
+    event_id: Uuid,
+    issuer_sequence: u64,
+    last_acked_issuer_sequence: u64,
+    accepted_at_unix_ms: i64,
+}
+
+impl VerifiedMaplePairingRevocationAckResponse {
+    pub fn protocol_version(&self) -> u16 {
+        self.protocol_version
+    }
+
+    pub fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+
+    pub fn host_registration_id(&self) -> Uuid {
+        self.host_registration_id
+    }
+
+    pub fn event_id(&self) -> Uuid {
+        self.event_id
+    }
+
+    pub fn issuer_sequence(&self) -> u64 {
+        self.issuer_sequence
+    }
+
+    pub fn last_acked_issuer_sequence(&self) -> u64 {
+        self.last_acked_issuer_sequence
+    }
+
+    pub fn accepted_at_unix_ms(&self) -> i64 {
+        self.accepted_at_unix_ms
+    }
+}
+
+impl std::fmt::Debug for VerifiedMaplePairingRevocationAckResponse {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("VerifiedMaplePairingRevocationAckResponse")
+            .field("protocol_version", &self.protocol_version)
+            .field("issuer_sequence", &self.issuer_sequence)
+            .field(
+                "last_acked_issuer_sequence",
+                &self.last_acked_issuer_sequence,
+            )
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+impl MaplePairingMutationResponse {
+    pub(crate) fn verify_create(
+        self,
+        request: &CreateMaplePairingRequest,
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingMutationResponse> {
+        self.verify_common(
+            request.operation_id,
+            MaplePairingState::Pending,
+            MaplePairingRole::Controller,
+            issuers,
+            trusted_now_unix_ms,
+        )?;
+        let pairing = &self.pairing;
+        let ticket = pairing.request_ticket.as_ref().ok_or_else(|| {
+            Error::InvalidResponse(
+                "Maple pairing create receipt omitted request ticket".to_string(),
+            )
+        })?;
+        if ticket.subject_account_id != request.asserted_account_id
+            || ticket.subject_project_id != request.asserted_project_id
+            || ticket.controller_request_operation_id != request.operation_id
+            || ticket.controller.registration_id != request.controller_registration_id
+            || ticket.controller.device_id != request.controller_device_id
+            || ticket.controller.installation_id != request.controller_installation_id
+            || ticket.controller.endpoint_id != request.controller_endpoint_id
+            || ticket.controller.endpoint_epoch != request.controller_endpoint_epoch
+            || ticket.host.registration_id != request.host_registration_id
+            || ticket.host.device_id != request.host_device_id
+            || ticket.host.installation_id != request.host_installation_id
+            || ticket.host.endpoint_id != request.host_endpoint_id
+            || ticket.host.endpoint_epoch != request.host_endpoint_epoch
+            || ticket.pairing_request_nonce != request.pairing_request_nonce
+            || ticket.controller_request_digest != request.transcript_digest()?
+            || ticket.controller_request_signature != request.signature
+            || ticket.protocol_min != request.protocol_min
+            || ticket.protocol_max != request.protocol_max
+            || pairing.controller_registration_id != request.controller_registration_id
+            || pairing.host_registration_id != request.host_registration_id
+            || pairing.execution_target_id != request.execution_target_id
+            || pairing.direction != request.direction
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing create receipt does not match its submitted device claims"
+                    .to_string(),
+            ));
+        }
+        self.into_verified(MaplePairingRole::Controller, issuers, trusted_now_unix_ms)
+    }
+
+    pub(crate) fn verify_approve(
+        self,
+        request: &ApproveMaplePairingRequest,
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingMutationResponse> {
+        self.verify_mutation_binding(
+            MutationExpectation {
+                operation_id: request.operation_id,
+                pairing_request_id: request.pairing_request_id,
+                pair_id: request.pair_id,
+                expected_revision: request.expected_pairing_revision,
+                pairing_incarnation: request.pairing_incarnation,
+                state: MaplePairingState::AwaitingHostCommit,
+                role: MaplePairingRole::Host,
+            },
+            issuers,
+            trusted_now_unix_ms,
+        )?;
+        let authorization = self.pairing.pair_authorization.as_ref().ok_or_else(|| {
+            Error::InvalidResponse("Maple approval receipt omitted pair authorization".to_string())
+        })?;
+        if authorization.request_ticket_digest != request.request_ticket_digest
+            || authorization.subject_account_id != request.asserted_account_id
+            || authorization.subject_project_id != request.asserted_project_id
+            || authorization.host.registration_id != request.host_registration_id
+            || authorization.pairing_request_id != request.pairing_request_id
+            || authorization.pair_id != request.pair_id
+            || authorization.pairing_incarnation != request.pairing_incarnation
+            || authorization.revocation_stream_id != request.revocation_stream_id
+            || authorization.revocation_stream_generation != request.revocation_stream_generation
+            || authorization.host_approval_operation_id != request.operation_id
+            || authorization.host_approval_expected_pairing_revision
+                != request.expected_pairing_revision
+            || authorization.host_approval_nonce != request.host_approval_nonce
+            || authorization.protocol_min != request.approved_protocol_min
+            || authorization.protocol_max != request.approved_protocol_max
+            || authorization.host_approval_digest != request.transcript_digest()?
+            || authorization.host_approval_signature != request.signature
+        {
+            return Err(Error::InvalidResponse(
+                "Maple approval receipt does not bind the submitted host approval".to_string(),
+            ));
+        }
+        self.into_verified(MaplePairingRole::Host, issuers, trusted_now_unix_ms)
+    }
+
+    pub(crate) fn verify_confirm(
+        self,
+        request: &ConfirmMaplePairingRequest,
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingMutationResponse> {
+        self.verify_mutation_binding(
+            MutationExpectation {
+                operation_id: request.operation_id,
+                pairing_request_id: request.pairing_request_id,
+                pair_id: request.pair_id,
+                expected_revision: request.expected_pairing_revision,
+                pairing_incarnation: request.pairing_incarnation,
+                state: MaplePairingState::Active,
+                role: MaplePairingRole::Host,
+            },
+            issuers,
+            trusted_now_unix_ms,
+        )?;
+        let authorization = self.pairing.pair_authorization.as_ref().ok_or_else(|| {
+            Error::InvalidResponse("Maple confirmation receipt omitted authorization".to_string())
+        })?;
+        if authorization.subject_account_id != request.asserted_account_id
+            || authorization.subject_project_id != request.asserted_project_id
+            || authorization.host.registration_id != request.host_registration_id
+            || authorization.transcript_digest()?.as_str()
+                != request.pair_authorization_digest.as_str()
+        {
+            return Err(Error::InvalidResponse(
+                "Maple confirmation receipt does not bind the submitted pair authorization"
+                    .to_string(),
+            ));
+        }
+        self.into_verified(MaplePairingRole::Host, issuers, trusted_now_unix_ms)
+    }
+
+    pub(crate) fn verify_revoke(
+        self,
+        request: &RevokeMaplePairingRequest,
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingMutationResponse> {
+        self.verify_mutation_binding(
+            MutationExpectation {
+                operation_id: request.operation_id,
+                pairing_request_id: request.pairing_request_id,
+                pair_id: request.pair_id,
+                expected_revision: request.expected_pairing_revision,
+                pairing_incarnation: request.pairing_incarnation,
+                state: MaplePairingState::Revoked,
+                role: request.actor_role,
+            },
+            issuers,
+            trusted_now_unix_ms,
+        )?;
+        let revocation = self.pairing.revocation.as_ref().ok_or_else(|| {
+            Error::InvalidResponse(
+                "Maple revocation receipt omitted revocation artifact".to_string(),
+            )
+        })?;
+        if revocation.revoked_by_registration_id != request.actor_registration_id
+            || revocation.revoked_by_role != request.actor_role
+            || revocation.reason_code != request.reason_code
+            || revocation.subject_account_id != request.asserted_account_id
+            || revocation.subject_project_id != request.asserted_project_id
+            || revocation.revocation_stream_id != request.revocation_stream_id
+            || revocation.revocation_stream_generation != request.revocation_stream_generation
+        {
+            return Err(Error::InvalidResponse(
+                "Maple revocation receipt does not bind the submitted revocation".to_string(),
+            ));
+        }
+        self.into_verified(request.actor_role, issuers, trusted_now_unix_ms)
+    }
+
+    fn verify_mutation_binding(
+        &self,
+        expected: MutationExpectation,
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<()> {
+        self.verify_common(
+            expected.operation_id,
+            expected.state,
+            expected.role,
+            issuers,
+            trusted_now_unix_ms,
+        )?;
+        if self.pairing.pairing_request_id != expected.pairing_request_id
+            || self.pairing.pair_id != expected.pair_id
+            || self.pairing.revision != expected.expected_revision + 1
+            || self.pairing.pairing_incarnation != expected.pairing_incarnation
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing mutation receipt does not match its request".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn verify_common(
+        &self,
+        operation_id: Uuid,
+        state: MaplePairingState,
+        role: MaplePairingRole,
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<()> {
+        if self.protocol_version != MAPLE_PAIRING_PROTOCOL_VERSION
+            || self.operation_id != operation_id
+            || self.pairing.state != state
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing mutation receipt has an unsupported version or mismatched operation/state"
+                    .to_string(),
+            ));
+        }
+        self.pairing.verify(issuers, role, trusted_now_unix_ms)?;
+        Ok(())
+    }
+
+    fn into_verified(
+        self,
+        role: MaplePairingRole,
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingMutationResponse> {
+        Ok(VerifiedMaplePairingMutationResponse {
+            protocol_version: self.protocol_version,
+            operation_id: self.operation_id,
+            pairing: self.pairing.verify(issuers, role, trusted_now_unix_ms)?,
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+struct MutationExpectation {
+    operation_id: Uuid,
+    pairing_request_id: Uuid,
+    pair_id: Uuid,
+    expected_revision: i64,
+    pairing_incarnation: u64,
+    state: MaplePairingState,
+    role: MaplePairingRole,
+}
+
+impl MaplePairingListResponse {
+    pub(crate) fn verify_for(
+        self,
+        request: &ListMaplePairingsRequest,
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingListResponse> {
+        let effective_limit = validate_limit(request.limit)?;
+        let cursor_consistent = self.has_more == self.next_cursor.is_some();
+        let cursor_valid = self.next_cursor.as_ref().is_none_or(|cursor| {
+            !cursor.is_empty()
+                && cursor.len() <= MAPLE_PAIRING_CURSOR_MAX_BYTES
+                && cursor.is_ascii()
+                && Some(cursor.as_str()) != request.cursor.as_deref()
+        });
+        if self.protocol_version != MAPLE_PAIRING_PROTOCOL_VERSION
+            || self.query_id != request.query_id
+            || self.role != request.role
+            || self.pairings.len() > usize::from(effective_limit)
+            || !cursor_consistent
+            || !cursor_valid
+            || (self.has_more && self.pairings.is_empty())
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing list response is unsupported or internally inconsistent".to_string(),
+            ));
+        }
+        let requested_states: HashSet<_> = request.states.iter().copied().collect();
+        let mut pair_ids = HashSet::with_capacity(self.pairings.len());
+        let mut request_ids = HashSet::with_capacity(self.pairings.len());
+        let mut verified = Vec::with_capacity(self.pairings.len());
+        let mut previous_pair_id: Option<Uuid> = None;
+        for pairing in self.pairings {
+            let ticket = pairing.request_ticket.as_ref().ok_or_else(|| {
+                Error::InvalidResponse(
+                    "Maple pairing list item omitted its signed request ticket".to_string(),
+                )
+            })?;
+            let belongs_to_actor = match request.role {
+                MaplePairingRole::Controller => {
+                    pairing.controller_registration_id == request.actor_registration_id
+                }
+                MaplePairingRole::Host => {
+                    pairing.host_registration_id == request.actor_registration_id
+                }
+            };
+            let ordered = previous_pair_id.is_none_or(|previous| previous > pairing.pair_id);
+            if !belongs_to_actor
+                || ticket.subject_account_id != request.asserted_account_id
+                || ticket.subject_project_id != request.asserted_project_id
+                || !ordered
+                || !requested_states.contains(&pairing.state)
+                || !pair_ids.insert(pairing.pair_id)
+                || !request_ids.insert(pairing.pairing_request_id)
+            {
+                return Err(Error::InvalidResponse(
+                    "Maple pairing list response contains an unrequested state or duplicate identity"
+                        .to_string(),
+                ));
+            }
+            previous_pair_id = Some(pairing.pair_id);
+            verified.push(pairing.verify(issuers, request.role, trusted_now_unix_ms)?);
+        }
+        Ok(VerifiedMaplePairingListResponse {
+            protocol_version: self.protocol_version,
+            query_id: self.query_id,
+            role: self.role,
+            pairings: verified,
+            next_cursor: self.next_cursor,
+            has_more: self.has_more,
+        })
+    }
+}
+
+impl MaplePairingStatusResponse {
+    pub(crate) fn verify_for(
+        self,
+        request: &MaplePairingStatusRequest,
+        actor_role: MaplePairingRole,
+        issuers: &MaplePairingIssuerKeySet,
+        trusted_now_unix_ms: i64,
+    ) -> Result<VerifiedMaplePairingStatusResponse> {
+        if self.protocol_version != MAPLE_PAIRING_PROTOCOL_VERSION
+            || self.query_id != request.query_id
+            || self.pairing.pair_id != request.pair_id
+            || self.pairing.request_ticket.as_ref().is_none_or(|ticket| {
+                ticket.subject_account_id != request.asserted_account_id
+                    || ticket.subject_project_id != request.asserted_project_id
+            })
+            || match actor_role {
+                MaplePairingRole::Controller => {
+                    self.pairing.controller_registration_id != request.actor_registration_id
+                }
+                MaplePairingRole::Host => {
+                    self.pairing.host_registration_id != request.actor_registration_id
+                }
+            }
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing status response does not match its query".to_string(),
+            ));
+        }
+        Ok(VerifiedMaplePairingStatusResponse {
+            protocol_version: self.protocol_version,
+            query_id: self.query_id,
+            pairing: self
+                .pairing
+                .verify(issuers, actor_role, trusted_now_unix_ms)?,
+        })
+    }
+}
+
+impl MaplePairingRevocationListResponse {
+    pub(crate) fn verify_for(
+        self,
+        request: &ListMaplePairingRevocationsRequest,
+        issuers: &MaplePairingIssuerKeySet,
+    ) -> Result<VerifiedMaplePairingRevocationListResponse> {
+        request.canonical_transcript()?;
+        let effective_limit = validate_limit(request.limit)?;
+        let revocation_sync = self.revocation_sync.verify(issuers)?;
+        let checkpoint_inner = revocation_sync.checkpoint().as_inner();
+        let discovery = request.revocation_stream_id.is_nil()
+            && request.revocation_stream_generation == 0
+            && request.after_issuer_sequence == 0;
+        let reset_page_shape_is_valid = match self.revocation_sync.status {
+            MapleRevocationSyncStatusV1::ResetClearRequired => {
+                self.events.len() == 1
+                    && matches!(
+                        (&self.events[0], self.revocation_sync.reset_clear_instruction.as_ref()),
+                        (MapleRevocationStreamEventV1::ResetClearRequired(event), Some(sync_event))
+                            if event == sync_event
+                    )
+            }
+            MapleRevocationSyncStatusV1::Ready
+            | MapleRevocationSyncStatusV1::RevocationsPending => true,
+        };
+        if self.protocol_version != MAPLE_PAIRING_PROTOCOL_VERSION
+            || self.query_id != request.query_id
+            || self.events.len() > usize::from(effective_limit)
+            || (self.has_more && self.events.is_empty())
+            || !reset_page_shape_is_valid
+            || checkpoint_inner.subject_account_id != request.asserted_account_id
+            || checkpoint_inner.subject_project_id != request.asserted_project_id
+            || checkpoint_inner.host.registration_id != request.host_registration_id
+            || (!discovery
+                && (checkpoint_inner.revocation_stream_id != request.revocation_stream_id
+                    || checkpoint_inner.revocation_stream_generation
+                        != request.revocation_stream_generation))
+            || request.after_issuer_sequence > checkpoint_inner.last_acked_issuer_sequence
+            || self.next_after_issuer_sequence > checkpoint_inner.last_issued_issuer_sequence
+            || self.has_more
+                != (self.next_after_issuer_sequence < checkpoint_inner.last_issued_issuer_sequence)
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing revocation page is unsupported or internally inconsistent"
+                    .to_string(),
+            ));
+        }
+        let mut expected = request
+            .after_issuer_sequence
+            .checked_add(1)
+            .ok_or_else(|| {
+                Error::Configuration("Maple pairing revocation cursor cannot advance".to_string())
+            })?;
+        let mut event_ids = HashSet::with_capacity(self.events.len());
+        let mut verified = Vec::with_capacity(self.events.len());
+        let mut expected_next = request.after_issuer_sequence;
+        for event in self.events {
+            let event_matches_scope = match &event {
+                MapleRevocationStreamEventV1::PairRevocation(event) => {
+                    event.recipient_host_registration_id == request.host_registration_id
+                        && event.subject_account_id == request.asserted_account_id
+                        && event.subject_project_id == request.asserted_project_id
+                        && event.revocation_stream_id == checkpoint_inner.revocation_stream_id
+                        && event.revocation_stream_generation
+                            == checkpoint_inner.revocation_stream_generation
+                        && device_claim_is_same_identity_at_or_before(
+                            &event.host,
+                            &checkpoint_inner.host,
+                        )
+                }
+                MapleRevocationStreamEventV1::ResetClearRequired(event) => {
+                    if revocation_sync.has_reset_clear_instruction() {
+                        event.verify_against_checkpoint(issuers, revocation_sync.checkpoint())?;
+                    } else {
+                        event
+                            .verify(issuers)?
+                            .verify_historical_against_checkpoint(revocation_sync.checkpoint())?;
+                    }
+                    event.recipient_host_registration_id == request.host_registration_id
+                        && event.subject_account_id == request.asserted_account_id
+                        && event.subject_project_id == request.asserted_project_id
+                        && event.security_epoch == checkpoint_inner.security_epoch
+                        && event.revocation_stream_id == checkpoint_inner.revocation_stream_id
+                        && event.revocation_stream_generation
+                            == checkpoint_inner.revocation_stream_generation
+                        && device_claim_is_same_identity_at_or_before(
+                            &event.host,
+                            &checkpoint_inner.host,
+                        )
+                }
+            };
+            if event.issuer_sequence() != expected
+                || !event_matches_scope
+                || !event_ids.insert(event.event_id())
+            {
+                return Err(Error::InvalidResponse(
+                    "Maple pairing revocation page has a gap or mismatched host/event".to_string(),
+                ));
+            }
+            expected = expected.checked_add(1).ok_or_else(|| {
+                Error::InvalidResponse("Maple pairing revocation sequence overflowed".to_string())
+            })?;
+            expected_next = event.issuer_sequence();
+            verified.push(event.verify(issuers)?);
+        }
+        if self.next_after_issuer_sequence != expected_next {
+            return Err(Error::InvalidResponse(
+                "Maple pairing revocation page returned a non-progressing sequence cursor"
+                    .to_string(),
+            ));
+        }
+        Ok(VerifiedMaplePairingRevocationListResponse {
+            protocol_version: self.protocol_version,
+            query_id: self.query_id,
+            revocation_sync,
+            events: verified,
+            next_after_issuer_sequence: self.next_after_issuer_sequence,
+            has_more: self.has_more,
+        })
+    }
+}
+
+impl MaplePairingRevocationAckResponse {
+    pub(crate) fn verify_for(
+        self,
+        request: &AckMaplePairingRevocationRequest,
+        issuers: &MaplePairingIssuerKeySet,
+    ) -> Result<VerifiedMaplePairingRevocationAckResponse> {
+        request.canonical_transcript()?;
+        let checkpoint = self.stream_checkpoint.verify(issuers)?;
+        let checkpoint_inner = checkpoint.as_inner();
+        if self.protocol_version != MAPLE_PAIRING_PROTOCOL_VERSION
+            || self.operation_id != request.operation_id
+            || self.host_registration_id != request.host_registration_id
+            || self.event_id != request.event_id
+            || self.issuer_sequence != request.issuer_sequence
+            || self.last_acked_issuer_sequence != request.issuer_sequence
+            || checkpoint_inner.subject_account_id != request.asserted_account_id
+            || checkpoint_inner.subject_project_id != request.asserted_project_id
+            || checkpoint_inner.host.registration_id != request.host_registration_id
+            || checkpoint_inner.revocation_stream_id != request.revocation_stream_id
+            || checkpoint_inner.revocation_stream_generation != request.revocation_stream_generation
+            || checkpoint_inner.last_acked_issuer_sequence != request.issuer_sequence
+            || self.accepted_at_unix_ms < 0
+        {
+            return Err(Error::InvalidResponse(
+                "Maple pairing revocation acknowledgement does not match its request".to_string(),
+            ));
+        }
+        Ok(VerifiedMaplePairingRevocationAckResponse {
+            protocol_version: self.protocol_version,
+            operation_id: self.operation_id,
+            host_registration_id: self.host_registration_id,
+            event_id: self.event_id,
+            issuer_sequence: self.issuer_sequence,
+            last_acked_issuer_sequence: self.last_acked_issuer_sequence,
+            accepted_at_unix_ms: self.accepted_at_unix_ms,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+    use serde::de::DeserializeOwned;
+    use serde_json::Value;
+
+    const FIXTURE_JSON: &str = include_str!("../tests/fixtures/maple_pairing_v1_vectors.json");
+
+    fn fixture() -> Value {
+        serde_json::from_str(FIXTURE_JSON).expect("literal server pairing fixture")
+    }
+
+    fn fixture_value<T: DeserializeOwned>(name: &str) -> T {
+        serde_json::from_value(fixture()[name].clone()).expect("fixture value matches SDK DTO")
+    }
+
+    fn fixture_string(name: &str) -> String {
+        fixture()[name]
+            .as_str()
+            .expect("fixture value is a string")
+            .to_string()
+    }
+
+    fn trusted_issuers() -> MaplePairingIssuerKeySet {
+        MaplePairingIssuerKeySet::from_v1(fixture_value("issuer_keyset"))
+            .expect("literal issuer key set is trusted explicitly")
+    }
+
+    #[test]
+    fn local_pairing_fixture_bytes_are_exactly_pinned() {
+        assert_eq!(
+            hex::encode(Sha256::digest(FIXTURE_JSON.as_bytes())),
+            "02be99e6c57c9e79de54a501fecc5ec5eeba19a2ef1d4ac54f131daff0f80a56"
+        );
+        assert!(FIXTURE_JSON.ends_with('\n'));
+        assert!(!FIXTURE_JSON.ends_with("\n\n"));
+        assert!(!FIXTURE_JSON.contains('\r'));
+    }
+
+    #[test]
+    fn backend_owned_extended_vectors_cover_materialization_retirement_and_authority_edges() {
+        let fixture = fixture();
+        assert_eq!(fixture["fixture_schema_version"].as_u64(), Some(1));
+
+        let create_bundle = &fixture["typed_materialization_vectors"]["create"];
+        let create_request: CreateMaplePairingRequest =
+            serde_json::from_value(create_bundle["request"].clone()).unwrap();
+        let create_ticket: MaplePairRequestTicketV1 =
+            serde_json::from_value(create_bundle["request_ticket"].clone()).unwrap();
+        let create_response: MaplePairingMutationResponse =
+            serde_json::from_value(create_bundle["response"].clone()).unwrap();
+        assert_eq!(create_request, fixture_value("create_request"));
+        assert_eq!(create_ticket, fixture_value("request_ticket"));
+        create_response
+            .verify_create(
+                &create_request,
+                &trusted_issuers(),
+                create_ticket.created_at_unix_ms,
+            )
+            .unwrap();
+
+        let revoke_bundle = &fixture["typed_materialization_vectors"]["revoke"];
+        let revoke_request: RevokeMaplePairingRequest =
+            serde_json::from_value(revoke_bundle["request"].clone()).unwrap();
+        let revoke_response: MaplePairingMutationResponse =
+            serde_json::from_value(revoke_bundle["response"].clone()).unwrap();
+        assert_eq!(revoke_request, fixture_value("revoke_request"));
+        assert_eq!(revoke_bundle["request_ticket"], fixture["request_ticket"]);
+        assert_eq!(
+            revoke_bundle["pair_authorization"],
+            fixture["pair_authorization"]
+        );
+        assert_eq!(revoke_bundle["revocation"], fixture["pair_revocation"]);
+        assert_eq!(revoke_bundle["response"], fixture["revoke_receipt"]);
+        revoke_response
+            .verify_revoke(
+                &revoke_request,
+                &trusted_issuers(),
+                create_ticket.created_at_unix_ms,
+            )
+            .unwrap();
+
+        let post_ack = &fixture["post_ack_registration_outcome_vectors"];
+        let exact_old: crate::RegisterMapleDeviceRequest =
+            serde_json::from_value(post_ack["exact_pre_reset_replay"]["request"].clone()).unwrap();
+        let changed_old: crate::RegisterMapleDeviceRequest =
+            serde_json::from_value(post_ack["changed_pre_reset_same_operation"]["request"].clone())
+                .unwrap();
+        let exact_pending: crate::RegisterMapleDeviceRequest =
+            serde_json::from_value(post_ack["exact_pending_reset_replay"]["request"].clone())
+                .unwrap();
+        let changed_pending: crate::RegisterMapleDeviceRequest = serde_json::from_value(
+            post_ack["changed_pending_reset_same_operation"]["request"].clone(),
+        )
+        .unwrap();
+        let retired_fresh: crate::RegisterMapleDeviceRequest = serde_json::from_value(
+            post_ack["fresh_operation_retired_installation"]["request"].clone(),
+        )
+        .unwrap();
+        let fresh_installation: crate::RegisterMapleDeviceRequest =
+            serde_json::from_value(post_ack["fresh_installation_current_epoch"]["request"].clone())
+                .unwrap();
+        for request in [
+            &exact_old,
+            &changed_old,
+            &exact_pending,
+            &changed_pending,
+            &retired_fresh,
+            &fresh_installation,
+        ] {
+            request.validate().unwrap();
+        }
+        assert_eq!(exact_old.operation_id, changed_old.operation_id);
+        assert_ne!(exact_old, changed_old);
+        assert_eq!(exact_pending.operation_id, changed_pending.operation_id);
+        assert_ne!(exact_pending, changed_pending);
+        assert_eq!(retired_fresh.installation_id, exact_pending.installation_id);
+        assert_ne!(retired_fresh.operation_id, exact_pending.operation_id);
+        assert_ne!(
+            fresh_installation.installation_id,
+            exact_pending.installation_id
+        );
+        assert_ne!(
+            fresh_installation.identity_public_key,
+            exact_pending.identity_public_key
+        );
+        assert_eq!(
+            post_ack["exact_pre_reset_replay"]["response"],
+            fixture["register_device_response_ready"]
+        );
+        assert_eq!(
+            post_ack["exact_pre_reset_replay"]["expected"],
+            "frozen_ready_replay"
+        );
+        assert_eq!(
+            post_ack["changed_pre_reset_same_operation"]["expected"],
+            "conflict"
+        );
+        assert_eq!(
+            post_ack["exact_pending_reset_replay"]["response"],
+            fixture["register_device_response_reset_clear_required"]
+        );
+        assert_eq!(
+            post_ack["exact_pending_reset_replay"]["expected"],
+            "reset_clear_required_replay"
+        );
+        assert_eq!(
+            post_ack["changed_pending_reset_same_operation"]["expected"],
+            "conflict"
+        );
+        assert_eq!(
+            post_ack["fresh_operation_retired_installation"]["expected"],
+            "MapleInstallationRetired"
+        );
+        assert_eq!(
+            post_ack["fresh_installation_current_epoch"]["expected"],
+            "ready"
+        );
+        assert_eq!(
+            post_ack["operation_replay_precedes_retirement_and_epoch_gates"],
+            true
+        );
+        let reset_response: crate::MapleDeviceRegistrationResponse = serde_json::from_value(
+            fixture["register_device_response_reset_clear_required"].clone(),
+        )
+        .unwrap();
+        let reset_instruction: MapleResetClearRequiredV1 = serde_json::from_value(
+            fixture["reset_clear_three_reset_chain"][2]["instruction"].clone(),
+        )
+        .unwrap();
+        let first_reset: MapleResetClearRequiredV1 = serde_json::from_value(
+            fixture["reset_clear_three_reset_chain"][0]["instruction"].clone(),
+        )
+        .unwrap();
+        let frozen_ready: crate::MapleDeviceRegistrationResponse =
+            serde_json::from_value(fixture["register_device_response_ready"].clone()).unwrap();
+        let frozen_ready_checkpoint = &frozen_ready.revocation_sync.stream_checkpoint;
+        assert_eq!(frozen_ready_checkpoint.host, first_reset.host);
+        assert_eq!(
+            frozen_ready_checkpoint.security_epoch,
+            first_reset.source_security_epoch
+        );
+        assert_eq!(
+            frozen_ready_checkpoint.revocation_stream_id,
+            first_reset.source_revocation_stream_id
+        );
+        assert_eq!(
+            frozen_ready_checkpoint.revocation_stream_generation,
+            first_reset.source_revocation_stream_generation
+        );
+        let ack_response: MaplePairingRevocationAckResponse =
+            serde_json::from_value(fixture["reset_clear_ack_response"].clone()).unwrap();
+        assert!(
+            reset_response.accepted_at.timestamp_millis() >= reset_instruction.reset_at_unix_ms
+        );
+        assert!(reset_response.accepted_at.timestamp_millis() < ack_response.accepted_at_unix_ms);
+        let fresh_response: crate::MapleDeviceRegistrationResponse = serde_json::from_value(
+            post_ack["fresh_installation_current_epoch"]["response"].clone(),
+        )
+        .unwrap();
+        fresh_response
+            .revocation_sync
+            .verify_against_registration(
+                &fresh_installation,
+                fresh_response.registration_id,
+                fresh_response.security_epoch,
+                &trusted_issuers(),
+            )
+            .unwrap();
+        assert!(fresh_response.accepted_at.timestamp_millis() > ack_response.accepted_at_unix_ms);
+
+        let two_host = &fixture["two_host_ack_namespace_vectors"];
+        let host_a_request: AckMaplePairingRevocationRequest =
+            serde_json::from_value(two_host["host_a"]["request"].clone()).unwrap();
+        let host_b_request: AckMaplePairingRevocationRequest =
+            serde_json::from_value(two_host["host_b"]["request"].clone()).unwrap();
+        let host_a_response: MaplePairingRevocationAckResponse =
+            serde_json::from_value(two_host["host_a"]["response"].clone()).unwrap();
+        let host_b_response: MaplePairingRevocationAckResponse =
+            serde_json::from_value(two_host["host_b"]["response"].clone()).unwrap();
+        assert_eq!(host_a_request.operation_id, host_b_request.operation_id);
+        assert_ne!(
+            host_a_request.host_registration_id,
+            host_b_request.host_registration_id
+        );
+        assert_ne!(
+            host_a_request.canonical_transcript().unwrap(),
+            host_b_request.canonical_transcript().unwrap()
+        );
+        let host_a_key = claim_signing_key(&host_a_response.stream_checkpoint.host);
+        let host_b_key = claim_signing_key(&host_b_response.stream_checkpoint.host);
+        host_a_request
+            .validate_with_signing_key(&host_a_key)
+            .unwrap();
+        host_b_request
+            .validate_with_signing_key(&host_b_key)
+            .unwrap();
+        host_a_response
+            .clone()
+            .verify_for(&host_a_request, &trusted_issuers())
+            .unwrap();
+        host_b_response
+            .clone()
+            .verify_for(&host_b_request, &trusted_issuers())
+            .unwrap();
+        assert!(host_a_response
+            .verify_for(&host_b_request, &trusted_issuers())
+            .is_err());
+        assert!(host_b_response
+            .verify_for(&host_a_request, &trusted_issuers())
+            .is_err());
+
+        let successor = &fixture["reset_clear_successor_vectors"];
+        assert_eq!(
+            successor["exact_full_host_claim_fields"],
+            serde_json::json!([
+                "registration_id",
+                "device_id",
+                "installation_id",
+                "identity_algorithm",
+                "identity_public_key",
+                "endpoint_id",
+                "endpoint_epoch"
+            ])
+        );
+        let predecessor: MapleResetClearRequiredV1 =
+            serde_json::from_value(successor["predecessor"].clone()).unwrap();
+        let accepted: MapleResetClearRequiredV1 =
+            serde_json::from_value(successor["accepted"]["instruction"].clone()).unwrap();
+        let changed_host: MapleResetClearRequiredV1 =
+            serde_json::from_value(successor["changed_host"]["instruction"].clone()).unwrap();
+        assert_eq!(predecessor.host, accepted.host);
+        assert_ne!(predecessor.host, changed_host.host);
+        let predecessor = predecessor.verify(&trusted_issuers()).unwrap();
+        accepted
+            .verify(&trusted_issuers())
+            .unwrap()
+            .verify_successor_of(&predecessor)
+            .unwrap();
+        assert!(changed_host
+            .verify(&trusted_issuers())
+            .unwrap()
+            .verify_successor_of(&predecessor)
+            .is_err());
+
+        let rotation = &fixture["issuer_rotation_vectors"];
+        let artifact: MaplePairRequestTicketV1 =
+            serde_json::from_value(rotation["artifact_signed_by_initial"].clone()).unwrap();
+        let initial = MaplePairingIssuerKeySet::from_v1(
+            serde_json::from_value(rotation["initial"]["keyset"].clone()).unwrap(),
+        )
+        .unwrap();
+        let retained = MaplePairingIssuerKeySet::from_v1(
+            serde_json::from_value(rotation["rotated_retaining_previous"]["keyset"].clone())
+                .unwrap(),
+        )
+        .unwrap();
+        let omitted = MaplePairingIssuerKeySet::from_v1(
+            serde_json::from_value(rotation["rotated_without_previous"]["keyset"].clone()).unwrap(),
+        )
+        .unwrap();
+        let remapped = MaplePairingIssuerKeySet::from_v1(
+            serde_json::from_value(rotation["remapped_previous_key_id"]["keyset"].clone()).unwrap(),
+        )
+        .unwrap();
+        for issuers in [&initial, &retained] {
+            artifact
+                .verify_at(
+                    issuers,
+                    artifact.created_at_unix_ms,
+                    0,
+                    MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+                )
+                .unwrap();
+        }
+        assert!(artifact
+            .verify_at(
+                &omitted,
+                artifact.created_at_unix_ms,
+                0,
+                MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+            )
+            .is_err());
+        assert!(artifact
+            .verify_at(
+                &remapped,
+                artifact.created_at_unix_ms,
+                0,
+                MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+            )
+            .is_err());
+        assert_eq!(
+            rotation["rotated_retaining_previous"]["registry_reconciliation_expected"],
+            "append_accepted"
+        );
+        assert_eq!(
+            rotation["rotated_without_previous"]["registry_reconciliation_expected"],
+            "MaplePairingIssuerConfigurationConflict"
+        );
+        assert_eq!(
+            rotation["remapped_previous_key_id"]["registry_reconciliation_expected"],
+            "MaplePairingIssuerConfigurationConflict"
+        );
+
+        let tombstones = &fixture["registration_operation_tombstone_vectors"];
+        assert_eq!(tombstones["exact_old_request"], "frozen_ready_replay");
+        assert_eq!(
+            tombstones["exact_pending_reset_request_after_ack"],
+            "reset_clear_required_replay"
+        );
+        assert_eq!(
+            tombstones["changed_pending_reset_request_after_ack"],
+            "conflict"
+        );
+        assert_eq!(
+            tombstones["fresh_operation_retired_installation"],
+            "MapleInstallationRetired"
+        );
+        assert_eq!(tombstones["fresh_installation_current_epoch"], "ready");
+    }
+
+    fn reconciled_stream(name: &str) -> DurablyReconciledMapleRevocationStreamV1 {
+        fixture_value::<MapleRevocationStreamCheckpointV1>(name)
+            .verify(&trusted_issuers())
+            .unwrap()
+            .plan_durable_transition(None)
+            .unwrap()
+            .after_durable_commit()
+    }
+
+    fn claim_signing_key(claim: &MaplePairingDeviceClaimV1) -> [u8; 32] {
+        decode_exact_base64(
+            &claim.identity_public_key,
+            ED25519_PUBLIC_KEY_BYTES,
+            "fixture signing public key",
+            ErrorClass::Configuration,
+        )
+        .expect("fixture key")
+        .try_into()
+        .expect("exact key length")
+    }
+
+    fn resign_revocation(mut revocation: MaplePairRevocationV1) -> MaplePairRevocationV1 {
+        let seed = hex::decode(
+            fixture()["test_private_seeds_hex"]["issuer"]
+                .as_str()
+                .unwrap(),
+        )
+        .unwrap();
+        let seed: [u8; 32] = seed.try_into().unwrap();
+        let signature =
+            SigningKey::from_bytes(&seed).sign(&revocation.canonical_transcript().unwrap());
+        revocation.issuer_signature = BASE64.encode(signature.to_bytes());
+        revocation
+    }
+
+    #[test]
+    fn literal_server_vectors_match_every_frozen_transcript_and_signature() {
+        let create: CreateMaplePairingRequest = fixture_value("create_request");
+        assert_eq!(
+            hex::encode(create.canonical_transcript().unwrap()),
+            fixture_string("create_request_transcript_hex")
+        );
+        assert_eq!(
+            create.transcript_digest().unwrap(),
+            fixture_string("create_request_digest")
+        );
+        create.validate().unwrap();
+
+        let ticket: MaplePairRequestTicketV1 = fixture_value("request_ticket");
+        assert_eq!(
+            hex::encode(ticket.canonical_transcript().unwrap()),
+            fixture_string("request_ticket_transcript_hex")
+        );
+        assert_eq!(
+            ticket.transcript_digest().unwrap(),
+            fixture_string("request_ticket_digest")
+        );
+        ticket
+            .verify_at(
+                &trusted_issuers(),
+                ticket.created_at_unix_ms,
+                MAPLE_PAIRING_MAX_CLOCK_SKEW_MS,
+                MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+            )
+            .unwrap();
+
+        let list: ListMaplePairingsRequest = fixture_value("list_pairings_request");
+        assert_eq!(
+            hex::encode(list.canonical_transcript().unwrap()),
+            fixture_string("list_pairings_request_transcript_hex")
+        );
+        assert_eq!(
+            sha256_base64(&list.canonical_transcript().unwrap()),
+            fixture_string("list_pairings_request_digest")
+        );
+        list.validate_with_signing_key(&claim_signing_key(&ticket.controller))
+            .unwrap();
+        let list_response: MaplePairingListResponse = fixture_value("list_pairings_response");
+        list_response
+            .verify_for(&list, &trusted_issuers(), ticket.created_at_unix_ms)
+            .unwrap();
+
+        let status: MaplePairingStatusRequest = fixture_value("pairing_status_request");
+        assert_eq!(
+            hex::encode(status.canonical_transcript().unwrap()),
+            fixture_string("pairing_status_request_transcript_hex")
+        );
+        assert_eq!(
+            sha256_base64(&status.canonical_transcript().unwrap()),
+            fixture_string("pairing_status_request_digest")
+        );
+        status
+            .validate_with_signing_key(&claim_signing_key(&ticket.controller))
+            .unwrap();
+        let status_response: MaplePairingStatusResponse = fixture_value("pairing_status_response");
+        let active_at = status_response.pairing.activated_at_unix_ms.unwrap();
+        status_response
+            .verify_for(
+                &status,
+                MaplePairingRole::Controller,
+                &trusted_issuers(),
+                active_at,
+            )
+            .unwrap();
+
+        let approval: ApproveMaplePairingRequest = fixture_value("approval_request");
+        assert_eq!(
+            hex::encode(approval.canonical_transcript().unwrap()),
+            fixture_string("approval_request_transcript_hex")
+        );
+        assert_eq!(
+            approval.transcript_digest().unwrap(),
+            fixture_string("approval_request_digest")
+        );
+        approval
+            .validate_with_signing_key(&claim_signing_key(&ticket.host))
+            .unwrap();
+
+        let authorization: MaplePairAuthorizationV1 = fixture_value("pair_authorization");
+        assert_eq!(
+            hex::encode(authorization.canonical_transcript().unwrap()),
+            fixture_string("pair_authorization_transcript_hex")
+        );
+        assert_eq!(
+            authorization.transcript_digest().unwrap(),
+            fixture_string("pair_authorization_digest")
+        );
+        authorization
+            .verify_against_ticket(&trusted_issuers(), &ticket)
+            .unwrap();
+
+        let confirm: ConfirmMaplePairingRequest = fixture_value("confirm_request");
+        assert_eq!(
+            hex::encode(confirm.canonical_transcript().unwrap()),
+            fixture_string("confirm_request_transcript_hex")
+        );
+        assert_eq!(
+            sha256_base64(&confirm.canonical_transcript().unwrap()),
+            fixture_string("confirm_request_digest")
+        );
+        confirm
+            .validate_with_signing_key(&claim_signing_key(&authorization.host))
+            .unwrap();
+
+        let active_receipt: MaplePairingMutationResponse = fixture_value("active_receipt");
+        let verified_active = active_receipt
+            .verify_confirm(
+                &confirm,
+                &trusted_issuers(),
+                authorization.approved_at_unix_ms,
+            )
+            .unwrap();
+        assert_eq!(
+            verified_active.pairing.as_inner().state,
+            MaplePairingState::Active
+        );
+        assert_eq!(verified_active.pairing.as_inner().revision, 3);
+
+        let revocation: MaplePairRevocationV1 = fixture_value("pair_revocation");
+        assert_eq!(
+            hex::encode(revocation.canonical_transcript().unwrap()),
+            fixture_string("pair_revocation_transcript_hex")
+        );
+        assert_eq!(
+            revocation.transcript_digest().unwrap(),
+            fixture_string("pair_revocation_digest")
+        );
+        revocation.verify_issuer(&trusted_issuers()).unwrap();
+
+        let revoke: RevokeMaplePairingRequest = fixture_value("revoke_request");
+        assert_eq!(
+            hex::encode(revoke.canonical_transcript().unwrap()),
+            fixture_string("revoke_request_transcript_hex")
+        );
+        assert_eq!(
+            sha256_base64(&revoke.canonical_transcript().unwrap()),
+            fixture_string("revoke_request_digest")
+        );
+        revoke
+            .validate_with_signing_key(&claim_signing_key(&ticket.controller))
+            .unwrap();
+        let revoke_receipt: MaplePairingMutationResponse = fixture_value("revoke_receipt");
+        let verified_revoke = revoke_receipt
+            .verify_revoke(&revoke, &trusted_issuers(), revocation.revoked_at_unix_ms)
+            .unwrap();
+        assert_eq!(
+            verified_revoke.pairing.as_inner().state,
+            MaplePairingState::Revoked
+        );
+
+        let revocations: ListMaplePairingRevocationsRequest =
+            fixture_value("list_revocations_request");
+        assert_eq!(
+            hex::encode(revocations.canonical_transcript().unwrap()),
+            fixture_string("list_revocations_request_transcript_hex")
+        );
+        assert_eq!(
+            sha256_base64(&revocations.canonical_transcript().unwrap()),
+            fixture_string("list_revocations_request_digest")
+        );
+        revocations
+            .validate_with_signing_key(&claim_signing_key(&ticket.host))
+            .unwrap();
+        let revocations_response: MaplePairingRevocationListResponse =
+            fixture_value("list_revocations_response");
+        let verified_page = revocations_response
+            .verify_for(&revocations, &trusted_issuers())
+            .unwrap();
+        assert_eq!(
+            verified_page
+                .revocation_sync
+                .checkpoint()
+                .as_inner()
+                .host
+                .endpoint_epoch,
+            5
+        );
+
+        let checkpoint: MapleRevocationStreamCheckpointV1 =
+            fixture_value("revocation_stream_checkpoint");
+        assert_eq!(
+            hex::encode(checkpoint.canonical_transcript().unwrap()),
+            fixture_string("revocation_stream_checkpoint_transcript_hex")
+        );
+        assert_eq!(
+            checkpoint.transcript_digest().unwrap(),
+            fixture_string("revocation_stream_checkpoint_digest")
+        );
+        checkpoint.verify(&trusted_issuers()).unwrap();
+
+        let discovery: ListMaplePairingRevocationsRequest =
+            fixture_value("discovery_list_revocations_request");
+        assert_eq!(
+            hex::encode(discovery.canonical_transcript().unwrap()),
+            fixture_string("discovery_list_revocations_request_transcript_hex")
+        );
+        assert_eq!(
+            sha256_base64(&discovery.canonical_transcript().unwrap()),
+            fixture_string("discovery_list_revocations_request_digest")
+        );
+        discovery
+            .validate_with_signing_key(&claim_signing_key(&ticket.host))
+            .unwrap();
+        let discovery_response: MaplePairingRevocationListResponse =
+            fixture_value("discovery_list_revocations_response");
+        discovery_response
+            .verify_for(&discovery, &trusted_issuers())
+            .unwrap();
+        let discovery_checkpoint: MapleRevocationStreamCheckpointV1 =
+            fixture_value("discovery_revocation_stream_checkpoint");
+        assert_eq!(
+            hex::encode(discovery_checkpoint.canonical_transcript().unwrap()),
+            fixture_string("discovery_revocation_stream_checkpoint_transcript_hex")
+        );
+        assert_eq!(
+            discovery_checkpoint.transcript_digest().unwrap(),
+            fixture_string("discovery_revocation_stream_checkpoint_digest")
+        );
+        discovery_checkpoint.verify(&trusted_issuers()).unwrap();
+
+        let ack: AckMaplePairingRevocationRequest = fixture_value("ack_revocation_request");
+        assert_eq!(
+            hex::encode(ack.canonical_transcript().unwrap()),
+            fixture_string("ack_revocation_request_transcript_hex")
+        );
+        assert_eq!(
+            sha256_base64(&ack.canonical_transcript().unwrap()),
+            fixture_string("ack_revocation_request_digest")
+        );
+        ack.validate_with_signing_key(&claim_signing_key(&ticket.host))
+            .unwrap();
+        let ack_response: MaplePairingRevocationAckResponse =
+            fixture_value("ack_revocation_response");
+        ack_response.verify_for(&ack, &trusted_issuers()).unwrap();
+        let ack_checkpoint: MapleRevocationStreamCheckpointV1 =
+            fixture_value("ack_revocation_stream_checkpoint");
+        assert_eq!(
+            hex::encode(ack_checkpoint.canonical_transcript().unwrap()),
+            fixture_string("ack_revocation_stream_checkpoint_transcript_hex")
+        );
+        assert_eq!(
+            ack_checkpoint.transcript_digest().unwrap(),
+            fixture_string("ack_revocation_stream_checkpoint_digest")
+        );
+        ack_checkpoint.verify(&trusted_issuers()).unwrap();
+    }
+
+    #[test]
+    fn pairing_v1_has_only_directed_incarnation_and_no_shared_account_epoch() {
+        let fixture = fixture().to_string();
+        assert!(fixture.contains("pairing_incarnation"));
+        assert!(!fixture.contains("account_authorization_epoch"));
+        assert!(!fixture.contains("account_epoch"));
+
+        let ticket: MaplePairRequestTicketV1 = fixture_value("request_ticket");
+        assert_ne!(
+            ticket.controller.registration_id,
+            ticket.host.registration_id
+        );
+        assert_ne!(ticket.controller.endpoint_id, ticket.host.endpoint_id);
+        assert_eq!(ticket.direction, MaplePairingDirection::ControllerToHost);
+        assert_ne!(ticket.pairing_incarnation, 0);
+    }
+
+    #[test]
+    fn ticket_verify_at_enforces_trusted_time_skew_and_maximum_ttl() {
+        let ticket: MaplePairRequestTicketV1 = fixture_value("request_ticket");
+        let issuers = trusted_issuers();
+        ticket
+            .verify_at(
+                &issuers,
+                ticket.created_at_unix_ms - MAPLE_PAIRING_MAX_CLOCK_SKEW_MS,
+                MAPLE_PAIRING_MAX_CLOCK_SKEW_MS,
+                MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+            )
+            .unwrap();
+        ticket
+            .verify_at(
+                &issuers,
+                ticket.expires_at_unix_ms + MAPLE_PAIRING_MAX_CLOCK_SKEW_MS - 1,
+                MAPLE_PAIRING_MAX_CLOCK_SKEW_MS,
+                MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+            )
+            .unwrap();
+        assert!(matches!(
+            ticket.verify_at(
+                &issuers,
+                ticket.expires_at_unix_ms + MAPLE_PAIRING_MAX_CLOCK_SKEW_MS,
+                MAPLE_PAIRING_MAX_CLOCK_SKEW_MS,
+                MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+            ),
+            Err(Error::InvalidResponse(_))
+        ));
+        assert!(matches!(
+            ticket.verify_at(
+                &issuers,
+                ticket.created_at_unix_ms,
+                MAPLE_PAIRING_MAX_CLOCK_SKEW_MS + 1,
+                MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+            ),
+            Err(Error::Configuration(_))
+        ));
+
+        let mut excessive_ttl = ticket.clone();
+        excessive_ttl.expires_at_unix_ms =
+            excessive_ttl.created_at_unix_ms + MAPLE_PAIRING_MAX_TICKET_TTL_MS + 1;
+        assert!(matches!(
+            excessive_ttl.verify_at(
+                &issuers,
+                excessive_ttl.created_at_unix_ms,
+                0,
+                MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+            ),
+            Err(Error::InvalidResponse(_))
+        ));
+    }
+
+    #[test]
+    fn artifact_verification_rejects_untrusted_tampered_and_mismatched_keys() {
+        let authorization: MaplePairAuthorizationV1 = fixture_value("pair_authorization");
+        let ticket: MaplePairRequestTicketV1 = fixture_value("request_ticket");
+        let untrusted =
+            MaplePairingIssuerKeySet::new([("different-key", claim_signing_key(&ticket.host))])
+                .unwrap();
+        assert!(matches!(
+            authorization.verify_against_ticket(&untrusted, &ticket),
+            Err(Error::InvalidResponse(_))
+        ));
+
+        let mut tampered = authorization.clone();
+        tampered.pairing_incarnation += 1;
+        assert!(matches!(
+            tampered.verify_against_ticket(&trusted_issuers(), &ticket),
+            Err(Error::InvalidResponse(_))
+        ));
+
+        let mut wrong_approval_revision = authorization.clone();
+        wrong_approval_revision.host_approval_expected_pairing_revision = 2;
+        assert!(matches!(
+            wrong_approval_revision.canonical_transcript(),
+            Err(Error::InvalidResponse(_))
+        ));
+
+        let mut mismatched = authorization;
+        mismatched.controller.endpoint_id = mismatched.host.endpoint_id.clone();
+        assert!(matches!(
+            mismatched.canonical_transcript(),
+            Err(Error::InvalidResponse(message)) if message.contains("must match")
+        ));
+
+        let mut collapsed: MaplePairRequestTicketV1 = fixture_value("request_ticket");
+        collapsed.host.registration_id = collapsed.controller.registration_id;
+        assert!(matches!(
+            collapsed.canonical_transcript(),
+            Err(Error::InvalidResponse(_))
+        ));
+
+        let ticket: MaplePairRequestTicketV1 = fixture_value("request_ticket");
+        let mut early_authorization: MaplePairAuthorizationV1 = fixture_value("pair_authorization");
+        early_authorization.approved_at_unix_ms = ticket.created_at_unix_ms - 1;
+        assert!(matches!(
+            early_authorization.validate_ticket_binding(&ticket),
+            Err(Error::InvalidResponse(_))
+        ));
+
+        let authorization: MaplePairAuthorizationV1 = fixture_value("pair_authorization");
+        let mut early_revocation: MaplePairRevocationV1 = fixture_value("pair_revocation");
+        early_revocation.revoked_at_unix_ms = authorization.approved_at_unix_ms - 1;
+        assert!(matches!(
+            early_revocation.validate_authorization_binding(&authorization),
+            Err(Error::InvalidResponse(_))
+        ));
+    }
+
+    #[test]
+    fn host_commit_is_manual_and_derived_from_verified_authorization() {
+        let active_receipt: MaplePairingMutationResponse = fixture_value("active_receipt");
+        let mut awaiting = active_receipt.pairing;
+        awaiting.state = MaplePairingState::AwaitingHostCommit;
+        awaiting.revision = 2;
+        awaiting.activated_at_unix_ms = None;
+        let verified_status = awaiting
+            .verify(
+                &trusted_issuers(),
+                MaplePairingRole::Host,
+                awaiting.approved_at_unix_ms.unwrap(),
+            )
+            .unwrap();
+        let stream = reconciled_stream("revocation_stream_checkpoint");
+        let ready = verified_status
+            .host_commit_ready_authorization(&stream)
+            .unwrap();
+        let unsigned = ConfirmMaplePairingRequest::unsigned_v1_after_durable_commit(
+            Uuid::parse_str("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee").unwrap(),
+            &ready,
+        )
+        .unwrap();
+        assert!(unsigned.as_inner().signature.is_empty());
+        assert_eq!(
+            unsigned.as_inner().pair_authorization_digest,
+            fixture_string("pair_authorization_digest")
+        );
+        assert_eq!(unsigned.as_inner().pairing_incarnation, 3);
+        let literal_confirm: ConfirmMaplePairingRequest = fixture_value("confirm_request");
+        assert_eq!(
+            unsigned.as_inner(),
+            &ConfirmMaplePairingRequest {
+                signature: String::new(),
+                ..literal_confirm
+            }
+        );
+
+        let active_response: MaplePairingStatusResponse = fixture_value("pairing_status_response");
+        let active = active_response
+            .pairing
+            .verify(
+                &trusted_issuers(),
+                MaplePairingRole::Controller,
+                active_response.pairing.activated_at_unix_ms.unwrap(),
+            )
+            .unwrap();
+        assert!(active.host_commit_ready_authorization(&stream).is_none());
+    }
+
+    #[test]
+    fn revocation_namespace_transition_rejects_replay_and_requires_durable_reset() {
+        let issuers = trusted_issuers();
+        let checkpoint =
+            fixture_value::<MapleRevocationStreamCheckpointV1>("revocation_stream_checkpoint")
+                .verify(&issuers)
+                .unwrap();
+        let stream_id = checkpoint.as_inner().revocation_stream_id;
+        let generation = checkpoint.as_inner().revocation_stream_generation;
+        let account_id = checkpoint.as_inner().subject_account_id;
+        let project_id = checkpoint.as_inner().subject_project_id;
+        let host_registration_id = checkpoint.as_inner().host.registration_id;
+        let security_epoch = checkpoint.as_inner().security_epoch;
+
+        let same = MapleInstalledRevocationStreamNamespaceV1::new(
+            account_id,
+            project_id,
+            host_registration_id,
+            security_epoch,
+            stream_id,
+            generation,
+        )
+        .unwrap();
+        let unchanged = checkpoint
+            .clone()
+            .plan_durable_transition(Some(same))
+            .unwrap();
+        assert!(!unchanged.requires_admission_reset());
+        let reconciled_same = unchanged.after_durable_commit();
+        let literal_list: ListMaplePairingRevocationsRequest =
+            fixture_value("list_revocations_request");
+        let unsigned_list = ListMaplePairingRevocationsRequest::unsigned_v1_from_reconciled_stream(
+            literal_list.query_id,
+            literal_list.after_issuer_sequence,
+            literal_list.limit,
+            &reconciled_same,
+        )
+        .unwrap();
+        assert_eq!(
+            unsigned_list,
+            ListMaplePairingRevocationsRequest {
+                signature: String::new(),
+                ..literal_list
+            }
+        );
+
+        let wrong_scope = MapleInstalledRevocationStreamNamespaceV1::new(
+            Uuid::new_v4(),
+            project_id,
+            host_registration_id,
+            security_epoch,
+            stream_id,
+            generation,
+        )
+        .unwrap();
+        assert!(matches!(
+            checkpoint
+                .clone()
+                .plan_durable_transition(Some(wrong_scope)),
+            Err(Error::Configuration(_))
+        ));
+
+        let wrong_id = MapleInstalledRevocationStreamNamespaceV1::new(
+            account_id,
+            project_id,
+            host_registration_id,
+            security_epoch,
+            Uuid::parse_str("17171717-1717-4717-8717-171717171717").unwrap(),
+            generation,
+        )
+        .unwrap();
+        assert!(matches!(
+            checkpoint.clone().plan_durable_transition(Some(wrong_id)),
+            Err(Error::InvalidResponse(_))
+        ));
+
+        let newer_installed = MapleInstalledRevocationStreamNamespaceV1::new(
+            account_id,
+            project_id,
+            host_registration_id,
+            security_epoch,
+            Uuid::parse_str("18181818-1818-4818-8818-181818181818").unwrap(),
+            generation + 1,
+        )
+        .unwrap();
+        assert!(matches!(
+            checkpoint.plan_durable_transition(Some(newer_installed)),
+            Err(Error::InvalidResponse(_))
+        ));
+
+        let rotated = fixture_value::<MapleRevocationStreamCheckpointV1>(
+            "discovery_revocation_stream_checkpoint",
+        )
+        .verify(&issuers)
+        .unwrap();
+        let old = MapleInstalledRevocationStreamNamespaceV1::new(
+            account_id,
+            project_id,
+            host_registration_id,
+            rotated.as_inner().security_epoch,
+            stream_id,
+            1,
+        )
+        .unwrap();
+        let reset_before_crash = rotated.clone().plan_durable_transition(Some(old)).unwrap();
+        assert!(reset_before_crash.requires_admission_reset());
+        drop(reset_before_crash);
+
+        // A crash before the clear/install transaction leaves the old durable
+        // namespace intact, so replaying the verified discovery on restart
+        // must require the reset again.
+        let reset = rotated.plan_durable_transition(Some(old)).unwrap();
+        assert!(reset.requires_admission_reset());
+        let reconciled_rotated = reset.after_durable_commit();
+
+        let literal_discovery: ListMaplePairingRevocationsRequest =
+            fixture_value("discovery_list_revocations_request");
+        let unsigned_discovery = ListMaplePairingRevocationsRequest::unsigned_v1_discovery(
+            literal_discovery.query_id,
+            literal_discovery.asserted_account_id,
+            literal_discovery.asserted_project_id,
+            literal_discovery.host_registration_id,
+            literal_discovery.limit,
+        )
+        .unwrap();
+        assert_eq!(
+            unsigned_discovery,
+            ListMaplePairingRevocationsRequest {
+                signature: String::new(),
+                ..literal_discovery.clone()
+            }
+        );
+        let mut partial_discovery = literal_discovery;
+        partial_discovery.after_issuer_sequence = 1;
+        assert!(partial_discovery.canonical_transcript().is_err());
+
+        let ticket: MaplePairRequestTicketV1 = fixture_value("request_ticket");
+        let authorization: MaplePairAuthorizationV1 = fixture_value("pair_authorization");
+        let verified_authorization = authorization
+            .verify_against_ticket(&issuers, &ticket)
+            .unwrap();
+        let revocation: MaplePairRevocationV1 = fixture_value("pair_revocation");
+        assert!(revocation
+            .verify_against_authorization(&issuers, &verified_authorization, &reconciled_rotated,)
+            .is_err());
+    }
+
+    #[test]
+    fn controller_precommit_revocation_is_redacted_and_ticket_bound() {
+        let issuers = trusted_issuers();
+        let revoke_receipt: MaplePairingMutationResponse = fixture_value("revoke_receipt");
+        let mut controller_view = revoke_receipt.pairing;
+        let authorization = controller_view.pair_authorization.take().unwrap();
+        controller_view.revision = 3;
+        controller_view.activated_at_unix_ms = None;
+
+        let verified = controller_view
+            .verify(
+                &issuers,
+                MaplePairingRole::Controller,
+                controller_view.revoked_at_unix_ms.unwrap(),
+            )
+            .unwrap();
+        assert!(verified.pair_authorization().is_none());
+        assert!(verified
+            .host_commit_ready_authorization(&reconciled_stream("revocation_stream_checkpoint"))
+            .is_none());
+        assert!(controller_view
+            .verify(
+                &issuers,
+                MaplePairingRole::Host,
+                controller_view.revoked_at_unix_ms.unwrap(),
+            )
+            .is_err());
+
+        let mut leaked = controller_view.clone();
+        leaked.pair_authorization = Some(authorization);
+        assert!(leaked
+            .verify(
+                &issuers,
+                MaplePairingRole::Controller,
+                leaked.revoked_at_unix_ms.unwrap(),
+            )
+            .is_err());
+
+        let mut mismatched = controller_view.clone();
+        let mut revocation = mismatched.revocation.take().unwrap();
+        revocation.controller.endpoint_epoch += 1;
+        mismatched.revocation = Some(resign_revocation(revocation));
+        assert!(mismatched
+            .verify(
+                &issuers,
+                MaplePairingRole::Controller,
+                mismatched.revoked_at_unix_ms.unwrap(),
+            )
+            .is_err());
+
+        let mut zero_digest: MaplePairRevocationV1 = fixture_value("pair_revocation");
+        zero_digest.pair_authorization_digest = BASE64.encode([0u8; DIGEST_BYTES]);
+        assert!(matches!(
+            zero_digest.canonical_transcript(),
+            Err(Error::InvalidResponse(_))
+        ));
+    }
+
+    #[test]
+    fn approval_and_revocation_ack_builders_preserve_verified_artifacts() {
+        let ticket: MaplePairRequestTicketV1 = fixture_value("request_ticket");
+        let verified_ticket = ticket
+            .verify_at(
+                &trusted_issuers(),
+                ticket.created_at_unix_ms,
+                MAPLE_PAIRING_MAX_CLOCK_SKEW_MS,
+                MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+            )
+            .unwrap();
+        let literal_approval: ApproveMaplePairingRequest = fixture_value("approval_request");
+        let stream = reconciled_stream("revocation_stream_checkpoint");
+        let approval = ApproveMaplePairingRequest::unsigned_v1_from_verified_ticket(
+            literal_approval.operation_id,
+            literal_approval.host_approval_nonce.clone(),
+            &verified_ticket,
+            &stream,
+        )
+        .unwrap();
+        assert_eq!(
+            approval.as_inner().approved_protocol_min,
+            ticket.protocol_min
+        );
+        assert_eq!(
+            approval.as_inner().approved_protocol_max,
+            ticket.protocol_max
+        );
+        assert_eq!(
+            approval.as_inner(),
+            &ApproveMaplePairingRequest {
+                signature: String::new(),
+                ..literal_approval
+            }
+        );
+
+        let revocation: MaplePairRevocationV1 = fixture_value("pair_revocation");
+        let authorization: MaplePairAuthorizationV1 = fixture_value("pair_authorization");
+        let verified_authorization = authorization
+            .verify_against_ticket(&trusted_issuers(), &ticket)
+            .unwrap();
+        let verified_revocation = revocation
+            .verify_against_authorization(&trusted_issuers(), &verified_authorization, &stream)
+            .unwrap();
+        let literal_ack: AckMaplePairingRevocationRequest = fixture_value("ack_revocation_request");
+        let ack = AckMaplePairingRevocationRequest::unsigned_v1_after_durable_commit(
+            literal_ack.operation_id,
+            literal_ack.expected_previous_issuer_sequence,
+            &verified_revocation,
+        )
+        .unwrap();
+        assert_eq!(
+            ack.as_inner(),
+            &AckMaplePairingRevocationRequest {
+                signature: String::new(),
+                ..literal_ack
+            }
+        );
+    }
+
+    #[test]
+    fn issuer_keyset_and_literal_json_fail_closed_on_shape_drift() {
+        let mut keyset: MaplePairingIssuerKeySetV1 = fixture_value("issuer_keyset");
+        keyset.keys.push(keyset.keys[0].clone());
+        assert!(MaplePairingIssuerKeySet::from_v1(keyset).is_err());
+
+        let mut request = fixture()["create_request"].clone();
+        request
+            .as_object_mut()
+            .unwrap()
+            .insert("account_epoch".to_string(), Value::from(7));
+        assert!(serde_json::from_value::<CreateMaplePairingRequest>(request).is_err());
+    }
+
+    #[test]
+    fn list_and_revocation_pages_reject_nonprogress_and_request_mismatches() {
+        let list_request = ListMaplePairingsRequest {
+            protocol_version: 1,
+            transcript_version: 1,
+            query_id: Uuid::new_v4(),
+            asserted_account_id: Uuid::new_v4(),
+            asserted_project_id: Uuid::new_v4(),
+            actor_registration_id: Uuid::new_v4(),
+            role: MaplePairingRole::Host,
+            states: vec![MaplePairingState::Active],
+            cursor: Some("opaque-cursor".to_string()),
+            limit: Some(1),
+            signature: BASE64.encode([0u8; 64]),
+        };
+        let nonprogressing = MaplePairingListResponse {
+            protocol_version: 1,
+            query_id: list_request.query_id,
+            role: list_request.role,
+            pairings: Vec::new(),
+            next_cursor: Some("opaque-cursor".to_string()),
+            has_more: true,
+        };
+        assert!(matches!(
+            nonprogressing.verify_for(&list_request, &trusted_issuers(), 1),
+            Err(Error::InvalidResponse(_))
+        ));
+
+        let revocation_request: ListMaplePairingRevocationsRequest =
+            fixture_value("list_revocations_request");
+        let mut empty_jump: MaplePairingRevocationListResponse =
+            fixture_value("list_revocations_response");
+        empty_jump.events.clear();
+        assert!(matches!(
+            empty_jump.verify_for(&revocation_request, &trusted_issuers()),
+            Err(Error::InvalidResponse(_))
+        ));
+
+        let mut gap: MaplePairingRevocationListResponse =
+            fixture_value("list_revocations_response");
+        match &mut gap.events[0] {
+            MapleRevocationStreamEventV1::PairRevocation(event) => event.issuer_sequence += 1,
+            MapleRevocationStreamEventV1::ResetClearRequired(event) => event.issuer_sequence += 1,
+        }
+        assert!(matches!(
+            gap.verify_for(&revocation_request, &trusted_issuers()),
+            Err(Error::InvalidResponse(_))
+        ));
+    }
+
+    fn fixture_reset_admission_leaves(name: &str) -> (u16, Vec<MapleResetClearAdmissionLeafV1>) {
+        let vector = &fixture()["reset_clear_admission_set_vectors"][name];
+        let leaves = vector["leaves"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|leaf| MapleResetClearAdmissionLeafV1 {
+                pair_id: serde_json::from_value(leaf["pair_id"].clone()).unwrap(),
+                pairing_incarnation: leaf["pairing_incarnation"].as_u64().unwrap(),
+                pair_authorization_digest: BASE64
+                    .decode(leaf["pair_authorization_digest"].as_str().unwrap())
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+            })
+            .collect();
+        (vector["artifact_version"].as_u64().unwrap() as u16, leaves)
+    }
+
+    #[test]
+    fn reset_clear_admission_vectors_are_literal_bounded_and_order_independent() {
+        for name in ["empty", "max_128"] {
+            let vector = &fixture()["reset_clear_admission_set_vectors"][name];
+            let (artifact_version, mut leaves) = fixture_reset_admission_leaves(name);
+            assert_eq!(
+                hex::encode(
+                    reset_clear_admission_set_transcript(artifact_version, &leaves).unwrap()
+                ),
+                vector["transcript_hex"].as_str().unwrap()
+            );
+            assert_eq!(
+                BASE64.encode(reset_clear_admission_set_digest(artifact_version, &leaves).unwrap()),
+                vector["digest"].as_str().unwrap()
+            );
+            leaves.reverse();
+            assert_eq!(
+                BASE64.encode(reset_clear_admission_set_digest(artifact_version, &leaves).unwrap()),
+                vector["digest"].as_str().unwrap()
+            );
+        }
+
+        let (artifact_version, mut leaves) = fixture_reset_admission_leaves("max_128");
+        let mut extra = leaves.last().unwrap().clone();
+        extra.pair_id = Uuid::new_v4();
+        leaves.push(extra);
+        assert!(matches!(
+            reset_clear_admission_set_transcript(artifact_version, &leaves),
+            Err(Error::Configuration(_))
+        ));
+
+        let (_, mut duplicate) = fixture_reset_admission_leaves("max_128");
+        duplicate[1] = duplicate[0].clone();
+        assert!(matches!(
+            reset_clear_admission_set_transcript(artifact_version, &duplicate),
+            Err(Error::Configuration(_))
+        ));
+    }
+
+    struct FixturePairingIssuer {
+        key_id: String,
+        signing_key: SigningKey,
+    }
+
+    impl MaplePairingIssuer for FixturePairingIssuer {
+        fn key_id(&self) -> &str {
+            &self.key_id
+        }
+
+        fn public_key_bytes(&self) -> [u8; ED25519_PUBLIC_KEY_BYTES] {
+            *self.signing_key.verifying_key().as_bytes()
+        }
+
+        fn sign(&self, transcript: &[u8]) -> Result<[u8; ED25519_SIGNATURE_BYTES]> {
+            Ok(self.signing_key.sign(transcript).to_bytes())
+        }
+    }
+
+    fn fixture_pairing_issuer() -> FixturePairingIssuer {
+        let seed: [u8; 32] = hex::decode(
+            fixture()["test_private_seeds_hex"]["issuer"]
+                .as_str()
+                .unwrap(),
+        )
+        .unwrap()
+        .try_into()
+        .unwrap();
+        FixturePairingIssuer {
+            key_id: fixture()["issuer_keyset"]["keys"][0]["key_id"]
+                .as_str()
+                .unwrap()
+                .to_string(),
+            signing_key: SigningKey::from_bytes(&seed),
+        }
+    }
+
+    #[test]
+    fn three_reset_chain_matches_every_literal_digest_signature_and_successor() {
+        let issuers = trusted_issuers();
+        let vectors = fixture()["reset_clear_three_reset_chain"]
+            .as_array()
+            .unwrap()
+            .clone();
+        let mut previous: Option<VerifiedMapleResetClearRequiredV1> = None;
+        for vector in vectors {
+            let instruction: MapleResetClearRequiredV1 =
+                serde_json::from_value(vector["instruction"].clone()).unwrap();
+            assert_eq!(
+                hex::encode(reset_clear_instruction_material_transcript(&instruction).unwrap()),
+                vector["instruction_material_transcript_hex"]
+                    .as_str()
+                    .unwrap()
+            );
+            assert_eq!(
+                instruction.instruction_material_digest,
+                vector["instruction_material_digest"].as_str().unwrap()
+            );
+            assert_eq!(
+                hex::encode(reset_clear_chain_transcript(&instruction).unwrap()),
+                vector["chain_transcript_hex"].as_str().unwrap()
+            );
+            assert_eq!(
+                instruction.chain_digest,
+                vector["chain_digest"].as_str().unwrap()
+            );
+            assert_eq!(
+                hex::encode(instruction.canonical_transcript().unwrap()),
+                vector["signed_transcript_hex"].as_str().unwrap()
+            );
+            assert_eq!(
+                instruction.event_digest().unwrap(),
+                vector["event_digest"].as_str().unwrap()
+            );
+            let verified = instruction.verify(&issuers).unwrap();
+            if let Some(previous) = &previous {
+                verified.verify_successor_of(previous).unwrap();
+            }
+            let mut unsigned = instruction.clone();
+            unsigned.instruction_material_digest.clear();
+            unsigned.chain_digest.clear();
+            unsigned.issuer_key_id.clear();
+            unsigned.issuer_signature.clear();
+            assert_eq!(
+                sign_reset_clear_required(unsigned, &fixture_pairing_issuer()).unwrap(),
+                instruction
+            );
+            previous = Some(verified);
+        }
+
+        let mut tampered: MapleResetClearRequiredV1 = serde_json::from_value(
+            fixture()["reset_clear_three_reset_chain"][2]["instruction"].clone(),
+        )
+        .unwrap();
+        tampered.cumulative_reset_count -= 1;
+        assert!(matches!(
+            tampered.verify(&issuers),
+            Err(Error::InvalidResponse(_))
+        ));
+
+        let predecessor: MapleResetClearRequiredV1 = serde_json::from_value(
+            fixture()["reset_clear_three_reset_chain"][1]["instruction"].clone(),
+        )
+        .unwrap();
+        let predecessor = predecessor.verify(&issuers).unwrap();
+        let mut changed_endpoint: MapleResetClearRequiredV1 = serde_json::from_value(
+            fixture()["reset_clear_three_reset_chain"][2]["instruction"].clone(),
+        )
+        .unwrap();
+        changed_endpoint.host.endpoint_epoch += 1;
+        let changed_endpoint =
+            sign_reset_clear_required(changed_endpoint, &fixture_pairing_issuer()).unwrap();
+        let changed_endpoint = changed_endpoint.verify(&issuers).unwrap();
+        assert!(matches!(
+            changed_endpoint.verify_successor_of(&predecessor),
+            Err(Error::InvalidResponse(_))
+        ));
+    }
+
+    #[test]
+    fn registration_sync_vectors_are_signed_request_bound_authority() {
+        let issuers = trusted_issuers();
+        for (request_name, transcript_name, digest_name) in [
+            (
+                "register_device_request_epoch_1",
+                "register_device_request_epoch_1_transcript_hex",
+                "register_device_request_epoch_1_digest",
+            ),
+            (
+                "register_device_request_epoch_4",
+                "register_device_request_epoch_4_transcript_hex",
+                "register_device_request_epoch_4_digest",
+            ),
+        ] {
+            let request: crate::RegisterMapleDeviceRequest = fixture_value(request_name);
+            let transcript = request.canonical_transcript().unwrap();
+            assert_eq!(hex::encode(&transcript), fixture_string(transcript_name));
+            assert_eq!(
+                BASE64.encode(Sha256::digest(&transcript)),
+                fixture_string(digest_name)
+            );
+            request.validate().unwrap();
+        }
+
+        for (request_name, response_name, expected_status, has_reset_plan) in [
+            (
+                "register_device_request_epoch_1",
+                "register_device_response_ready",
+                MapleRevocationSyncStatusV1::Ready,
+                false,
+            ),
+            (
+                "register_device_request_epoch_4",
+                "register_device_response_reset_clear_required",
+                MapleRevocationSyncStatusV1::ResetClearRequired,
+                true,
+            ),
+            (
+                "register_device_request_epoch_1",
+                "register_device_response_revocations_pending",
+                MapleRevocationSyncStatusV1::RevocationsPending,
+                false,
+            ),
+        ] {
+            let request: crate::RegisterMapleDeviceRequest = fixture_value(request_name);
+            let response: crate::MapleDeviceRegistrationResponse = fixture_value(response_name);
+            request.validate().unwrap();
+            assert_eq!(response.protocol_version, MAPLE_PAIRING_PROTOCOL_VERSION);
+            assert_eq!(response.operation_id, request.operation_id);
+            assert_eq!(response.device_id, request.device_id);
+            assert_eq!(response.security_epoch, request.known_security_epoch);
+            let sync = response
+                .revocation_sync
+                .verify_against_registration(
+                    &request,
+                    response.registration_id,
+                    response.security_epoch,
+                    &issuers,
+                )
+                .unwrap();
+            assert_eq!(sync.as_inner().status, expected_status);
+            let verified = VerifiedRegisterMapleDeviceResponseV1::new(response, sync);
+            assert_eq!(verified.has_reset_clear_plan(), has_reset_plan);
+        }
+
+        let request: crate::RegisterMapleDeviceRequest =
+            fixture_value("register_device_request_epoch_4");
+        let mut response: crate::MapleDeviceRegistrationResponse =
+            fixture_value("register_device_response_reset_clear_required");
+        response.security_epoch -= 1;
+        assert!(matches!(
+            response.revocation_sync.verify_against_registration(
+                &request,
+                response.registration_id,
+                response.security_epoch,
+                &issuers,
+            ),
+            Err(Error::InvalidResponse(_))
+        ));
+    }
+
+    #[test]
+    fn every_frozen_v6_checkpoint_request_and_epoch_vector_is_consumed() {
+        let issuers = trusted_issuers();
+        let pending_sync: MapleRevocationSyncV1 = fixture_value("reset_clear_pending_sync");
+        let host_key =
+            claim_signing_key(&pending_sync.reset_clear_instruction.as_ref().unwrap().host);
+
+        for (request_name, transcript_name, digest_name) in [
+            (
+                "reset_clear_list_revocations_request",
+                "reset_clear_list_revocations_request_transcript_hex",
+                "reset_clear_list_revocations_request_digest",
+            ),
+            (
+                "reset_clear_historical_later_request",
+                "reset_clear_historical_later_request_transcript_hex",
+                "reset_clear_historical_later_request_digest",
+            ),
+        ] {
+            let request: ListMaplePairingRevocationsRequest = fixture_value(request_name);
+            let transcript = request.canonical_transcript().unwrap();
+            assert_eq!(hex::encode(&transcript), fixture_string(transcript_name));
+            assert_eq!(sha256_base64(&transcript), fixture_string(digest_name));
+            request.validate_with_signing_key(&host_key).unwrap();
+        }
+
+        for (checkpoint_name, transcript_name, digest_name) in [
+            (
+                "reset_clear_pending_checkpoint",
+                "reset_clear_pending_checkpoint_transcript_hex",
+                "reset_clear_pending_checkpoint_digest",
+            ),
+            (
+                "reset_clear_acked_checkpoint",
+                "reset_clear_acked_checkpoint_transcript_hex",
+                "reset_clear_acked_checkpoint_digest",
+            ),
+            (
+                "reset_clear_later_checkpoint",
+                "reset_clear_later_checkpoint_transcript_hex",
+                "reset_clear_later_checkpoint_digest",
+            ),
+        ] {
+            let checkpoint: MapleRevocationStreamCheckpointV1 = fixture_value(checkpoint_name);
+            let transcript = checkpoint.canonical_transcript().unwrap();
+            assert_eq!(hex::encode(&transcript), fixture_string(transcript_name));
+            assert_eq!(
+                checkpoint.transcript_digest().unwrap(),
+                fixture_string(digest_name)
+            );
+            checkpoint.verify(&issuers).unwrap();
+        }
+
+        let later_revocation: MaplePairRevocationV1 =
+            fixture_value("reset_clear_later_pair_revocation");
+        assert_eq!(
+            hex::encode(later_revocation.canonical_transcript().unwrap()),
+            fixture_string("reset_clear_later_pair_revocation_transcript_hex")
+        );
+        assert_eq!(
+            later_revocation.transcript_digest().unwrap(),
+            fixture_string("reset_clear_later_pair_revocation_digest")
+        );
+        later_revocation.verify_issuer(&issuers).unwrap();
+
+        let ack: AckMaplePairingRevocationRequest = fixture_value("reset_clear_ack_request");
+        let ack_transcript = ack.canonical_transcript().unwrap();
+        assert_eq!(
+            hex::encode(&ack_transcript),
+            fixture_string("reset_clear_ack_request_transcript_hex")
+        );
+        assert_eq!(
+            sha256_base64(&ack_transcript),
+            fixture_string("reset_clear_ack_request_digest")
+        );
+        ack.validate_with_signing_key(&host_key).unwrap();
+
+        let device_list: crate::MapleDeviceListResponse =
+            fixture_value("list_devices_response_security_epoch");
+        assert_eq!(device_list.protocol_version, MAPLE_PAIRING_PROTOCOL_VERSION);
+        assert_eq!(device_list.security_epoch, 4);
+        assert!(device_list.devices.is_empty());
+        assert!(device_list.next_cursor.is_none());
+        assert!(!device_list.has_more);
+        let device_list_json = serde_json::to_value(&device_list).unwrap();
+        assert!(device_list_json.get("signature").is_none());
+        assert!(device_list_json.get("revocation_sync").is_none());
+
+        for vector in fixture()["security_epoch_outcome_vectors"]
+            .as_array()
+            .unwrap()
+        {
+            let known = vector["known_security_epoch"].as_u64().unwrap();
+            let current = vector["current_security_epoch"].as_u64().unwrap();
+            let reset_pending = vector["pending_reset_clear"].as_bool().unwrap();
+            let expected_outcome = if known < current {
+                "MapleSecurityEpochStale"
+            } else if known > current {
+                "conflict"
+            } else if reset_pending {
+                "reset_clear_required"
+            } else {
+                "ready"
+            };
+            assert_eq!(
+                vector["registration_operation_accepted"].as_bool().unwrap(),
+                known == current
+            );
+            assert_eq!(vector["outcome"].as_str().unwrap(), expected_outcome);
+        }
+
+        let tombstones = &fixture()["registration_operation_tombstone_vectors"];
+        assert_eq!(
+            tombstones["storage"]["operation_lookup_digest"],
+            "hmac_only"
+        );
+        assert_eq!(tombstones["storage"]["raw_operation_id_stored"], false);
+        assert_eq!(tombstones["exact_old_request"], "frozen_ready_replay");
+        assert_eq!(
+            tombstones["changed_request_same_operation_lookup"],
+            "conflict"
+        );
+
+        let structural = &fixture()["wire_structural_assertions"];
+        assert_eq!(
+            structural["list_devices_security_epoch_source"],
+            "authenticated_encrypted_account_authority_head"
+        );
+        assert_eq!(structural["list_devices_response_signed"], false);
+        assert_eq!(
+            structural["pending_reset_checkpoint"],
+            serde_json::json!({
+                "last_issued_issuer_sequence": 1,
+                "last_acked_issuer_sequence": 0,
+            })
+        );
+        assert_eq!(structural["historical_reset_event_allowed_after_ack"], true);
+        assert_eq!(
+            structural["historical_reset_event_allowed_when_later_events_exist"],
+            true
+        );
+        assert_eq!(
+            structural["reset_admission_public_shape"],
+            serde_json::json!(["admission_count", "admission_set_digest"])
+        );
+        assert_eq!(structural["retained_admission_leaves_cross_wire"], false);
+
+        let instruction: MapleResetClearRequiredV1 = serde_json::from_value(
+            fixture()["reset_clear_three_reset_chain"][2]["instruction"].clone(),
+        )
+        .unwrap();
+        let event = MapleRevocationStreamEventV1::ResetClearRequired(instruction.clone());
+        let event_json = serde_json::to_string(&event).unwrap();
+        assert!(event_json.starts_with("{\"event_type\":\"reset_clear_required\",\"event\":"));
+        assert_eq!(
+            structural["reset_event_json_key_order"],
+            serde_json::json!(["event_type", "event"])
+        );
+        let instruction_json = serde_json::to_value(instruction).unwrap();
+        assert!(instruction_json.get("admission_count").is_some());
+        assert!(instruction_json.get("admission_set_digest").is_some());
+        assert!(instruction_json.get("admission_leaves").is_none());
+        assert!(instruction_json.get("admissions").is_none());
+    }
+
+    #[test]
+    fn v6_authority_debug_is_fully_redacted_before_and_after_verification() {
+        let issuers = trusted_issuers();
+        let instruction: MapleResetClearRequiredV1 = serde_json::from_value(
+            fixture()["reset_clear_three_reset_chain"][2]["instruction"].clone(),
+        )
+        .unwrap();
+        let checkpoint: MapleRevocationStreamCheckpointV1 =
+            fixture_value("reset_clear_pending_checkpoint");
+        let sync: MapleRevocationSyncV1 = fixture_value("reset_clear_pending_sync");
+        let event = MapleRevocationStreamEventV1::ResetClearRequired(instruction.clone());
+        let list_request: ListMaplePairingRevocationsRequest =
+            fixture_value("reset_clear_list_revocations_request");
+        let list: MaplePairingRevocationListResponse =
+            fixture_value("reset_clear_list_revocations_response");
+        let ack_request: AckMaplePairingRevocationRequest =
+            fixture_value("reset_clear_ack_request");
+        let ack_response: MaplePairingRevocationAckResponse =
+            fixture_value("reset_clear_ack_response");
+        let register_request: crate::RegisterMapleDeviceRequest =
+            fixture_value("register_device_request_epoch_4");
+        let register_response: crate::MapleDeviceRegistrationResponse =
+            fixture_value("register_device_response_reset_clear_required");
+
+        let verified_list = list.clone().verify_for(&list_request, &issuers).unwrap();
+        let verified_event = verified_list.events[0].clone();
+        let verified_ack = ack_response
+            .clone()
+            .verify_for(&ack_request, &issuers)
+            .unwrap();
+        let verified_sync = register_response
+            .revocation_sync
+            .verify_against_registration(
+                &register_request,
+                register_response.registration_id,
+                register_response.security_epoch,
+                &issuers,
+            )
+            .unwrap();
+        let verified_register =
+            VerifiedRegisterMapleDeviceResponseV1::new(register_response.clone(), verified_sync);
+
+        let forbidden_values = [
+            instruction.event_id.to_string(),
+            instruction.reset_id.to_string(),
+            instruction.subject_account_id.to_string(),
+            instruction.subject_project_id.to_string(),
+            instruction.recipient_host_registration_id.to_string(),
+            instruction.host.device_id.to_string(),
+            instruction.host.installation_id.to_string(),
+            instruction.host.identity_public_key.clone(),
+            instruction.host.endpoint_id.clone(),
+            instruction.source_revocation_stream_id.to_string(),
+            instruction.revocation_stream_id.to_string(),
+            instruction.admission_set_digest.clone(),
+            instruction.instruction_material_digest.clone(),
+            instruction.chain_digest.clone(),
+            instruction.issuer_key_id.clone(),
+            instruction.issuer_signature.clone(),
+            ack_request.operation_id.to_string(),
+            ack_request.event_digest.clone(),
+            ack_request.signature.clone(),
+            list.query_id.to_string(),
+            register_response.operation_id.to_string(),
+            register_response.registration_id.to_string(),
+            register_response.device_id.to_string(),
+        ];
+        let forbidden_fields = [
+            "operation_id",
+            "query_id",
+            "registration_id",
+            "device_id",
+            "installation_id",
+            "identity_public_key",
+            "endpoint_id",
+            "revocation_stream_id",
+            "event_id",
+            "reset_id",
+            "event_digest",
+            "admission_set_digest",
+            "instruction_material_digest",
+            "chain_digest",
+            "issuer_key_id",
+            "issuer_signature",
+            "next_after_issuer_sequence",
+        ];
+        for debug in [
+            format!("{instruction:?}"),
+            format!("{checkpoint:?}"),
+            format!("{sync:?}"),
+            format!("{event:?}"),
+            format!("{list:?}"),
+            format!("{ack_request:?}"),
+            format!("{ack_response:?}"),
+            format!("{register_response:?}"),
+            format!("{verified_event:?}"),
+            format!("{verified_list:?}"),
+            format!("{verified_ack:?}"),
+            format!("{verified_register:?}"),
+        ] {
+            assert!(debug.contains("[redacted]"));
+            for secret in &forbidden_values {
+                assert!(!debug.contains(secret), "Debug leaked authority value");
+            }
+            for field in forbidden_fields {
+                assert!(!debug.contains(field), "Debug leaked authority field");
+            }
+        }
+    }
+
+    #[test]
+    fn opaque_authority_wrapper_debug_never_delegates_to_inner_wire_dtos() {
+        let issuers = trusted_issuers();
+        let ticket: MaplePairRequestTicketV1 = fixture_value("request_ticket");
+        let verified_ticket = ticket
+            .verify_at(
+                &issuers,
+                ticket.created_at_unix_ms,
+                MAPLE_PAIRING_MAX_CLOCK_SKEW_MS,
+                MAPLE_PAIRING_MAX_TICKET_TTL_MS,
+            )
+            .unwrap();
+        let authorization: MaplePairAuthorizationV1 = fixture_value("pair_authorization");
+        let verified_authorization = authorization
+            .verify_against_ticket(&issuers, &ticket)
+            .unwrap();
+        let revocation: MaplePairRevocationV1 = fixture_value("pair_revocation");
+        let verified_revocation = revocation.verify_issuer(&issuers).unwrap();
+        let status_response: MaplePairingStatusResponse = fixture_value("pairing_status_response");
+        let status_request: MaplePairingStatusRequest = fixture_value("pairing_status_request");
+        let verified_status = status_response
+            .verify_for(
+                &status_request,
+                MaplePairingRole::Controller,
+                &issuers,
+                ticket.created_at_unix_ms,
+            )
+            .unwrap();
+        let checkpoint =
+            fixture_value::<MapleRevocationStreamCheckpointV1>("revocation_stream_checkpoint")
+                .verify(&issuers)
+                .unwrap();
+        let reconciled = checkpoint
+            .clone()
+            .plan_durable_transition(None)
+            .unwrap()
+            .after_durable_commit();
+        let reset: MapleResetClearRequiredV1 = serde_json::from_value(
+            fixture()["reset_clear_three_reset_chain"][2]["instruction"].clone(),
+        )
+        .unwrap();
+        let verified_reset = reset.verify(&issuers).unwrap();
+        let pending_checkpoint =
+            fixture_value::<MapleRevocationStreamCheckpointV1>("reset_clear_pending_checkpoint")
+                .verify(&issuers)
+                .unwrap();
+        let latest_reset = reset
+            .verify_against_checkpoint(&issuers, &pending_checkpoint)
+            .unwrap();
+
+        let forbidden = [
+            ticket.pairing_request_id.to_string(),
+            ticket.pair_id.to_string(),
+            ticket.pairing_request_nonce.clone(),
+            ticket.controller.identity_public_key.clone(),
+            ticket.host.endpoint_id.clone(),
+            ticket.controller_request_digest.clone(),
+            ticket.issuer_signature.clone(),
+            authorization.host_approval_nonce.clone(),
+            authorization.host_approval_digest.clone(),
+            authorization.issuer_signature.clone(),
+            revocation.event_id.to_string(),
+            revocation.pair_authorization_digest.clone(),
+            revocation.issuer_signature.clone(),
+            reset.event_id.to_string(),
+            reset.instruction_material_digest.clone(),
+            reset.chain_digest.clone(),
+        ];
+        for debug in [
+            format!("{verified_ticket:?}"),
+            format!("{verified_authorization:?}"),
+            format!("{verified_revocation:?}"),
+            format!("{verified_status:?}"),
+            format!("{checkpoint:?}"),
+            format!("{reconciled:?}"),
+            format!("{verified_reset:?}"),
+            format!("{latest_reset:?}"),
+        ] {
+            assert!(debug.contains("[redacted]"));
+            for secret in &forbidden {
+                assert!(
+                    !debug.contains(secret),
+                    "opaque wrapper Debug leaked inner DTO"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn reset_clear_pending_and_historical_pages_have_distinct_authority() {
+        let issuers = trusted_issuers();
+        let pending_request: ListMaplePairingRevocationsRequest =
+            fixture_value("reset_clear_list_revocations_request");
+        let pending_response: MaplePairingRevocationListResponse =
+            fixture_value("reset_clear_list_revocations_response");
+        let pending = pending_response
+            .verify_for(&pending_request, &issuers)
+            .unwrap();
+        assert!(pending.has_reset_clear_instruction());
+        assert!(matches!(
+            pending.events.as_slice(),
+            [VerifiedMapleRevocationStreamEventV1::ResetClearRequired(_)]
+        ));
+
+        let acked_history: MaplePairingRevocationListResponse =
+            fixture_value("reset_clear_historical_acked_response");
+        let acked = acked_history
+            .verify_for(&pending_request, &issuers)
+            .unwrap();
+        assert!(!acked.has_reset_clear_instruction());
+        assert!(matches!(
+            acked.events.as_slice(),
+            [VerifiedMapleRevocationStreamEventV1::ResetClearRequired(_)]
+        ));
+
+        let later_request: ListMaplePairingRevocationsRequest =
+            fixture_value("reset_clear_historical_later_request");
+        let later_response: MaplePairingRevocationListResponse =
+            fixture_value("reset_clear_historical_later_response");
+        let later = later_response
+            .clone()
+            .verify_for(&later_request, &issuers)
+            .unwrap();
+        assert!(!later.has_reset_clear_instruction());
+        assert!(matches!(
+            later.events.as_slice(),
+            [
+                VerifiedMapleRevocationStreamEventV1::ResetClearRequired(_),
+                VerifiedMapleRevocationStreamEventV1::PairRevocation(_)
+            ]
+        ));
+
+        let mut too_small = later_request.clone();
+        too_small.limit = Some(1);
+        assert!(matches!(
+            later_response.verify_for(&too_small, &issuers),
+            Err(Error::InvalidResponse(_))
+        ));
+
+        // Even when every nested artifact remains issuer-signed, a sync that
+        // relabels the unacknowledged reset head as an ordinary pending
+        // revocation must fail closed rather than downgrading it to history.
+        let mut downgraded_pending: MaplePairingRevocationListResponse =
+            fixture_value("reset_clear_list_revocations_response");
+        downgraded_pending.revocation_sync.status = MapleRevocationSyncStatusV1::RevocationsPending;
+        downgraded_pending.revocation_sync.reset_clear_instruction = None;
+        assert!(matches!(
+            downgraded_pending.verify_for(&pending_request, &issuers),
+            Err(Error::InvalidResponse(_))
+        ));
+    }
+
+    #[test]
+    fn reset_clear_ack_requires_successful_durable_full_scope_callback() {
+        let issuers = trusted_issuers();
+        let request: ListMaplePairingRevocationsRequest =
+            fixture_value("reset_clear_list_revocations_request");
+        let response: MaplePairingRevocationListResponse =
+            fixture_value("reset_clear_list_revocations_response");
+        let failure_latest = response
+            .clone()
+            .verify_for(&request, &issuers)
+            .unwrap()
+            .into_reset_clear_instruction()
+            .unwrap();
+        let failure = failure_latest.after_durable_full_scope_admission_clear(|_| {
+            Err(Error::Io(std::io::Error::other("durable commit failed")))
+        });
+        assert!(matches!(failure, Err(Error::Io(_))));
+
+        let expected_sync: MapleRevocationSyncV1 = fixture_value("reset_clear_pending_sync");
+        let expected_instruction = expected_sync.reset_clear_instruction.unwrap();
+        // A failed callback consumes the linear capability. Re-fetching and
+        // verifying current signed state is required before another attempt.
+        let latest = response
+            .verify_for(&request, &issuers)
+            .unwrap()
+            .into_reset_clear_instruction()
+            .unwrap();
+        let cleared = latest
+            .after_durable_full_scope_admission_clear(|instruction| {
+                assert_eq!(instruction, &expected_instruction);
+                Ok(())
+            })
+            .unwrap();
+        let literal: AckMaplePairingRevocationRequest = fixture_value("reset_clear_ack_request");
+        let prepared = AckMaplePairingRevocationRequest::unsigned_v1_after_durable_reset_clear(
+            literal.operation_id,
+            cleared,
+        )
+        .unwrap();
+        let exact_retry = prepared.clone();
+        assert_eq!(exact_retry.as_inner(), prepared.as_inner());
+        let ack_response: MaplePairingRevocationAckResponse =
+            fixture_value("reset_clear_ack_response");
+        ack_response
+            .clone()
+            .verify_for(&literal, &trusted_issuers())
+            .unwrap();
+        let mut zero_time = ack_response.clone();
+        zero_time.accepted_at_unix_ms = 0;
+        zero_time.verify_for(&literal, &trusted_issuers()).unwrap();
+        let mut negative_time = ack_response;
+        negative_time.accepted_at_unix_ms = -1;
+        assert!(matches!(
+            negative_time.verify_for(&literal, &trusted_issuers()),
+            Err(Error::InvalidResponse(_))
+        ));
+        assert_eq!(
+            prepared.as_inner(),
+            &AckMaplePairingRevocationRequest {
+                signature: String::new(),
+                ..literal
+            }
+        );
+    }
+
+    #[test]
+    fn ack_receipt_does_not_establish_current_readiness() {
+        let issuers = trusted_issuers();
+        let request: AckMaplePairingRevocationRequest = fixture_value("reset_clear_ack_request");
+        let response: MaplePairingRevocationAckResponse = fixture_value("reset_clear_ack_response");
+        let receipt = response.verify_for(&request, &issuers).unwrap();
+        assert_eq!(receipt.operation_id(), request.operation_id);
+        assert_eq!(receipt.event_id(), request.event_id);
+        assert_eq!(
+            receipt.last_acked_issuer_sequence(),
+            request.issuer_sequence
+        );
+
+        // An exact retry may still return the receipt above after the signed
+        // current head has advanced. Only this separately fetched and verified
+        // sync can establish current readiness.
+        let later_request: ListMaplePairingRevocationsRequest =
+            fixture_value("reset_clear_historical_later_request");
+        let later_response: MaplePairingRevocationListResponse =
+            fixture_value("reset_clear_historical_later_response");
+        let current = later_response.verify_for(&later_request, &issuers).unwrap();
+        assert_eq!(
+            current.revocation_sync.as_inner().status,
+            MapleRevocationSyncStatusV1::RevocationsPending
+        );
+        assert_eq!(
+            current
+                .revocation_sync
+                .checkpoint()
+                .as_inner()
+                .last_issued_issuer_sequence,
+            2
+        );
+        assert_eq!(
+            current
+                .revocation_sync
+                .checkpoint()
+                .as_inner()
+                .last_acked_issuer_sequence,
+            receipt.last_acked_issuer_sequence()
+        );
+    }
+}

--- a/rust/src/pairing.rs
+++ b/rust/src/pairing.rs
@@ -1928,19 +1928,22 @@ impl ApproveMaplePairingRequest {
 
 impl ConfirmMaplePairingRequest {
     /// Builds the unsigned host-commit request after the caller has durably
-    /// promoted its local approval record.
+    /// written the approval to a non-admitting stage and reconciled it against
+    /// a fresh current `awaiting_host_commit` STATUS.
     ///
-    /// The verified authorization supplies the exact pair lineage and digest;
-    /// this constructor does not persist anything and deliberately does not
-    /// send or auto-confirm. The caller must sign the returned prepared value's
-    /// canonical transcript with the host installation key, attach it through
+    /// The staged authorization supplies the exact pair lineage and digest;
+    /// this constructor does not persist, admit, send, or auto-confirm. The
+    /// caller must sign the returned prepared value's canonical transcript
+    /// with the host installation key, attach it through
     /// `PreparedMaplePairingHostCommitV1::with_signature`, and invoke
-    /// `OpenSecretClient::confirm_maple_pairing` separately.
-    pub fn unsigned_v1_after_durable_commit(
+    /// `OpenSecretClient::confirm_maple_pairing` separately. Even a successful
+    /// CONFIRM receipt is historical-capable and cannot promote the stage; a
+    /// second fresh current `active` STATUS must match it exactly.
+    pub fn unsigned_v1_after_durable_stage(
         operation_id: Uuid,
         ready: &HostCommitReadyMaplePairAuthorizationV1,
     ) -> Result<PreparedMaplePairingHostCommitV1> {
-        let authorization = ready.authorization().as_inner();
+        let authorization = ready.staged_authorization().as_inner();
         let request = Self {
             protocol_version: MAPLE_PAIRING_PROTOCOL_VERSION,
             transcript_version: MAPLE_PAIRING_TRANSCRIPT_VERSION,
@@ -3804,25 +3807,119 @@ impl VerifiedMaplePairAuthorizationV1 {
     }
 }
 
-/// An awaiting-host-commit authorization whose status revision and host role
-/// were verified. This is the only input accepted by the manual confirm
-/// constructor, preventing active or revoked historical artifacts from being
-/// reinstalled and reconfirmed.
+/// Issuer-verified approval material that may only be written to a
+/// non-admitting durable stage.
+///
+/// This value can come from an exact-operation APPROVE receipt that is
+/// historical by the time it is replayed. It is therefore not evidence of the
+/// pair's current lifecycle state and must never be installed as an active
+/// admission. Use [`Self::after_durable_stage`] to obtain the only staged type
+/// accepted by a later fresh-status reconciliation.
+#[derive(Clone)]
+pub struct NonAdmittingMaplePairAuthorizationStageV1 {
+    authorization: VerifiedMaplePairAuthorizationV1,
+}
+
+redacted_debug!(NonAdmittingMaplePairAuthorizationStageV1);
+
+impl NonAdmittingMaplePairAuthorizationStageV1 {
+    pub fn as_inner(&self) -> &MaplePairAuthorizationV1 {
+        self.authorization.as_inner()
+    }
+
+    pub fn transcript_digest(&self) -> Result<String> {
+        self.authorization.transcript_digest()
+    }
+
+    /// Runs the caller's durable, non-admitting stage write before minting the
+    /// capability accepted by current-status reconciliation.
+    ///
+    /// The callback must not update the host's active admission set. If the
+    /// write is ambiguous or fails, return an error and retain/retry the exact
+    /// APPROVE operation rather than treating the authorization as admitted.
+    pub fn after_durable_stage<F>(self, persist: F) -> Result<DurablyStagedMaplePairAuthorizationV1>
+    where
+        F: FnOnce(&MaplePairAuthorizationV1) -> Result<()>,
+    {
+        persist(self.authorization.as_inner())?;
+        Ok(DurablyStagedMaplePairAuthorizationV1 {
+            authorization: self.authorization,
+        })
+    }
+}
+
+/// An issuer-verified pair authorization persisted in a durable,
+/// non-admitting stage.
+///
+/// This remains non-admitting until a fresh current STATUS reports `active`
+/// for the exact staged authorization and yields an
+/// [`AdmissionReadyMaplePairAuthorizationV1`].
+#[derive(Clone)]
+pub struct DurablyStagedMaplePairAuthorizationV1 {
+    authorization: VerifiedMaplePairAuthorizationV1,
+}
+
+redacted_debug!(DurablyStagedMaplePairAuthorizationV1);
+
+impl DurablyStagedMaplePairAuthorizationV1 {
+    pub fn as_inner(&self) -> &MaplePairAuthorizationV1 {
+        self.authorization.as_inner()
+    }
+
+    pub fn transcript_digest(&self) -> Result<String> {
+        self.authorization.transcript_digest()
+    }
+}
+
+/// A durably staged authorization whose exact pair, incarnation, namespace,
+/// and digest were matched by a fresh current host STATUS in
+/// `awaiting_host_commit` state.
+///
+/// This is the only input accepted by the manual CONFIRM constructor. It is
+/// still non-admitting: confirmation and a second fresh current `active`
+/// STATUS are required before promotion.
 #[derive(Clone)]
 pub struct HostCommitReadyMaplePairAuthorizationV1 {
-    authorization: VerifiedMaplePairAuthorizationV1,
+    staged_authorization: DurablyStagedMaplePairAuthorizationV1,
     expected_pairing_revision: i64,
 }
 
 redacted_debug!(HostCommitReadyMaplePairAuthorizationV1);
 
 impl HostCommitReadyMaplePairAuthorizationV1 {
-    pub fn authorization(&self) -> &VerifiedMaplePairAuthorizationV1 {
-        &self.authorization
+    pub fn staged_authorization(&self) -> &DurablyStagedMaplePairAuthorizationV1 {
+        &self.staged_authorization
     }
 
     pub fn expected_pairing_revision(&self) -> i64 {
         self.expected_pairing_revision
+    }
+}
+
+/// A pair authorization that a fresh current host STATUS reported as active
+/// and matched exactly to the caller's durable non-admitting stage and
+/// reconciled revocation namespace.
+///
+/// This is the only SDK capability intended for promotion into the host's
+/// active admission set. Mutation receipts never construct this type.
+#[derive(Clone)]
+pub struct AdmissionReadyMaplePairAuthorizationV1 {
+    authorization: VerifiedMaplePairAuthorizationV1,
+}
+
+redacted_debug!(AdmissionReadyMaplePairAuthorizationV1);
+
+impl AdmissionReadyMaplePairAuthorizationV1 {
+    pub fn as_inner(&self) -> &MaplePairAuthorizationV1 {
+        self.authorization.as_inner()
+    }
+
+    pub fn into_inner(self) -> MaplePairAuthorizationV1 {
+        self.authorization.into_inner()
+    }
+
+    pub fn transcript_digest(&self) -> Result<String> {
+        self.authorization.transcript_digest()
     }
 }
 
@@ -3890,8 +3987,13 @@ impl VerifiedMaplePairingStatusV1 {
         self.status
     }
 
-    /// Returns the authorization only after the enclosing status verifier has
-    /// bound it to the status's issuer-verified request ticket.
+    /// Returns an issuer-verified authorization after the enclosing status
+    /// verifier bound it to the signed request ticket.
+    ///
+    /// This artifact alone is not current admission authority. Mutation
+    /// receipts may be historical, and a current non-active status must not be
+    /// admitted. Use the fresh-status capabilities on
+    /// [`VerifiedMaplePairingStatusResponse`] for host materialization.
     pub fn pair_authorization(&self) -> Option<VerifiedMaplePairAuthorizationV1> {
         self.status.pair_authorization.clone().map(|authorization| {
             // Construction of `Self` already verified and bound this artifact
@@ -3901,25 +4003,23 @@ impl VerifiedMaplePairingStatusV1 {
         })
     }
 
-    /// Returns a host-commit-ready authorization only for a verified host view
-    /// in `awaiting_host_commit` state whose namespace matches the host's
-    /// durably reconciled revocation stream.
-    pub fn host_commit_ready_authorization(
+    fn authorization_matching_durable_stage(
         &self,
-        revocation_stream: &DurablyReconciledMapleRevocationStreamV1,
-    ) -> Option<HostCommitReadyMaplePairAuthorizationV1> {
-        if self.status.state != MaplePairingState::AwaitingHostCommit || self.status.revision != 2 {
-            return None;
+        staged: &DurablyStagedMaplePairAuthorizationV1,
+    ) -> Result<VerifiedMaplePairAuthorizationV1> {
+        let authorization = self.pair_authorization().ok_or_else(|| {
+            Error::InvalidResponse(
+                "Current Maple pairing status omitted the staged pair authorization; fence or remove the non-admitting stage"
+                    .to_string(),
+            )
+        })?;
+        if authorization.as_inner() != staged.as_inner() {
+            return Err(Error::InvalidResponse(
+                "Current Maple pairing status does not exactly match the staged authorization; fence or remove the non-admitting stage"
+                    .to_string(),
+            ));
         }
-        self.pair_authorization().and_then(|authorization| {
-            revocation_stream
-                .validate_authorization(authorization.as_inner())
-                .ok()?;
-            Some(HostCommitReadyMaplePairAuthorizationV1 {
-                authorization,
-                expected_pairing_revision: self.status.revision,
-            })
-        })
+        Ok(authorization)
     }
 }
 
@@ -4306,6 +4406,117 @@ pub struct VerifiedMaplePairingMutationResponse {
 
 redacted_debug!(VerifiedMaplePairingMutationResponse);
 
+/// Verified historical-capable receipt for one exact APPROVE operation.
+///
+/// The contained issuer-verified authorization may only enter a durable,
+/// non-admitting stage. This receipt deliberately exposes no verified pairing
+/// status and cannot construct [`HostCommitReadyMaplePairAuthorizationV1`]: an
+/// exact operation replay may return it after the pair was activated or
+/// revoked. After staging, fetch and verify a fresh current host STATUS and use
+/// [`VerifiedMaplePairingStatusResponse::confirm_ready_after_durable_stage`].
+///
+/// ```compile_fail
+/// use opensecret::{
+///     AdmissionReadyMaplePairAuthorizationV1,
+///     VerifiedMaplePairingApprovalReceipt,
+/// };
+///
+/// fn admit(_: AdmissionReadyMaplePairAuthorizationV1) {}
+///
+/// fn historical_approval_cannot_admit(receipt: VerifiedMaplePairingApprovalReceipt) {
+///     admit(receipt.into_non_admitting_stage());
+/// }
+/// ```
+#[derive(Clone)]
+pub struct VerifiedMaplePairingApprovalReceipt {
+    protocol_version: u16,
+    operation_id: Uuid,
+    pairing_request_id: Uuid,
+    pair_id: Uuid,
+    pairing_incarnation: u64,
+    non_admitting_stage: NonAdmittingMaplePairAuthorizationStageV1,
+}
+
+redacted_debug!(VerifiedMaplePairingApprovalReceipt);
+
+impl VerifiedMaplePairingApprovalReceipt {
+    pub fn protocol_version(&self) -> u16 {
+        self.protocol_version
+    }
+
+    pub fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+
+    pub fn pairing_request_id(&self) -> Uuid {
+        self.pairing_request_id
+    }
+
+    pub fn pair_id(&self) -> Uuid {
+        self.pair_id
+    }
+
+    pub fn pairing_incarnation(&self) -> u64 {
+        self.pairing_incarnation
+    }
+
+    pub fn non_admitting_stage(&self) -> &NonAdmittingMaplePairAuthorizationStageV1 {
+        &self.non_admitting_stage
+    }
+
+    pub fn into_non_admitting_stage(self) -> NonAdmittingMaplePairAuthorizationStageV1 {
+        self.non_admitting_stage
+    }
+}
+
+/// Verified historical-capable receipt for one exact CONFIRM operation.
+///
+/// This proves that the exact submitted operation once succeeded. It exposes
+/// no pairing status or admission capability because a replay may return the
+/// same receipt after a later revocation. Fetch and verify a fresh current host
+/// STATUS, then reconcile the durable stage with
+/// [`VerifiedMaplePairingStatusResponse::admission_ready_after_confirm`].
+///
+/// ```compile_fail
+/// use opensecret::VerifiedMaplePairingConfirmationReceipt;
+///
+/// fn historical_confirm_is_not_current(receipt: VerifiedMaplePairingConfirmationReceipt) {
+///     let _ = receipt.pairing;
+/// }
+/// ```
+#[derive(Clone)]
+pub struct VerifiedMaplePairingConfirmationReceipt {
+    protocol_version: u16,
+    operation_id: Uuid,
+    pairing_request_id: Uuid,
+    pair_id: Uuid,
+    pairing_incarnation: u64,
+}
+
+redacted_debug!(VerifiedMaplePairingConfirmationReceipt);
+
+impl VerifiedMaplePairingConfirmationReceipt {
+    pub fn protocol_version(&self) -> u16 {
+        self.protocol_version
+    }
+
+    pub fn operation_id(&self) -> Uuid {
+        self.operation_id
+    }
+
+    pub fn pairing_request_id(&self) -> Uuid {
+        self.pairing_request_id
+    }
+
+    pub fn pair_id(&self) -> Uuid {
+        self.pair_id
+    }
+
+    pub fn pairing_incarnation(&self) -> u64 {
+        self.pairing_incarnation
+    }
+}
+
 #[derive(Clone)]
 pub struct VerifiedMaplePairingListResponse {
     pub protocol_version: u16,
@@ -4323,9 +4534,72 @@ pub struct VerifiedMaplePairingStatusResponse {
     pub protocol_version: u16,
     pub query_id: Uuid,
     pub pairing: VerifiedMaplePairingStatusV1,
+    role: MaplePairingRole,
 }
 
 redacted_debug!(VerifiedMaplePairingStatusResponse);
+
+impl VerifiedMaplePairingStatusResponse {
+    /// Reconciles a durable non-admitting stage against one fresh current host
+    /// STATUS before constructing the manual CONFIRM capability.
+    ///
+    /// The status must be the host view in `awaiting_host_commit` revision 2,
+    /// and its full issuer-verified authorization (including digest,
+    /// incarnation, and revocation namespace) must exactly equal the staged
+    /// value. Any verified current conflict, expiry, revocation, or mismatch is
+    /// a fail-closed instruction for the caller to fence or remove the stage.
+    /// An ambiguous network error before a current status is obtained leaves
+    /// the stage non-admitting and retryable.
+    pub fn confirm_ready_after_durable_stage(
+        &self,
+        staged: &DurablyStagedMaplePairAuthorizationV1,
+        revocation_stream: &DurablyReconciledMapleRevocationStreamV1,
+    ) -> Result<HostCommitReadyMaplePairAuthorizationV1> {
+        if self.role != MaplePairingRole::Host
+            || self.pairing.status.state != MaplePairingState::AwaitingHostCommit
+            || self.pairing.status.revision != 2
+        {
+            return Err(Error::InvalidResponse(
+                "Current Maple host status is not awaiting host commit; fence or remove the non-admitting stage"
+                    .to_string(),
+            ));
+        }
+        let authorization = self.pairing.authorization_matching_durable_stage(staged)?;
+        revocation_stream.validate_authorization(authorization.as_inner())?;
+        Ok(HostCommitReadyMaplePairAuthorizationV1 {
+            staged_authorization: staged.clone(),
+            expected_pairing_revision: self.pairing.status.revision,
+        })
+    }
+
+    /// Reconciles a durable non-admitting stage against one fresh current host
+    /// STATUS after CONFIRM.
+    ///
+    /// Only an exact host `active` revision 3 match in the reconciled
+    /// revocation namespace yields a capability intended for promotion into
+    /// the active admission set. A CONFIRM mutation receipt never yields this
+    /// type because exact-operation receipts may be historical after a later
+    /// revocation. Any verified current non-active state or mismatch must fence
+    /// or remove the stage; an ambiguous network error leaves it staged.
+    pub fn admission_ready_after_confirm(
+        &self,
+        staged: &DurablyStagedMaplePairAuthorizationV1,
+        revocation_stream: &DurablyReconciledMapleRevocationStreamV1,
+    ) -> Result<AdmissionReadyMaplePairAuthorizationV1> {
+        if self.role != MaplePairingRole::Host
+            || self.pairing.status.state != MaplePairingState::Active
+            || self.pairing.status.revision != 3
+        {
+            return Err(Error::InvalidResponse(
+                "Current Maple host status is not active; fence or remove the non-admitting stage"
+                    .to_string(),
+            ));
+        }
+        let authorization = self.pairing.authorization_matching_durable_stage(staged)?;
+        revocation_stream.validate_authorization(authorization.as_inner())?;
+        Ok(AdmissionReadyMaplePairAuthorizationV1 { authorization })
+    }
+}
 
 pub struct VerifiedMaplePairingRevocationListResponse {
     pub protocol_version: u16,
@@ -4495,7 +4769,7 @@ impl MaplePairingMutationResponse {
         request: &ApproveMaplePairingRequest,
         issuers: &MaplePairingIssuerKeySet,
         trusted_now_unix_ms: i64,
-    ) -> Result<VerifiedMaplePairingMutationResponse> {
+    ) -> Result<VerifiedMaplePairingApprovalReceipt> {
         self.verify_mutation_binding(
             MutationExpectation {
                 operation_id: request.operation_id,
@@ -4534,7 +4808,19 @@ impl MaplePairingMutationResponse {
                 "Maple approval receipt does not bind the submitted host approval".to_string(),
             ));
         }
-        self.into_verified(MaplePairingRole::Host, issuers, trusted_now_unix_ms)
+        Ok(VerifiedMaplePairingApprovalReceipt {
+            protocol_version: self.protocol_version,
+            operation_id: self.operation_id,
+            pairing_request_id: self.pairing.pairing_request_id,
+            pair_id: self.pairing.pair_id,
+            pairing_incarnation: self.pairing.pairing_incarnation,
+            non_admitting_stage: NonAdmittingMaplePairAuthorizationStageV1 {
+                // `verify_mutation_binding` verified the enclosing host status,
+                // including this ticket-bound issuer signature. The stage is
+                // intentionally not a current-state or admission capability.
+                authorization: VerifiedMaplePairAuthorizationV1(authorization.clone()),
+            },
+        })
     }
 
     pub(crate) fn verify_confirm(
@@ -4542,7 +4828,7 @@ impl MaplePairingMutationResponse {
         request: &ConfirmMaplePairingRequest,
         issuers: &MaplePairingIssuerKeySet,
         trusted_now_unix_ms: i64,
-    ) -> Result<VerifiedMaplePairingMutationResponse> {
+    ) -> Result<VerifiedMaplePairingConfirmationReceipt> {
         self.verify_mutation_binding(
             MutationExpectation {
                 operation_id: request.operation_id,
@@ -4570,7 +4856,13 @@ impl MaplePairingMutationResponse {
                     .to_string(),
             ));
         }
-        self.into_verified(MaplePairingRole::Host, issuers, trusted_now_unix_ms)
+        Ok(VerifiedMaplePairingConfirmationReceipt {
+            protocol_version: self.protocol_version,
+            operation_id: self.operation_id,
+            pairing_request_id: self.pairing.pairing_request_id,
+            pair_id: self.pairing.pair_id,
+            pairing_incarnation: self.pairing.pairing_incarnation,
+        })
     }
 
     pub(crate) fn verify_revoke(
@@ -4791,6 +5083,7 @@ impl MaplePairingStatusResponse {
             pairing: self
                 .pairing
                 .verify(issuers, actor_role, trusted_now_unix_ms)?,
+            role: actor_role,
         })
     }
 }
@@ -5339,16 +5632,66 @@ mod tests {
         .expect("exact key length")
     }
 
-    fn resign_revocation(mut revocation: MaplePairRevocationV1) -> MaplePairRevocationV1 {
+    fn fixture_signing_key(name: &str) -> SigningKey {
         let seed = hex::decode(
-            fixture()["test_private_seeds_hex"]["issuer"]
+            fixture()["test_private_seeds_hex"][name]
                 .as_str()
-                .unwrap(),
+                .expect("fixture signing seed"),
         )
-        .unwrap();
-        let seed: [u8; 32] = seed.try_into().unwrap();
+        .expect("hex fixture signing seed");
+        let seed: [u8; 32] = seed.try_into().expect("exact fixture signing seed length");
+        SigningKey::from_bytes(&seed)
+    }
+
+    fn historical_approval_receipt() -> MaplePairingMutationResponse {
+        let approval: ApproveMaplePairingRequest = fixture_value("approval_request");
+        let mut receipt: MaplePairingMutationResponse = fixture_value("active_receipt");
+        receipt.operation_id = approval.operation_id;
+        receipt.pairing.state = MaplePairingState::AwaitingHostCommit;
+        receipt.pairing.revision = 2;
+        receipt.pairing.activated_at_unix_ms = None;
+        receipt
+    }
+
+    fn current_host_status(
+        pairing: MaplePairingStatusV1,
+        trusted_now_unix_ms: i64,
+    ) -> VerifiedMaplePairingStatusResponse {
+        let host_claim = pairing
+            .request_ticket
+            .as_ref()
+            .expect("fixture status ticket")
+            .host
+            .clone();
+        let mut request: MaplePairingStatusRequest = fixture_value("pairing_status_request");
+        request.actor_registration_id = host_claim.registration_id;
+        request.pair_id = pairing.pair_id;
+        request.signature.clear();
+        request.signature = BASE64.encode(
+            fixture_signing_key("host")
+                .sign(&request.canonical_transcript().unwrap())
+                .to_bytes(),
+        );
+        request
+            .validate_with_signing_key(&claim_signing_key(&host_claim))
+            .unwrap();
+        MaplePairingStatusResponse {
+            protocol_version: MAPLE_PAIRING_PROTOCOL_VERSION,
+            query_id: request.query_id,
+            pairing,
+        }
+        .verify_for(
+            &request,
+            MaplePairingRole::Host,
+            &trusted_issuers(),
+            trusted_now_unix_ms,
+        )
+        .unwrap()
+    }
+
+    fn resign_revocation(mut revocation: MaplePairRevocationV1) -> MaplePairRevocationV1 {
         let signature =
-            SigningKey::from_bytes(&seed).sign(&revocation.canonical_transcript().unwrap());
+            fixture_signing_key("issuer").sign(&revocation.canonical_transcript().unwrap());
         revocation.issuer_signature = BASE64.encode(signature.to_bytes());
         revocation
     }
@@ -5470,11 +5813,17 @@ mod tests {
                 authorization.approved_at_unix_ms,
             )
             .unwrap();
+        assert_eq!(verified_active.protocol_version(), 1);
+        assert_eq!(verified_active.operation_id(), confirm.operation_id);
         assert_eq!(
-            verified_active.pairing.as_inner().state,
-            MaplePairingState::Active
+            verified_active.pairing_request_id(),
+            confirm.pairing_request_id
         );
-        assert_eq!(verified_active.pairing.as_inner().revision, 3);
+        assert_eq!(verified_active.pair_id(), confirm.pair_id);
+        assert_eq!(
+            verified_active.pairing_incarnation(),
+            confirm.pairing_incarnation
+        );
 
         let revocation: MaplePairRevocationV1 = fixture_value("pair_revocation");
         assert_eq!(
@@ -5733,24 +6082,93 @@ mod tests {
     }
 
     #[test]
-    fn host_commit_is_manual_and_derived_from_verified_authorization() {
+    fn historical_approval_and_confirm_receipts_are_non_promotable() {
+        let approval: ApproveMaplePairingRequest = fixture_value("approval_request");
+        let approval_wire = historical_approval_receipt();
+        let approved_at = approval_wire.pairing.approved_at_unix_ms.unwrap();
+        let approval_receipt = approval_wire
+            .verify_approve(&approval, &trusted_issuers(), approved_at)
+            .unwrap();
+        assert_eq!(approval_receipt.operation_id(), approval.operation_id);
+        assert_eq!(approval_receipt.pair_id(), approval.pair_id);
+        assert_eq!(approval_receipt.pairing_incarnation(), 3);
+        assert_eq!(
+            approval_receipt
+                .non_admitting_stage()
+                .transcript_digest()
+                .unwrap(),
+            fixture_string("pair_authorization_digest")
+        );
+
+        let confirm: ConfirmMaplePairingRequest = fixture_value("confirm_request");
         let active_receipt: MaplePairingMutationResponse = fixture_value("active_receipt");
-        let mut awaiting = active_receipt.pairing;
-        awaiting.state = MaplePairingState::AwaitingHostCommit;
-        awaiting.revision = 2;
-        awaiting.activated_at_unix_ms = None;
-        let verified_status = awaiting
-            .verify(
-                &trusted_issuers(),
-                MaplePairingRole::Host,
-                awaiting.approved_at_unix_ms.unwrap(),
-            )
+        let confirmation_receipt = active_receipt
+            .verify_confirm(&confirm, &trusted_issuers(), approved_at)
             .unwrap();
+        assert_eq!(confirmation_receipt.operation_id(), confirm.operation_id);
+        assert_eq!(confirmation_receipt.pair_id(), confirm.pair_id);
+        assert_eq!(confirmation_receipt.pairing_incarnation(), 3);
+
+        for debug in [
+            format!("{approval_receipt:?}"),
+            format!("{confirmation_receipt:?}"),
+        ] {
+            assert!(debug.contains("[redacted]"));
+            assert!(!debug.contains(&approval.pair_id.to_string()));
+            assert!(!debug.contains(&fixture_string("pair_authorization_digest")));
+        }
+    }
+
+    #[test]
+    fn fresh_current_status_controls_confirm_and_admission_promotion() {
+        let failed_approval_wire = historical_approval_receipt();
+        let failed_approved_at = failed_approval_wire.pairing.approved_at_unix_ms.unwrap();
+        let failed_approval: ApproveMaplePairingRequest = fixture_value("approval_request");
+        let mut failed_stage_write_attempted = false;
+        let failed_stage = failed_approval_wire
+            .verify_approve(&failed_approval, &trusted_issuers(), failed_approved_at)
+            .unwrap()
+            .into_non_admitting_stage()
+            .after_durable_stage(|_| {
+                failed_stage_write_attempted = true;
+                Err(Error::Configuration(
+                    "simulated durable stage failure".to_string(),
+                ))
+            });
+        assert!(failed_stage_write_attempted);
+        assert!(failed_stage.is_err());
+
+        let approval_wire = historical_approval_receipt();
+        let awaiting = approval_wire.pairing.clone();
+        let approved_at = awaiting.approved_at_unix_ms.unwrap();
+        let approval: ApproveMaplePairingRequest = fixture_value("approval_request");
+        let approval_receipt = approval_wire
+            .verify_approve(&approval, &trusted_issuers(), approved_at)
+            .unwrap();
+        let mut persisted_non_admitting = false;
+        let staged = approval_receipt
+            .into_non_admitting_stage()
+            .after_durable_stage(|authorization| {
+                assert_eq!(
+                    authorization.transcript_digest().unwrap(),
+                    fixture_string("pair_authorization_digest")
+                );
+                persisted_non_admitting = true;
+                Ok(())
+            })
+            .unwrap();
+        assert!(persisted_non_admitting);
+
         let stream = reconciled_stream("revocation_stream_checkpoint");
-        let ready = verified_status
-            .host_commit_ready_authorization(&stream)
+        let current_awaiting = current_host_status(awaiting, approved_at);
+        let wrong_stream = reconciled_stream("discovery_revocation_stream_checkpoint");
+        assert!(current_awaiting
+            .confirm_ready_after_durable_stage(&staged, &wrong_stream)
+            .is_err());
+        let ready = current_awaiting
+            .confirm_ready_after_durable_stage(&staged, &stream)
             .unwrap();
-        let unsigned = ConfirmMaplePairingRequest::unsigned_v1_after_durable_commit(
+        let unsigned = ConfirmMaplePairingRequest::unsigned_v1_after_durable_stage(
             Uuid::parse_str("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee").unwrap(),
             &ready,
         )
@@ -5771,15 +6189,52 @@ mod tests {
         );
 
         let active_response: MaplePairingStatusResponse = fixture_value("pairing_status_response");
-        let active = active_response
-            .pairing
-            .verify(
-                &trusted_issuers(),
+        let active_at = active_response.pairing.activated_at_unix_ms.unwrap();
+        let current_active = current_host_status(active_response.pairing, active_at);
+        let admission = current_active
+            .admission_ready_after_confirm(&staged, &stream)
+            .unwrap();
+        assert_eq!(
+            admission.transcript_digest().unwrap(),
+            fixture_string("pair_authorization_digest")
+        );
+        assert!(current_active
+            .confirm_ready_after_durable_stage(&staged, &stream)
+            .is_err());
+        assert!(current_awaiting
+            .admission_ready_after_confirm(&staged, &stream)
+            .is_err());
+
+        let mut mismatched_stage = staged.clone();
+        mismatched_stage.authorization.0.pairing_incarnation += 1;
+        assert!(current_awaiting
+            .confirm_ready_after_durable_stage(&mismatched_stage, &stream)
+            .is_err());
+        assert!(current_active
+            .admission_ready_after_confirm(&mismatched_stage, &stream)
+            .is_err());
+
+        let controller_request: MaplePairingStatusRequest = fixture_value("pairing_status_request");
+        let controller_response: MaplePairingStatusResponse =
+            fixture_value("pairing_status_response");
+        let controller_current = controller_response
+            .verify_for(
+                &controller_request,
                 MaplePairingRole::Controller,
-                active_response.pairing.activated_at_unix_ms.unwrap(),
+                &trusted_issuers(),
+                active_at,
             )
             .unwrap();
-        assert!(active.host_commit_ready_authorization(&stream).is_none());
+        assert!(controller_current
+            .admission_ready_after_confirm(&staged, &stream)
+            .is_err());
+
+        let revoke_receipt: MaplePairingMutationResponse = fixture_value("revoke_receipt");
+        let revoked_at = revoke_receipt.pairing.revoked_at_unix_ms.unwrap();
+        let current_revoked = current_host_status(revoke_receipt.pairing, revoked_at);
+        assert!(current_revoked
+            .admission_ready_after_confirm(&staged, &stream)
+            .is_err());
     }
 
     #[test]
@@ -5946,9 +6401,6 @@ mod tests {
             )
             .unwrap();
         assert!(verified.pair_authorization().is_none());
-        assert!(verified
-            .host_commit_ready_authorization(&reconciled_stream("revocation_stream_checkpoint"))
-            .is_none());
         assert!(controller_view
             .verify(
                 &issuers,

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1,6 +1,9 @@
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use chrono::{DateTime, Utc};
+use ring::signature::{UnparsedPublicKey, ED25519};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
+use std::{collections::HashSet, net::SocketAddr};
 use uuid::Uuid;
 
 // Attestation & Key Exchange Types
@@ -235,6 +238,783 @@ pub struct AppUser {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserResponse {
     pub user: AppUser,
+}
+
+// Maple Remote Device Types
+
+/// Current version of the Maple remote-device registration contract.
+pub const MAPLE_DEVICE_PROTOCOL_VERSION: u16 = 1;
+
+/// Current version of the server-reconstructed canonical registration transcript.
+pub const MAPLE_DEVICE_TRANSCRIPT_VERSION: u16 = 1;
+
+/// Default Maple device-directory page size applied by the server.
+pub const MAPLE_DEVICE_LIST_DEFAULT_LIMIT: u16 = 25;
+
+/// Largest Maple device-directory page accepted by the Rust SDK.
+pub const MAPLE_DEVICE_LIST_MAX_LIMIT: u16 = 100;
+
+/// Largest opaque Maple device-directory cursor accepted from a caller.
+pub const MAPLE_DEVICE_LIST_MAX_CURSOR_BYTES: usize = 512;
+
+/// Maximum relay routes carried in one signed Iroh endpoint address.
+pub const MAPLE_DEVICE_MAX_RELAY_URLS: usize = 4;
+
+/// Maximum direct socket routes carried in one signed Iroh endpoint address.
+pub const MAPLE_DEVICE_MAX_DIRECT_ADDRESSES: usize = 16;
+
+/// Maximum encoded length of one canonical relay URL.
+pub const MAPLE_DEVICE_MAX_RELAY_URL_BYTES: usize = 512;
+
+/// Maximum encoded length of one canonical direct `SocketAddr`.
+pub const MAPLE_DEVICE_MAX_DIRECT_ADDRESS_BYTES: usize = 64;
+
+/// Bounded, non-secret routing information for one Iroh endpoint.
+///
+/// This intentionally represents only Iroh relay URLs and direct socket
+/// addresses. It cannot carry an endpoint secret key or an opaque/custom Iroh
+/// transport address. Direct routes may be public, private, or loopback
+/// unicast addresses. The device directory itself is encrypted; callers must
+/// treat all routes as sensitive network metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MapleIrohEndpointAddr {
+    pub relay_urls: Vec<String>,
+    pub direct_addresses: Vec<String>,
+}
+
+struct ValidatedMapleDeviceTranscript<'a> {
+    identity_public_key: [u8; 32],
+    iroh_endpoint_key: [u8; 32],
+    relay_urls: Vec<&'a str>,
+    direct_addresses: Vec<&'a str>,
+    capabilities: Vec<&'a str>,
+}
+
+impl MapleIrohEndpointAddr {
+    /// Builds the canonical JSON form used by registration and list records.
+    pub fn canonical_v1(
+        relay_urls: Vec<String>,
+        direct_addresses: Vec<String>,
+    ) -> crate::Result<Self> {
+        let candidate = Self {
+            relay_urls,
+            direct_addresses,
+        };
+        let (relay_urls, direct_addresses) = candidate.canonical_parts()?;
+        Ok(Self {
+            relay_urls: relay_urls.into_iter().map(str::to_owned).collect(),
+            direct_addresses: direct_addresses.into_iter().map(str::to_owned).collect(),
+        })
+    }
+
+    /// Validates that the DTO contains only bounded, non-secret Iroh routes.
+    pub fn validate(&self) -> crate::Result<()> {
+        let (relay_urls, direct_addresses) = self.canonical_parts()?;
+        if relay_urls.as_slice() != self.relay_urls
+            || direct_addresses.as_slice() != self.direct_addresses
+        {
+            return Err(crate::Error::Configuration(
+                "Maple Iroh endpoint routes must use canonical sorted order".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn canonical_parts(&self) -> crate::Result<(Vec<&str>, Vec<&str>)> {
+        if self.relay_urls.len() > MAPLE_DEVICE_MAX_RELAY_URLS {
+            return Err(crate::Error::Configuration(format!(
+                "Maple Iroh endpoint supports at most {MAPLE_DEVICE_MAX_RELAY_URLS} relay URLs"
+            )));
+        }
+        if self.direct_addresses.len() > MAPLE_DEVICE_MAX_DIRECT_ADDRESSES {
+            return Err(crate::Error::Configuration(format!(
+                "Maple Iroh endpoint supports at most {MAPLE_DEVICE_MAX_DIRECT_ADDRESSES} direct addresses"
+            )));
+        }
+        if self.relay_urls.is_empty() && self.direct_addresses.is_empty() {
+            return Err(crate::Error::Configuration(
+                "Maple Iroh endpoint must contain at least one relay URL or direct address"
+                    .to_string(),
+            ));
+        }
+
+        let mut relay_urls = Vec::with_capacity(self.relay_urls.len());
+        let mut seen_relays = HashSet::with_capacity(self.relay_urls.len());
+        for relay_url in &self.relay_urls {
+            let parsed = reqwest::Url::parse(relay_url).map_err(|_| {
+                crate::Error::Configuration("Maple Iroh relay URL is invalid".to_string())
+            })?;
+            if relay_url.is_empty()
+                || relay_url.len() > MAPLE_DEVICE_MAX_RELAY_URL_BYTES
+                || parsed.as_str() != relay_url
+                || parsed.scheme() != "https"
+                || parsed.host().is_none()
+                || !parsed.username().is_empty()
+                || parsed.password().is_some()
+                || parsed.port() == Some(0)
+                || parsed.query().is_some()
+                || parsed.fragment().is_some()
+                || !seen_relays.insert(relay_url.as_str())
+            {
+                return Err(crate::Error::Configuration(
+                    "Maple Iroh relay URLs must be unique canonical HTTPS URLs without credentials, queries, or fragments"
+                        .to_string(),
+                ));
+            }
+            relay_urls.push(relay_url.as_str());
+        }
+        relay_urls.sort_unstable();
+
+        let mut direct_addresses = Vec::with_capacity(self.direct_addresses.len());
+        let mut seen_direct = HashSet::with_capacity(self.direct_addresses.len());
+        for direct_address in &self.direct_addresses {
+            let parsed = direct_address.parse::<SocketAddr>().map_err(|_| {
+                crate::Error::Configuration(
+                    "Maple Iroh direct address is not a socket address".to_string(),
+                )
+            })?;
+            if direct_address.is_empty()
+                || direct_address.len() > MAPLE_DEVICE_MAX_DIRECT_ADDRESS_BYTES
+                || parsed.to_string() != *direct_address
+                || parsed.port() == 0
+                || parsed.ip().is_unspecified()
+                || parsed.ip().is_multicast()
+                || parsed.ip() == std::net::IpAddr::V4(std::net::Ipv4Addr::BROADCAST)
+                || !seen_direct.insert(direct_address.as_str())
+            {
+                return Err(crate::Error::Configuration(
+                    "Maple Iroh direct addresses must be unique canonical unicast SocketAddr values with nonzero ports"
+                        .to_string(),
+                ));
+            }
+            direct_addresses.push(direct_address.as_str());
+        }
+        direct_addresses.sort_unstable();
+
+        Ok((relay_urls, direct_addresses))
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MapleDeviceIdentityAlgorithm {
+    Ed25519,
+}
+
+impl MapleDeviceIdentityAlgorithm {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Ed25519 => "ed25519",
+        }
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MapleDevicePlatform {
+    Macos,
+    Windows,
+    Linux,
+    Ios,
+    Android,
+}
+
+impl MapleDevicePlatform {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Macos => "macos",
+            Self::Windows => "windows",
+            Self::Linux => "linux",
+            Self::Ios => "ios",
+            Self::Android => "android",
+        }
+    }
+}
+
+/// A signed, caller-owned Maple device registration request.
+///
+/// These structured fields are the input to the server's canonical transcript
+/// reconstruction. The SDK does not accept caller-chosen canonical bytes and
+/// verifies the completed Ed25519 signature before sending the request.
+/// Private-key generation and storage belong to the Maple installation and its
+/// platform secure-storage implementation.
+///
+/// An installation ID whose remote enrollment lineage has been retired is
+/// permanently unavailable for registration. Re-enrollment must create a
+/// fresh installation ID and identity key/endpoint identity; changing mutable
+/// display or routing fields does not revive the retired installation.
+/// `operation_id` must be generated once by the caller and retained across
+/// ambiguous outcomes; the encrypted client may automatically retry this exact
+/// request after refreshing authentication or its attested session.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RegisterMapleDeviceRequest {
+    pub protocol_version: u16,
+    pub transcript_version: u16,
+    pub operation_id: Uuid,
+    pub device_id: Uuid,
+    pub installation_id: Uuid,
+    /// Signed compare-and-swap precondition for an existing registration.
+    /// `None` creates a registration; `Some(current_revision)` refreshes the
+    /// same installation without permitting identity-key replacement.
+    pub expected_revision: Option<i64>,
+    /// Signed account security-epoch precondition. A newly bootstrapped
+    /// account starts at epoch 1; callers must persist the latest verified
+    /// epoch and refresh device state when the service rejects a stale value.
+    pub known_security_epoch: u64,
+    /// Signed stale-state precondition. The server derives account authority
+    /// from authentication and rejects a mismatch; this field never selects a
+    /// database namespace.
+    pub asserted_account_id: Uuid,
+    /// Signed public `org_projects.client_id` precondition for the authenticated
+    /// OpenSecret project. The server derives project authority independently.
+    pub asserted_project_id: Uuid,
+    pub identity_algorithm: MapleDeviceIdentityAlgorithm,
+    pub identity_public_key: String,
+    pub iroh_endpoint_id: String,
+    /// Monotonic endpoint lifecycle epoch, not an address-generation counter.
+    /// Routine relay/direct address churn keeps this value stable and advances
+    /// the registration `revision` through `expected_revision` CAS instead;
+    /// v1 updates may retain or advance it for the same immutable identity but
+    /// may never decrease it.
+    pub endpoint_epoch: u64,
+    pub iroh_endpoint_addr: MapleIrohEndpointAddr,
+    pub platform: MapleDevicePlatform,
+    pub display_name: String,
+    pub capabilities: Vec<String>,
+    pub signature: String,
+}
+
+impl std::fmt::Debug for RegisterMapleDeviceRequest {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RegisterMapleDeviceRequest")
+            .field("protocol_version", &self.protocol_version)
+            .field("transcript_version", &self.transcript_version)
+            .field("operation_id", &self.operation_id)
+            .field("device_id", &self.device_id)
+            .field("installation_id", &self.installation_id)
+            .field("expected_revision", &self.expected_revision)
+            .field("known_security_epoch", &self.known_security_epoch)
+            .field("asserted_account_id", &self.asserted_account_id)
+            .field("asserted_project_id", &self.asserted_project_id)
+            .field("identity_algorithm", &self.identity_algorithm.as_str())
+            .field("identity_public_key", &"<redacted>")
+            .field("iroh_endpoint_id", &"<redacted>")
+            .field("endpoint_epoch", &self.endpoint_epoch)
+            .field("relay_url_count", &self.iroh_endpoint_addr.relay_urls.len())
+            .field(
+                "direct_address_count",
+                &self.iroh_endpoint_addr.direct_addresses.len(),
+            )
+            .field("platform", &self.platform.as_str())
+            .field("display_name", &"<redacted>")
+            .field("capability_count", &self.capabilities.len())
+            .field("signature", &"<redacted>")
+            .finish()
+    }
+}
+
+impl RegisterMapleDeviceRequest {
+    #[allow(clippy::too_many_arguments)]
+    pub fn v1(
+        operation_id: Uuid,
+        device_id: Uuid,
+        installation_id: Uuid,
+        expected_revision: Option<i64>,
+        known_security_epoch: u64,
+        asserted_account_id: Uuid,
+        asserted_project_id: Uuid,
+        identity_public_key: impl Into<String>,
+        iroh_endpoint_id: impl Into<String>,
+        endpoint_epoch: u64,
+        iroh_endpoint_addr: MapleIrohEndpointAddr,
+        platform: MapleDevicePlatform,
+        display_name: impl Into<String>,
+        capabilities: Vec<String>,
+        signature: impl Into<String>,
+    ) -> Self {
+        Self::unsigned_v1(
+            operation_id,
+            device_id,
+            installation_id,
+            expected_revision,
+            known_security_epoch,
+            asserted_account_id,
+            asserted_project_id,
+            identity_public_key,
+            iroh_endpoint_id,
+            endpoint_epoch,
+            iroh_endpoint_addr,
+            platform,
+            display_name,
+            capabilities,
+        )
+        .with_signature(signature)
+    }
+
+    /// Creates the structured v1 registration before the caller signs it.
+    ///
+    /// Call [`Self::canonical_transcript`], sign those bytes with the
+    /// installation's externally managed key, then attach the public signature
+    /// with [`Self::with_signature`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn unsigned_v1(
+        operation_id: Uuid,
+        device_id: Uuid,
+        installation_id: Uuid,
+        expected_revision: Option<i64>,
+        known_security_epoch: u64,
+        asserted_account_id: Uuid,
+        asserted_project_id: Uuid,
+        identity_public_key: impl Into<String>,
+        iroh_endpoint_id: impl Into<String>,
+        endpoint_epoch: u64,
+        iroh_endpoint_addr: MapleIrohEndpointAddr,
+        platform: MapleDevicePlatform,
+        display_name: impl Into<String>,
+        capabilities: Vec<String>,
+    ) -> Self {
+        Self {
+            protocol_version: MAPLE_DEVICE_PROTOCOL_VERSION,
+            transcript_version: MAPLE_DEVICE_TRANSCRIPT_VERSION,
+            operation_id,
+            device_id,
+            installation_id,
+            expected_revision,
+            known_security_epoch,
+            asserted_account_id,
+            asserted_project_id,
+            identity_algorithm: MapleDeviceIdentityAlgorithm::Ed25519,
+            identity_public_key: identity_public_key.into(),
+            iroh_endpoint_id: iroh_endpoint_id.into(),
+            endpoint_epoch,
+            iroh_endpoint_addr,
+            platform,
+            display_name: display_name.into(),
+            capabilities,
+            signature: String::new(),
+        }
+    }
+
+    pub fn with_signature(mut self, signature: impl Into<String>) -> Self {
+        self.signature = signature.into();
+        self
+    }
+
+    /// Reconstructs the versioned canonical bytes this request must sign.
+    ///
+    /// This validates every signed public field, sorts capabilities without
+    /// changing the caller's request object, and deliberately excludes
+    /// `signature`. The OpenSecret service independently reconstructs these
+    /// exact bytes after deriving and matching the account and project from the
+    /// authenticated request context.
+    pub fn canonical_transcript(&self) -> crate::Result<Vec<u8>> {
+        let validated = self.validate_transcript_fields()?;
+        let mut canonical = MapleCanonicalBytes::new("os.maple-device-registration.v1");
+        canonical
+            .append_u16(self.protocol_version)
+            .append_u16(self.transcript_version)
+            .append_uuid(self.asserted_account_id)
+            .append_uuid(self.asserted_project_id)
+            .append_u64(self.known_security_epoch)
+            .append_uuid(self.operation_id)
+            .append_uuid(self.device_id)
+            .append_uuid(self.installation_id)
+            .append_bool(self.expected_revision.is_some());
+        if let Some(expected_revision) = self.expected_revision {
+            canonical.append_i64(expected_revision);
+        }
+        canonical
+            .append_str(self.identity_algorithm.as_str())
+            .append_bytes(&validated.identity_public_key)
+            .append_bytes(&validated.iroh_endpoint_key)
+            .append_u64(self.endpoint_epoch)
+            .append_u16(validated.relay_urls.len() as u16);
+        for relay_url in validated.relay_urls {
+            canonical.append_str(relay_url);
+        }
+        canonical.append_u16(validated.direct_addresses.len() as u16);
+        for direct_address in validated.direct_addresses {
+            canonical.append_str(direct_address);
+        }
+        canonical
+            .append_str(self.platform.as_str())
+            .append_str(&self.display_name)
+            .append_u16(validated.capabilities.len() as u16);
+        for capability in validated.capabilities {
+            canonical.append_str(capability);
+        }
+        Ok(canonical.into_bytes())
+    }
+
+    /// Validates the complete signed request without generating or storing keys.
+    pub fn validate(&self) -> crate::Result<()> {
+        let transcript = self.canonical_transcript()?;
+        let validated = self.validate_transcript_fields()?;
+        let signature = decode_canonical_base64(&self.signature, "Maple device signature")?;
+        if signature.len() != 64 {
+            return Err(crate::Error::Configuration(
+                "Maple device signature must contain exactly 64 bytes".to_string(),
+            ));
+        }
+        UnparsedPublicKey::new(&ED25519, validated.identity_public_key)
+            .verify(&transcript, &signature)
+            .map_err(|_| {
+                crate::Error::Configuration(
+                    "Maple device signature does not verify for the signed registration"
+                        .to_string(),
+                )
+            })?;
+        Ok(())
+    }
+
+    fn validate_transcript_fields(&self) -> crate::Result<ValidatedMapleDeviceTranscript<'_>> {
+        if self.protocol_version != MAPLE_DEVICE_PROTOCOL_VERSION {
+            return Err(crate::Error::Configuration(format!(
+                "Unsupported Maple device protocol version: {}",
+                self.protocol_version
+            )));
+        }
+        if self.transcript_version != MAPLE_DEVICE_TRANSCRIPT_VERSION {
+            return Err(crate::Error::Configuration(format!(
+                "Unsupported Maple device transcript version: {}",
+                self.transcript_version
+            )));
+        }
+        for (name, value) in [
+            ("operation_id", self.operation_id),
+            ("asserted_account_id", self.asserted_account_id),
+            ("asserted_project_id", self.asserted_project_id),
+            ("device_id", self.device_id),
+            ("installation_id", self.installation_id),
+        ] {
+            if value.is_nil() {
+                return Err(crate::Error::Configuration(format!(
+                    "Maple device {name} must not be nil"
+                )));
+            }
+        }
+        if self
+            .expected_revision
+            .is_some_and(|revision| revision <= 0 || revision == i64::MAX)
+        {
+            return Err(crate::Error::Configuration(
+                "Maple device expected revision must be positive and incrementable".to_string(),
+            ));
+        }
+        if self.known_security_epoch == 0 || self.known_security_epoch > i64::MAX as u64 {
+            return Err(crate::Error::Configuration(
+                "Maple device known security epoch must be nonzero and supported by the service"
+                    .to_string(),
+            ));
+        }
+        if self.endpoint_epoch > i64::MAX as u64 {
+            return Err(crate::Error::Configuration(
+                "Maple device endpoint epoch exceeds the supported range".to_string(),
+            ));
+        }
+        let (relay_urls, direct_addresses) = self.iroh_endpoint_addr.canonical_parts()?;
+
+        let identity_public_key =
+            decode_canonical_base64(&self.identity_public_key, "Maple device public key")?;
+        let identity_public_key: [u8; 32] = identity_public_key.try_into().map_err(|_| {
+            crate::Error::Configuration(
+                "Maple device public key must contain exactly 32 bytes".to_string(),
+            )
+        })?;
+
+        if self.iroh_endpoint_id.len() != 64
+            || !self
+                .iroh_endpoint_id
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        {
+            return Err(crate::Error::Configuration(
+                "Maple Iroh endpoint ID must be canonical lowercase 64-character hex".to_string(),
+            ));
+        }
+        let iroh_endpoint_key: [u8; 32] = hex::decode(&self.iroh_endpoint_id)
+            .map_err(|_| {
+                crate::Error::Configuration("Maple Iroh endpoint ID is invalid hex".to_string())
+            })?
+            .try_into()
+            .map_err(|_| {
+                crate::Error::Configuration(
+                    "Maple Iroh endpoint ID must contain exactly 32 bytes".to_string(),
+                )
+            })?;
+        if iroh_endpoint_key != identity_public_key {
+            return Err(crate::Error::Configuration(
+                "Maple device public key must match the Iroh endpoint ID".to_string(),
+            ));
+        }
+
+        if self.display_name.is_empty()
+            || self.display_name.trim() != self.display_name
+            || self.display_name.chars().count() > 80
+            || self.display_name.chars().any(char::is_control)
+        {
+            return Err(crate::Error::Configuration(
+                "Maple device display name must be trimmed, contain 1 to 80 characters, and contain no control characters"
+                    .to_string(),
+            ));
+        }
+
+        if self.capabilities.len() > 32 {
+            return Err(crate::Error::Configuration(
+                "Maple device registration supports at most 32 capabilities".to_string(),
+            ));
+        }
+        let mut unique_capabilities = HashSet::with_capacity(self.capabilities.len());
+        for capability in &self.capabilities {
+            let valid = !capability.is_empty()
+                && capability.len() <= 64
+                && capability.bytes().all(|byte| {
+                    byte.is_ascii_lowercase()
+                        || byte.is_ascii_digit()
+                        || matches!(byte, b'.' | b'_' | b':' | b'-')
+                });
+            if !valid || !unique_capabilities.insert(capability.as_str()) {
+                return Err(crate::Error::Configuration(
+                    "Maple device capabilities must be unique lowercase tokens of at most 64 bytes"
+                        .to_string(),
+                ));
+            }
+        }
+        let mut capabilities = unique_capabilities.into_iter().collect::<Vec<_>>();
+        capabilities.sort_unstable();
+
+        Ok(ValidatedMapleDeviceTranscript {
+            identity_public_key,
+            iroh_endpoint_key,
+            relay_urls,
+            direct_addresses,
+            capabilities,
+        })
+    }
+}
+
+fn decode_canonical_base64(value: &str, field_name: &str) -> crate::Result<Vec<u8>> {
+    let decoded = BASE64.decode(value).map_err(|_| {
+        crate::Error::Configuration(format!("{field_name} must be standard base64"))
+    })?;
+    if BASE64.encode(&decoded) != value {
+        return Err(crate::Error::Configuration(format!(
+            "{field_name} must use canonical padded standard base64"
+        )));
+    }
+    Ok(decoded)
+}
+
+#[derive(Default)]
+struct MapleCanonicalBytes {
+    bytes: Vec<u8>,
+}
+
+impl MapleCanonicalBytes {
+    fn new(domain: &str) -> Self {
+        let mut canonical = Self::default();
+        canonical.append_str(domain);
+        canonical
+    }
+
+    fn append_str(&mut self, value: &str) -> &mut Self {
+        self.append_field(b's', value.as_bytes())
+    }
+
+    fn append_bytes(&mut self, value: &[u8]) -> &mut Self {
+        self.append_field(b'b', value)
+    }
+
+    fn append_u16(&mut self, value: u16) -> &mut Self {
+        self.append_field(b'j', &value.to_be_bytes())
+    }
+
+    fn append_bool(&mut self, value: bool) -> &mut Self {
+        self.append_field(b'?', &[u8::from(value)])
+    }
+
+    fn append_i64(&mut self, value: i64) -> &mut Self {
+        self.append_field(b'l', &value.to_be_bytes())
+    }
+
+    fn append_u64(&mut self, value: u64) -> &mut Self {
+        self.append_field(b'L', &value.to_be_bytes())
+    }
+
+    fn append_uuid(&mut self, value: Uuid) -> &mut Self {
+        self.append_field(b'u', value.as_bytes())
+    }
+
+    fn append_field(&mut self, tag: u8, value: &[u8]) -> &mut Self {
+        let len = u32::try_from(value.len()).expect("Maple canonical field length fits in u32");
+        self.bytes.push(tag);
+        self.bytes.extend_from_slice(&len.to_be_bytes());
+        self.bytes.extend_from_slice(value);
+        self
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+/// Idempotent receipt returned by Maple device registration.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MapleDeviceRegistrationResponse {
+    pub protocol_version: u16,
+    pub operation_id: Uuid,
+    pub registration_id: Uuid,
+    pub device_id: Uuid,
+    pub revision: i64,
+    pub accepted_at: DateTime<Utc>,
+    pub security_epoch: u64,
+    pub revocation_sync: crate::MapleRevocationSyncV1,
+}
+
+impl std::fmt::Debug for MapleDeviceRegistrationResponse {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MapleDeviceRegistrationResponse")
+            .field("protocol_version", &self.protocol_version)
+            .field("revision", &self.revision)
+            .field("security_epoch", &self.security_epoch)
+            .field("sync_status", &self.revocation_sync.status)
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+/// Durable account-scoped record returned after device-directory decryption.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MapleDevice {
+    pub registration_id: Uuid,
+    pub device_id: Uuid,
+    pub installation_id: Uuid,
+    pub identity_algorithm: MapleDeviceIdentityAlgorithm,
+    pub identity_public_key: String,
+    pub iroh_endpoint_id: String,
+    pub endpoint_epoch: u64,
+    pub iroh_endpoint_addr: MapleIrohEndpointAddr,
+    pub platform: MapleDevicePlatform,
+    pub display_name: String,
+    pub capabilities: Vec<String>,
+    pub revision: i64,
+}
+
+impl std::fmt::Debug for MapleDevice {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MapleDevice")
+            .field("endpoint_epoch", &self.endpoint_epoch)
+            .field("platform", &self.platform.as_str())
+            .field("capability_count", &self.capabilities.len())
+            .field("revision", &self.revision)
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
+}
+
+impl MapleDevice {
+    /// Validates a decrypted device-directory record before it is handed to
+    /// Maple's transport layer.
+    pub fn validate(&self) -> crate::Result<()> {
+        if self.registration_id.is_nil()
+            || self.device_id.is_nil()
+            || self.installation_id.is_nil()
+            || self.revision <= 0
+            || self.endpoint_epoch > i64::MAX as u64
+        {
+            return Err(crate::Error::Configuration(
+                "Maple device directory record contains invalid identifiers or revision"
+                    .to_string(),
+            ));
+        }
+
+        let identity_public_key =
+            decode_canonical_base64(&self.identity_public_key, "Maple device public key")?;
+        let identity_public_key: [u8; 32] = identity_public_key.try_into().map_err(|_| {
+            crate::Error::Configuration(
+                "Maple device public key must contain exactly 32 bytes".to_string(),
+            )
+        })?;
+        if self.iroh_endpoint_id != hex::encode(identity_public_key) {
+            return Err(crate::Error::Configuration(
+                "Maple device directory public key does not match its Iroh endpoint ID".to_string(),
+            ));
+        }
+        self.iroh_endpoint_addr.validate()?;
+        if self.display_name.is_empty()
+            || self.display_name.trim() != self.display_name
+            || self.display_name.chars().count() > 80
+            || self.display_name.chars().any(char::is_control)
+        {
+            return Err(crate::Error::Configuration(
+                "Maple device directory display name must be trimmed, contain 1 to 80 characters, and contain no control characters"
+                    .to_string(),
+            ));
+        }
+        if self.capabilities.len() > 32 {
+            return Err(crate::Error::Configuration(
+                "Maple device directory record supports at most 32 capabilities".to_string(),
+            ));
+        }
+        for capability in &self.capabilities {
+            let valid = !capability.is_empty()
+                && capability.len() <= 64
+                && capability.bytes().all(|byte| {
+                    byte.is_ascii_lowercase()
+                        || byte.is_ascii_digit()
+                        || matches!(byte, b'.' | b'_' | b':' | b'-')
+                });
+            if !valid {
+                return Err(crate::Error::Configuration(
+                    "Maple device directory capabilities must be lowercase tokens of at most 64 bytes"
+                        .to_string(),
+                ));
+            }
+        }
+        if self.capabilities.windows(2).any(|pair| pair[0] >= pair[1]) {
+            return Err(crate::Error::Configuration(
+                "Maple device directory capabilities must be in strictly ascending canonical order"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct MapleDeviceListParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u16>,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MapleDeviceListResponse {
+    pub protocol_version: u16,
+    pub security_epoch: u64,
+    pub devices: Vec<MapleDevice>,
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
+}
+
+impl std::fmt::Debug for MapleDeviceListResponse {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MapleDeviceListResponse")
+            .field("protocol_version", &self.protocol_version)
+            .field("security_epoch", &self.security_epoch)
+            .field("device_count", &self.devices.len())
+            .field("has_more", &self.has_more)
+            .field("authority_material", &"[redacted]")
+            .finish()
+    }
 }
 
 // Push Notification Types
@@ -1263,7 +2043,430 @@ pub enum AgentSseEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ring::signature::{Ed25519KeyPair, KeyPair};
     use serde_json::json;
+    use sha2::{Digest, Sha256};
+
+    fn sign_maple_request(unsigned: RegisterMapleDeviceRequest) -> RegisterMapleDeviceRequest {
+        let key = Ed25519KeyPair::from_seed_unchecked(&[17u8; 32]).unwrap();
+        assert_eq!(
+            key.public_key().as_ref(),
+            BASE64.decode(&unsigned.identity_public_key).unwrap()
+        );
+        let signature = key.sign(&unsigned.canonical_transcript().unwrap());
+        unsigned.with_signature(BASE64.encode(signature.as_ref()))
+    }
+
+    fn sample_iroh_addr() -> MapleIrohEndpointAddr {
+        MapleIrohEndpointAddr::canonical_v1(
+            vec![
+                "https://use1-1.relay.n0.iroh.link./".to_string(),
+                "https://euw1-1.relay.n0.iroh.link./".to_string(),
+            ],
+            vec![
+                "[2001:db8::1]:4433".to_string(),
+                "203.0.113.7:4433".to_string(),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn maple_device_v1_request_serializes_only_structured_transcript_fields() {
+        let identity_public_key =
+            hex::decode("d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737")
+                .unwrap();
+        let identity_public_key_base64 = BASE64.encode(&identity_public_key);
+        let iroh_endpoint_id = hex::encode(&identity_public_key);
+        let request = sign_maple_request(RegisterMapleDeviceRequest::unsigned_v1(
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440003").unwrap(),
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440004").unwrap(),
+            None,
+            1,
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap(),
+            Uuid::parse_str("550e8400-e29b-41d4-a716-446655440002").unwrap(),
+            &identity_public_key_base64,
+            &iroh_endpoint_id,
+            7,
+            sample_iroh_addr(),
+            MapleDevicePlatform::Macos,
+            "MacBook Pro",
+            vec!["agent.control".to_string(), "agent.host".to_string()],
+        ));
+        let signature = request.signature.clone();
+
+        let serialized_string = serde_json::to_string(&request).unwrap();
+        let expected_serialized_string = format!(
+            concat!(
+                "{{\"protocol_version\":1,\"transcript_version\":1,",
+                "\"operation_id\":\"550e8400-e29b-41d4-a716-446655440000\",",
+                "\"device_id\":\"550e8400-e29b-41d4-a716-446655440003\",",
+                "\"installation_id\":\"550e8400-e29b-41d4-a716-446655440004\",",
+                "\"expected_revision\":null,\"known_security_epoch\":1,",
+                "\"asserted_account_id\":\"550e8400-e29b-41d4-a716-446655440001\",",
+                "\"asserted_project_id\":\"550e8400-e29b-41d4-a716-446655440002\",",
+                "\"identity_algorithm\":\"ed25519\",",
+                "\"identity_public_key\":\"0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=\",",
+                "\"iroh_endpoint_id\":\"d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737\",",
+                "\"endpoint_epoch\":7,",
+                "\"iroh_endpoint_addr\":{{\"relay_urls\":[\"https://euw1-1.relay.n0.iroh.link./\",\"https://use1-1.relay.n0.iroh.link./\"],",
+                "\"direct_addresses\":[\"203.0.113.7:4433\",\"[2001:db8::1]:4433\"]}},",
+                "\"platform\":\"macos\",\"display_name\":\"MacBook Pro\",",
+                "\"capabilities\":[\"agent.control\",\"agent.host\"],\"signature\":\"{}\"}}"
+            ),
+            signature
+        );
+        assert_eq!(serialized_string, expected_serialized_string);
+        let expected_serialized = json!({
+            "protocol_version": 1,
+            "transcript_version": 1,
+            "operation_id": "550e8400-e29b-41d4-a716-446655440000",
+            "device_id": "550e8400-e29b-41d4-a716-446655440003",
+            "installation_id": "550e8400-e29b-41d4-a716-446655440004",
+            "expected_revision": null,
+            "known_security_epoch": 1,
+            "asserted_account_id": "550e8400-e29b-41d4-a716-446655440001",
+            "asserted_project_id": "550e8400-e29b-41d4-a716-446655440002",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": identity_public_key_base64,
+            "iroh_endpoint_id": iroh_endpoint_id,
+            "endpoint_epoch": 7,
+            "iroh_endpoint_addr": {
+                "relay_urls": [
+                    "https://euw1-1.relay.n0.iroh.link./",
+                    "https://use1-1.relay.n0.iroh.link./"
+                ],
+                "direct_addresses": ["203.0.113.7:4433", "[2001:db8::1]:4433"]
+            },
+            "platform": "macos",
+            "display_name": "MacBook Pro",
+            "capabilities": ["agent.control", "agent.host"],
+            "signature": signature
+        });
+        let serialized: Value = serde_json::from_str(&serialized_string).unwrap();
+        assert_eq!(serialized, expected_serialized);
+        assert!(serialized.get("canonical_transcript").is_none());
+        assert!(serialized.get("private_key").is_none());
+    }
+
+    #[test]
+    fn maple_device_v1_canonical_transcript_matches_frozen_epoch_vectors() {
+        let fixture: Value = serde_json::from_str(include_str!(
+            "../tests/fixtures/maple_pairing_v1_vectors.json"
+        ))
+        .unwrap();
+        for (request_name, transcript_name, digest_name) in [
+            (
+                "register_device_request_epoch_1",
+                "register_device_request_epoch_1_transcript_hex",
+                "register_device_request_epoch_1_digest",
+            ),
+            (
+                "register_device_request_epoch_4",
+                "register_device_request_epoch_4_transcript_hex",
+                "register_device_request_epoch_4_digest",
+            ),
+        ] {
+            let request: RegisterMapleDeviceRequest =
+                serde_json::from_value(fixture[request_name].clone()).unwrap();
+            request.validate().unwrap();
+            let transcript = request.canonical_transcript().unwrap();
+            assert_eq!(
+                hex::encode(&transcript),
+                fixture[transcript_name].as_str().unwrap()
+            );
+            assert_eq!(
+                BASE64.encode(Sha256::digest(&transcript)),
+                fixture[digest_name].as_str().unwrap()
+            );
+
+            let mut tampered_epoch = request;
+            tampered_epoch.known_security_epoch += 1;
+            assert!(matches!(
+                tampered_epoch.validate(),
+                Err(crate::Error::Configuration(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn maple_device_v1_validation_rejects_identity_and_metadata_ambiguity() {
+        let identity_public_key =
+            hex::decode("d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737")
+                .unwrap();
+        let valid = sign_maple_request(RegisterMapleDeviceRequest::unsigned_v1(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            None,
+            1,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            BASE64.encode(&identity_public_key),
+            hex::encode(&identity_public_key),
+            1,
+            sample_iroh_addr(),
+            MapleDevicePlatform::Ios,
+            "iPhone",
+            vec!["agent.control".to_string()],
+        ));
+        valid.validate().unwrap();
+
+        let invalid_requests = [
+            RegisterMapleDeviceRequest {
+                iroh_endpoint_id: hex::encode([8u8; 32]),
+                ..valid.clone()
+            },
+            RegisterMapleDeviceRequest {
+                display_name: " iPhone".to_string(),
+                ..valid.clone()
+            },
+            RegisterMapleDeviceRequest {
+                capabilities: vec!["agent.control".to_string(), "agent.control".to_string()],
+                ..valid.clone()
+            },
+            RegisterMapleDeviceRequest {
+                signature: BASE64.encode([9u8; 63]),
+                ..valid
+            },
+        ];
+        for request in invalid_requests {
+            assert!(matches!(
+                request.validate(),
+                Err(crate::Error::Configuration(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn maple_device_registration_debug_redacts_identity_endpoint_routes_name_and_signature() {
+        let identity_public_key =
+            hex::decode("d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737")
+                .unwrap();
+        let request = sign_maple_request(RegisterMapleDeviceRequest::unsigned_v1(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            None,
+            1,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            BASE64.encode(&identity_public_key),
+            hex::encode(&identity_public_key),
+            1,
+            sample_iroh_addr(),
+            MapleDevicePlatform::Macos,
+            "Sensitive Maple Host Name",
+            vec!["agent.host".to_string()],
+        ));
+
+        let debug = format!("{request:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains(&request.identity_public_key));
+        assert!(!debug.contains(&request.iroh_endpoint_id));
+        assert!(!debug.contains(&request.display_name));
+        assert!(!debug.contains(&request.signature));
+        assert!(!request
+            .iroh_endpoint_addr
+            .relay_urls
+            .iter()
+            .any(|relay_url| debug.contains(relay_url)));
+        assert!(!request
+            .iroh_endpoint_addr
+            .direct_addresses
+            .iter()
+            .any(|address| debug.contains(address)));
+    }
+
+    #[test]
+    fn maple_device_directory_debug_redacts_identity_routes_names_and_cursor() {
+        let identity_public_key =
+            hex::decode("d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737")
+                .unwrap();
+        let device = MapleDevice {
+            registration_id: Uuid::new_v4(),
+            device_id: Uuid::new_v4(),
+            installation_id: Uuid::new_v4(),
+            identity_algorithm: MapleDeviceIdentityAlgorithm::Ed25519,
+            identity_public_key: BASE64.encode(&identity_public_key),
+            iroh_endpoint_id: hex::encode(&identity_public_key),
+            endpoint_epoch: 7,
+            iroh_endpoint_addr: sample_iroh_addr(),
+            platform: MapleDevicePlatform::Macos,
+            display_name: "Sensitive Maple Host Name".to_string(),
+            capabilities: vec!["agent.host".to_string()],
+            revision: 3,
+        };
+        let cursor = "sensitive-device-directory-cursor".to_string();
+        let page = MapleDeviceListResponse {
+            protocol_version: 1,
+            security_epoch: 4,
+            devices: vec![device.clone()],
+            next_cursor: Some(cursor.clone()),
+            has_more: true,
+        };
+
+        for debug in [format!("{device:?}"), format!("{page:?}")] {
+            assert!(debug.contains("[redacted]"));
+            for secret in [
+                device.registration_id.to_string(),
+                device.device_id.to_string(),
+                device.installation_id.to_string(),
+                device.identity_public_key.clone(),
+                device.iroh_endpoint_id.clone(),
+                device.display_name.clone(),
+                cursor.clone(),
+            ] {
+                assert!(!debug.contains(&secret));
+            }
+            assert!(!device
+                .iroh_endpoint_addr
+                .relay_urls
+                .iter()
+                .any(|route| debug.contains(route)));
+            assert!(!device
+                .iroh_endpoint_addr
+                .direct_addresses
+                .iter()
+                .any(|route| debug.contains(route)));
+        }
+    }
+
+    #[test]
+    fn maple_iroh_endpoint_addr_is_canonical_bounded_and_contains_no_secret_material() {
+        let canonical = sample_iroh_addr();
+        assert_eq!(
+            serde_json::to_value(&canonical).unwrap(),
+            json!({
+                "relay_urls": [
+                    "https://euw1-1.relay.n0.iroh.link./",
+                    "https://use1-1.relay.n0.iroh.link./"
+                ],
+                "direct_addresses": ["203.0.113.7:4433", "[2001:db8::1]:4433"]
+            })
+        );
+
+        let unsorted = MapleIrohEndpointAddr {
+            relay_urls: vec![
+                "https://use1-1.relay.n0.iroh.link./".to_string(),
+                "https://euw1-1.relay.n0.iroh.link./".to_string(),
+            ],
+            direct_addresses: vec![],
+        };
+        assert!(unsorted.validate().is_err());
+        assert_eq!(
+            MapleIrohEndpointAddr::canonical_v1(unsorted.relay_urls, unsorted.direct_addresses)
+                .unwrap()
+                .relay_urls,
+            vec![
+                "https://euw1-1.relay.n0.iroh.link./",
+                "https://use1-1.relay.n0.iroh.link./"
+            ]
+        );
+
+        for invalid in [
+            MapleIrohEndpointAddr {
+                relay_urls: vec![],
+                direct_addresses: vec![],
+            },
+            MapleIrohEndpointAddr {
+                relay_urls: vec!["http://relay.example/".to_string()],
+                direct_addresses: vec![],
+            },
+            MapleIrohEndpointAddr {
+                relay_urls: vec!["https://user@relay.example/".to_string()],
+                direct_addresses: vec![],
+            },
+            MapleIrohEndpointAddr {
+                relay_urls: vec![],
+                direct_addresses: vec!["0.0.0.0:4433".to_string()],
+            },
+            MapleIrohEndpointAddr {
+                relay_urls: vec![],
+                direct_addresses: vec!["255.255.255.255:4433".to_string()],
+            },
+            MapleIrohEndpointAddr {
+                relay_urls: vec![],
+                direct_addresses: vec!["2001:db8::1:4433".to_string()],
+            },
+        ] {
+            assert!(invalid.validate().is_err());
+        }
+
+        let literal: MapleIrohEndpointAddr = serde_json::from_value(json!({
+            "relay_urls": ["https://relay.example/"],
+            "direct_addresses": ["192.0.2.7:7777"]
+        }))
+        .unwrap();
+        literal.validate().unwrap();
+        assert!(serde_json::from_value::<MapleIrohEndpointAddr>(json!({
+            "relay_urls": ["https://relay.example/"],
+            "direct_addresses": [],
+            "private_key": "must-not-fit-this-schema"
+        }))
+        .is_err());
+    }
+
+    #[test]
+    fn maple_device_literal_json_preserves_endpoint_address_contract() {
+        let literal = json!({
+            "registration_id": "550e8400-e29b-41d4-a716-446655440005",
+            "device_id": "550e8400-e29b-41d4-a716-446655440003",
+            "installation_id": "550e8400-e29b-41d4-a716-446655440004",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+            "iroh_endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+            "endpoint_epoch": 7,
+            "iroh_endpoint_addr": {
+                "relay_urls": ["https://relay.example/"],
+                "direct_addresses": ["192.0.2.7:7777"]
+            },
+            "platform": "macos",
+            "display_name": "MacBook Pro",
+            "capabilities": ["agent.host"],
+            "revision": 2
+        });
+        let device: MapleDevice = serde_json::from_value(literal.clone()).unwrap();
+        device.validate().unwrap();
+        assert_eq!(serde_json::to_value(device).unwrap(), literal);
+    }
+
+    #[test]
+    fn maple_device_directory_capabilities_require_strict_ascending_order() {
+        let identity_public_key =
+            hex::decode("d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737")
+                .unwrap();
+        let valid = MapleDevice {
+            registration_id: Uuid::new_v4(),
+            device_id: Uuid::new_v4(),
+            installation_id: Uuid::new_v4(),
+            identity_algorithm: MapleDeviceIdentityAlgorithm::Ed25519,
+            identity_public_key: BASE64.encode(&identity_public_key),
+            iroh_endpoint_id: hex::encode(&identity_public_key),
+            endpoint_epoch: 1,
+            iroh_endpoint_addr: sample_iroh_addr(),
+            platform: MapleDevicePlatform::Macos,
+            display_name: "Maple Host".to_string(),
+            capabilities: vec!["agent.control".to_string(), "agent.host".to_string()],
+            revision: 1,
+        };
+        valid.validate().unwrap();
+
+        for capabilities in [
+            vec!["agent.host".to_string(), "agent.control".to_string()],
+            vec!["agent.control".to_string(), "agent.control".to_string()],
+        ] {
+            let invalid = MapleDevice {
+                capabilities,
+                ..valid.clone()
+            };
+            assert!(matches!(
+                invalid.validate(),
+                Err(crate::Error::Configuration(_))
+            ));
+        }
+    }
 
     #[test]
     fn nullable_field_request_serialization_distinguishes_missing_and_null() {

--- a/rust/tests/fixtures/maple_pairing_v1_vectors.json
+++ b/rust/tests/fixtures/maple_pairing_v1_vectors.json
@@ -1,0 +1,3731 @@
+{
+  "description": "Authoritative deterministic Maple pairing v1 wire vectors, including typed CREATE/REVOKE material bundles, security-epoch checkpoints, typed revocation events, aggregate reset-clear instructions, recursive chaining, registration sync and tombstone outcomes, host-scoped ACK namespaces, exact-host successor binding, retained issuer rotation, paging, and sanitized conflicts.",
+  "fixture_schema_version": 1,
+  "issuer_keyset": {
+    "version": 1,
+    "keys": [
+      {
+        "key_id": "maple-test-issuer-2026-08-13",
+        "algorithm": "ed25519",
+        "public_key": "a3NKjv8kb+c0s41ARsFI7uXwT+h7OgpCOVWneVbeBms="
+      }
+    ]
+  },
+  "test_private_seeds_hex": {
+    "controller": "1111111111111111111111111111111111111111111111111111111111111111",
+    "host": "1717171717171717171717171717171717171717171717171717171717171717",
+    "second_host": "3737373737373737373737373737373737373737373737373737373737373737",
+    "fresh_installation": "2929292929292929292929292929292929292929292929292929292929292929",
+    "issuer": "5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b5b",
+    "issuer_next": "6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d",
+    "issuer_remap": "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f"
+  },
+  "create_request": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "operation_id": "33333333-3333-4333-8333-333333333333",
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "controller_registration_id": "44444444-4444-4444-8444-444444444444",
+    "controller_device_id": "55555555-5555-4555-8555-555555555555",
+    "controller_installation_id": "66666666-6666-4666-8666-666666666666",
+    "controller_endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+    "controller_endpoint_epoch": 7,
+    "host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "host_device_id": "88888888-8888-4888-8888-888888888888",
+    "host_installation_id": "99999999-9999-4999-8999-999999999999",
+    "host_endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+    "host_endpoint_epoch": 4,
+    "direction": "controller_to_host",
+    "execution_target_id": "77777777-7777-4777-8777-777777777777",
+    "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+    "protocol_min": 1,
+    "protocol_max": 1,
+    "signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg=="
+  },
+  "create_request_transcript_hex": "73000000186f732e6d61706c652d706169722d726571756573742e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010333333333333433383333333333333337500000010444444444444444484444444444444447500000010555555555555455585555555555555557500000010666666666666466686666666666666666200000020d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c97787374c000000080000000000000007750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000047300000012636f6e74726f6c6c65725f746f5f686f7374750000001077777777777747778777777777777777620000002021212121212121212121212121212121212121212121212121212121212121216a0000000200016a000000020001",
+  "create_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+  "request_ticket": {
+    "artifact_version": 1,
+    "subject_account_id": "11111111-1111-4111-8111-111111111111",
+    "subject_project_id": "22222222-2222-4222-8222-222222222222",
+    "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    "direction": "controller_to_host",
+    "execution_target_id": "77777777-7777-4777-8777-777777777777",
+    "controller": {
+      "registration_id": "44444444-4444-4444-8444-444444444444",
+      "device_id": "55555555-5555-4555-8555-555555555555",
+      "installation_id": "66666666-6666-4666-8666-666666666666",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+      "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+      "endpoint_epoch": 7
+    },
+    "host": {
+      "registration_id": "77777777-7777-4777-8777-777777777777",
+      "device_id": "88888888-8888-4888-8888-888888888888",
+      "installation_id": "99999999-9999-4999-8999-999999999999",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+      "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+      "endpoint_epoch": 4
+    },
+    "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+    "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+    "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+    "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+    "pairing_incarnation": 3,
+    "protocol_min": 1,
+    "protocol_max": 1,
+    "created_at_unix_ms": 1786579200000,
+    "expires_at_unix_ms": 1786579800000,
+    "issuer_key_id": "maple-test-issuer-2026-08-13",
+    "issuer_signature": "7pFcCius3oPkwbDWAGRWGHUxAUDN8MEOQYKgerl9+jANv21mToaaCpJ4wWT/PElhq1OFgR+o18xRo21BcI9xAg=="
+  },
+  "request_ticket_transcript_hex": "730000001f6f732e6d61706c652d706169722d726571756573742d7469636b65742e76316a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb7500000010cccccccccccc4ccc8ccccccccccccccc7300000012636f6e74726f6c6c65725f746f5f686f73747500000010777777777777477787777777777777777500000010444444444444444484444444444444447500000010555555555555455585555555555555557500000010666666666666466686666666666666667300000007656432353531396200000020d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c97787376200000020d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c97787374c000000080000000000000007750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c00000008000000000000000462000000202121212121212121212121212121212121212121212121212121212121212121750000001033333333333343338333333333333333620000002094d98604defb10608fe63b24295e32e3c7c83649ff3bfa57ebfc01a67c56c33f6200000040e6de6f9999fcc0c729c82e97a5cbc853a9d71bf56be05a43f6dfe41cabbf9347b7798003047392329379f800bafa5c6e9b78e43983c20dfc34f50b18ff0faa064c0000000800000000000000036a0000000200016a0000000200016c000000080000019ff86b28006c000000080000019ff8744fc0730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+  "request_ticket_digest": "WI1pBGQBP/rBJqixOKw2NQK0tqwkFiFJ07C0KMzPfFY=",
+  "approval_request": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "operation_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    "expected_pairing_revision": 1,
+    "pairing_incarnation": 3,
+    "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+    "revocation_stream_generation": 5,
+    "request_ticket_digest": "WI1pBGQBP/rBJqixOKw2NQK0tqwkFiFJ07C0KMzPfFY=",
+    "host_approval_nonce": "LCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCw=",
+    "approved_protocol_min": 1,
+    "approved_protocol_max": 1,
+    "signature": "rWNkE2XHl1r9G5jSiRCKCgFzdjQItEC50M2J4LqwrB/1vMTjqkYP0q0gKeNU9aFMWMZxFVg3f0NQpvAi07wABA=="
+  },
+  "approval_request_transcript_hex": "73000000196f732e6d61706c652d706169722d617070726f76616c2e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010dddddddddddd4ddd8ddddddddddddddd7500000010777777777777477787777777777777777500000010bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb7500000010cccccccccccc4ccc8ccccccccccccccc6c0000000800000000000000014c0000000800000000000000037500000010151515151515451585151515151515154c0000000800000000000000056200000020588d690464013ffac126a8b138ac363502b4b6ac24162149d3b0b428cccf7c5662000000202c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c6a0000000200016a000000020001",
+  "approval_request_digest": "dAPgkh43ujVyqz93IQU6CDGUhn+SOVlOSSUhMfWupxQ=",
+  "pair_authorization": {
+    "artifact_version": 1,
+    "subject_account_id": "11111111-1111-4111-8111-111111111111",
+    "subject_project_id": "22222222-2222-4222-8222-222222222222",
+    "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    "direction": "controller_to_host",
+    "execution_target_id": "77777777-7777-4777-8777-777777777777",
+    "controller": {
+      "registration_id": "44444444-4444-4444-8444-444444444444",
+      "device_id": "55555555-5555-4555-8555-555555555555",
+      "installation_id": "66666666-6666-4666-8666-666666666666",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+      "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+      "endpoint_epoch": 7
+    },
+    "host": {
+      "registration_id": "77777777-7777-4777-8777-777777777777",
+      "device_id": "88888888-8888-4888-8888-888888888888",
+      "installation_id": "99999999-9999-4999-8999-999999999999",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+      "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+      "endpoint_epoch": 4
+    },
+    "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+    "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+    "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+    "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+    "request_ticket_digest": "WI1pBGQBP/rBJqixOKw2NQK0tqwkFiFJ07C0KMzPfFY=",
+    "host_approval_operation_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    "host_approval_expected_pairing_revision": 1,
+    "host_approval_nonce": "LCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCw=",
+    "host_approval_digest": "dAPgkh43ujVyqz93IQU6CDGUhn+SOVlOSSUhMfWupxQ=",
+    "host_approval_signature": "rWNkE2XHl1r9G5jSiRCKCgFzdjQItEC50M2J4LqwrB/1vMTjqkYP0q0gKeNU9aFMWMZxFVg3f0NQpvAi07wABA==",
+    "pairing_incarnation": 3,
+    "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+    "revocation_stream_generation": 5,
+    "protocol_min": 1,
+    "protocol_max": 1,
+    "approved_at_unix_ms": 1786579260000,
+    "issuer_key_id": "maple-test-issuer-2026-08-13",
+    "issuer_signature": "y0PKI2OlyTml7KGztmZgte2iPAn4xqnceHjtbsN91BWMTjaWLayST/b76mFYKehWNy9XtzYjOH8wh31t/c60Cg=="
+  },
+  "pair_authorization_transcript_hex": "730000001e6f732e6d61706c652d706169722d617574686f72697a6174696f6e2e76316a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb7500000010cccccccccccc4ccc8ccccccccccccccc7300000012636f6e74726f6c6c65725f746f5f686f73747500000010777777777777477787777777777777777500000010444444444444444484444444444444447500000010555555555555455585555555555555557500000010666666666666466686666666666666667300000007656432353531396200000020d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c97787376200000020d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c97787374c000000080000000000000007750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c00000008000000000000000462000000202121212121212121212121212121212121212121212121212121212121212121750000001033333333333343338333333333333333620000002094d98604defb10608fe63b24295e32e3c7c83649ff3bfa57ebfc01a67c56c33f6200000040e6de6f9999fcc0c729c82e97a5cbc853a9d71bf56be05a43f6dfe41cabbf9347b7798003047392329379f800bafa5c6e9b78e43983c20dfc34f50b18ff0faa066200000020588d690464013ffac126a8b138ac363502b4b6ac24162149d3b0b428cccf7c567500000010dddddddddddd4ddd8ddddddddddddddd6c00000008000000000000000162000000202c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c2c62000000207403e0921e37ba3572ab3f7721053a083194867f9239594e49252131f5aea7146200000040ad63641365c7975afd1b98d289108a0a0173763408b440b9d0cd89e0bab0ac1ff5bcc4e3aa460fd2ad2029e354f5a14c58c6711558377f4350a6f022d3bc00044c0000000800000000000000037500000010151515151515451585151515151515154c0000000800000000000000056a0000000200016a0000000200016c000000080000019ff86c1260730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+  "pair_authorization_digest": "CQ/HPMinOZUsvf9kh5qmq8uOHtfoM45yj7HB/5704iQ=",
+  "confirm_request": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "operation_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    "expected_pairing_revision": 2,
+    "pairing_incarnation": 3,
+    "pair_authorization_digest": "CQ/HPMinOZUsvf9kh5qmq8uOHtfoM45yj7HB/5704iQ=",
+    "signature": "0BzrThexLd5jnZDDe4Hvpt4GL1ygCS47XI9HeTwvSpIcAsoxNB4t+dQUkpv9z8NUfmNOyJql2heZkjitPy4sAA=="
+  },
+  "confirm_request_transcript_hex": "730000001c6f732e6d61706c652d706169722d686f73742d636f6d6d69742e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010eeeeeeeeeeee4eee8eeeeeeeeeeeeeee7500000010777777777777477787777777777777777500000010bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb7500000010cccccccccccc4ccc8ccccccccccccccc6c0000000800000000000000024c0000000800000000000000036200000020090fc73cc8a739952cbdff64879aa6abcb8e1ed7e8338e728fb1c1ff9ef4e224",
+  "confirm_request_digest": "ne1W7F6qhuM2cFvBzCLp05DDAWnuZyaPpKp5QkjgnrM=",
+  "active_receipt": {
+    "protocol_version": 1,
+    "operation_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+    "pairing": {
+      "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      "state": "active",
+      "revision": 3,
+      "pairing_incarnation": 3,
+      "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+      "revocation_stream_generation": 5,
+      "direction": "controller_to_host",
+      "execution_target_id": "77777777-7777-4777-8777-777777777777",
+      "controller_registration_id": "44444444-4444-4444-8444-444444444444",
+      "host_registration_id": "77777777-7777-4777-8777-777777777777",
+      "created_at_unix_ms": 1786579200000,
+      "expires_at_unix_ms": 1786579800000,
+      "approved_at_unix_ms": 1786579260000,
+      "activated_at_unix_ms": 1786579320000,
+      "revoked_at_unix_ms": null,
+      "request_ticket": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "controller": {
+          "registration_id": "44444444-4444-4444-8444-444444444444",
+          "device_id": "55555555-5555-4555-8555-555555555555",
+          "installation_id": "66666666-6666-4666-8666-666666666666",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+          "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+          "endpoint_epoch": 7
+        },
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 4
+        },
+        "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+        "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+        "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+        "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+        "pairing_incarnation": 3,
+        "protocol_min": 1,
+        "protocol_max": 1,
+        "created_at_unix_ms": 1786579200000,
+        "expires_at_unix_ms": 1786579800000,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "7pFcCius3oPkwbDWAGRWGHUxAUDN8MEOQYKgerl9+jANv21mToaaCpJ4wWT/PElhq1OFgR+o18xRo21BcI9xAg=="
+      },
+      "pair_authorization": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "controller": {
+          "registration_id": "44444444-4444-4444-8444-444444444444",
+          "device_id": "55555555-5555-4555-8555-555555555555",
+          "installation_id": "66666666-6666-4666-8666-666666666666",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+          "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+          "endpoint_epoch": 7
+        },
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 4
+        },
+        "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+        "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+        "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+        "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+        "request_ticket_digest": "WI1pBGQBP/rBJqixOKw2NQK0tqwkFiFJ07C0KMzPfFY=",
+        "host_approval_operation_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        "host_approval_expected_pairing_revision": 1,
+        "host_approval_nonce": "LCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCw=",
+        "host_approval_digest": "dAPgkh43ujVyqz93IQU6CDGUhn+SOVlOSSUhMfWupxQ=",
+        "host_approval_signature": "rWNkE2XHl1r9G5jSiRCKCgFzdjQItEC50M2J4LqwrB/1vMTjqkYP0q0gKeNU9aFMWMZxFVg3f0NQpvAi07wABA==",
+        "pairing_incarnation": 3,
+        "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+        "revocation_stream_generation": 5,
+        "protocol_min": 1,
+        "protocol_max": 1,
+        "approved_at_unix_ms": 1786579260000,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "y0PKI2OlyTml7KGztmZgte2iPAn4xqnceHjtbsN91BWMTjaWLayST/b76mFYKehWNy9XtzYjOH8wh31t/c60Cg=="
+      },
+      "revocation": null
+    }
+  },
+  "typed_materialization_vectors": {
+    "create": {
+      "request": {
+        "protocol_version": 1,
+        "transcript_version": 1,
+        "operation_id": "33333333-3333-4333-8333-333333333333",
+        "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+        "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+        "controller_registration_id": "44444444-4444-4444-8444-444444444444",
+        "controller_device_id": "55555555-5555-4555-8555-555555555555",
+        "controller_installation_id": "66666666-6666-4666-8666-666666666666",
+        "controller_endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+        "controller_endpoint_epoch": 7,
+        "host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "host_device_id": "88888888-8888-4888-8888-888888888888",
+        "host_installation_id": "99999999-9999-4999-8999-999999999999",
+        "host_endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+        "host_endpoint_epoch": 4,
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+        "protocol_min": 1,
+        "protocol_max": 1,
+        "signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg=="
+      },
+      "request_ticket": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "controller": {
+          "registration_id": "44444444-4444-4444-8444-444444444444",
+          "device_id": "55555555-5555-4555-8555-555555555555",
+          "installation_id": "66666666-6666-4666-8666-666666666666",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+          "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+          "endpoint_epoch": 7
+        },
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 4
+        },
+        "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+        "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+        "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+        "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+        "pairing_incarnation": 3,
+        "protocol_min": 1,
+        "protocol_max": 1,
+        "created_at_unix_ms": 1786579200000,
+        "expires_at_unix_ms": 1786579800000,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "7pFcCius3oPkwbDWAGRWGHUxAUDN8MEOQYKgerl9+jANv21mToaaCpJ4wWT/PElhq1OFgR+o18xRo21BcI9xAg=="
+      },
+      "response": {
+        "protocol_version": 1,
+        "operation_id": "33333333-3333-4333-8333-333333333333",
+        "pairing": {
+          "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          "state": "pending",
+          "revision": 1,
+          "pairing_incarnation": 3,
+          "revocation_stream_id": null,
+          "revocation_stream_generation": null,
+          "direction": "controller_to_host",
+          "execution_target_id": "77777777-7777-4777-8777-777777777777",
+          "controller_registration_id": "44444444-4444-4444-8444-444444444444",
+          "host_registration_id": "77777777-7777-4777-8777-777777777777",
+          "created_at_unix_ms": 1786579200000,
+          "expires_at_unix_ms": 1786579800000,
+          "approved_at_unix_ms": null,
+          "activated_at_unix_ms": null,
+          "revoked_at_unix_ms": null,
+          "request_ticket": {
+            "artifact_version": 1,
+            "subject_account_id": "11111111-1111-4111-8111-111111111111",
+            "subject_project_id": "22222222-2222-4222-8222-222222222222",
+            "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            "direction": "controller_to_host",
+            "execution_target_id": "77777777-7777-4777-8777-777777777777",
+            "controller": {
+              "registration_id": "44444444-4444-4444-8444-444444444444",
+              "device_id": "55555555-5555-4555-8555-555555555555",
+              "installation_id": "66666666-6666-4666-8666-666666666666",
+              "identity_algorithm": "ed25519",
+              "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+              "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+              "endpoint_epoch": 7
+            },
+            "host": {
+              "registration_id": "77777777-7777-4777-8777-777777777777",
+              "device_id": "88888888-8888-4888-8888-888888888888",
+              "installation_id": "99999999-9999-4999-8999-999999999999",
+              "identity_algorithm": "ed25519",
+              "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+              "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+              "endpoint_epoch": 4
+            },
+            "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+            "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+            "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+            "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+            "pairing_incarnation": 3,
+            "protocol_min": 1,
+            "protocol_max": 1,
+            "created_at_unix_ms": 1786579200000,
+            "expires_at_unix_ms": 1786579800000,
+            "issuer_key_id": "maple-test-issuer-2026-08-13",
+            "issuer_signature": "7pFcCius3oPkwbDWAGRWGHUxAUDN8MEOQYKgerl9+jANv21mToaaCpJ4wWT/PElhq1OFgR+o18xRo21BcI9xAg=="
+          },
+          "pair_authorization": null,
+          "revocation": null
+        }
+      }
+    },
+    "revoke": {
+      "request": {
+        "protocol_version": 1,
+        "transcript_version": 1,
+        "operation_id": "abababab-abab-4bab-8bab-abababababab",
+        "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+        "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+        "actor_registration_id": "44444444-4444-4444-8444-444444444444",
+        "actor_role": "controller",
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "expected_pairing_revision": 3,
+        "pairing_incarnation": 3,
+        "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+        "revocation_stream_generation": 5,
+        "reason_code": "user_removed_access",
+        "signature": "ZpfeVbpIr5c4EsFPkIoJlHqrkX35D+QPr90vVUahXkKUm2QtNJIFNaAVza1/18mmNQ5tVF/i/VwRDpkKKOV/AA=="
+      },
+      "request_ticket": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "controller": {
+          "registration_id": "44444444-4444-4444-8444-444444444444",
+          "device_id": "55555555-5555-4555-8555-555555555555",
+          "installation_id": "66666666-6666-4666-8666-666666666666",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+          "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+          "endpoint_epoch": 7
+        },
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 4
+        },
+        "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+        "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+        "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+        "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+        "pairing_incarnation": 3,
+        "protocol_min": 1,
+        "protocol_max": 1,
+        "created_at_unix_ms": 1786579200000,
+        "expires_at_unix_ms": 1786579800000,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "7pFcCius3oPkwbDWAGRWGHUxAUDN8MEOQYKgerl9+jANv21mToaaCpJ4wWT/PElhq1OFgR+o18xRo21BcI9xAg=="
+      },
+      "pair_authorization": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "controller": {
+          "registration_id": "44444444-4444-4444-8444-444444444444",
+          "device_id": "55555555-5555-4555-8555-555555555555",
+          "installation_id": "66666666-6666-4666-8666-666666666666",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+          "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+          "endpoint_epoch": 7
+        },
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 4
+        },
+        "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+        "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+        "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+        "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+        "request_ticket_digest": "WI1pBGQBP/rBJqixOKw2NQK0tqwkFiFJ07C0KMzPfFY=",
+        "host_approval_operation_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        "host_approval_expected_pairing_revision": 1,
+        "host_approval_nonce": "LCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCw=",
+        "host_approval_digest": "dAPgkh43ujVyqz93IQU6CDGUhn+SOVlOSSUhMfWupxQ=",
+        "host_approval_signature": "rWNkE2XHl1r9G5jSiRCKCgFzdjQItEC50M2J4LqwrB/1vMTjqkYP0q0gKeNU9aFMWMZxFVg3f0NQpvAi07wABA==",
+        "pairing_incarnation": 3,
+        "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+        "revocation_stream_generation": 5,
+        "protocol_min": 1,
+        "protocol_max": 1,
+        "approved_at_unix_ms": 1786579260000,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "y0PKI2OlyTml7KGztmZgte2iPAn4xqnceHjtbsN91BWMTjaWLayST/b76mFYKehWNy9XtzYjOH8wh31t/c60Cg=="
+      },
+      "revocation": {
+        "artifact_version": 1,
+        "event_id": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "issuer_sequence": 13,
+        "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+        "revocation_stream_generation": 5,
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "controller": {
+          "registration_id": "44444444-4444-4444-8444-444444444444",
+          "device_id": "55555555-5555-4555-8555-555555555555",
+          "installation_id": "66666666-6666-4666-8666-666666666666",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+          "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+          "endpoint_epoch": 7
+        },
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 4
+        },
+        "pairing_incarnation": 3,
+        "pair_authorization_digest": "CQ/HPMinOZUsvf9kh5qmq8uOHtfoM45yj7HB/5704iQ=",
+        "revoked_by_registration_id": "44444444-4444-4444-8444-444444444444",
+        "revoked_by_role": "controller",
+        "reason_code": "user_removed_access",
+        "revoked_at_unix_ms": 1786579500000,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "Xhq3BWK+ptQj1+CKePKek3/9icVQDcYTdJ/bps0E9rsixkVnAR1fgJtwmYQiv9xI/8gugyqyce4DDzkWW61TCQ=="
+      },
+      "response": {
+        "protocol_version": 1,
+        "operation_id": "abababab-abab-4bab-8bab-abababababab",
+        "pairing": {
+          "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          "state": "revoked",
+          "revision": 4,
+          "pairing_incarnation": 3,
+          "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+          "revocation_stream_generation": 5,
+          "direction": "controller_to_host",
+          "execution_target_id": "77777777-7777-4777-8777-777777777777",
+          "controller_registration_id": "44444444-4444-4444-8444-444444444444",
+          "host_registration_id": "77777777-7777-4777-8777-777777777777",
+          "created_at_unix_ms": 1786579200000,
+          "expires_at_unix_ms": 1786579800000,
+          "approved_at_unix_ms": 1786579260000,
+          "activated_at_unix_ms": 1786579320000,
+          "revoked_at_unix_ms": 1786579500000,
+          "request_ticket": {
+            "artifact_version": 1,
+            "subject_account_id": "11111111-1111-4111-8111-111111111111",
+            "subject_project_id": "22222222-2222-4222-8222-222222222222",
+            "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            "direction": "controller_to_host",
+            "execution_target_id": "77777777-7777-4777-8777-777777777777",
+            "controller": {
+              "registration_id": "44444444-4444-4444-8444-444444444444",
+              "device_id": "55555555-5555-4555-8555-555555555555",
+              "installation_id": "66666666-6666-4666-8666-666666666666",
+              "identity_algorithm": "ed25519",
+              "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+              "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+              "endpoint_epoch": 7
+            },
+            "host": {
+              "registration_id": "77777777-7777-4777-8777-777777777777",
+              "device_id": "88888888-8888-4888-8888-888888888888",
+              "installation_id": "99999999-9999-4999-8999-999999999999",
+              "identity_algorithm": "ed25519",
+              "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+              "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+              "endpoint_epoch": 4
+            },
+            "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+            "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+            "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+            "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+            "pairing_incarnation": 3,
+            "protocol_min": 1,
+            "protocol_max": 1,
+            "created_at_unix_ms": 1786579200000,
+            "expires_at_unix_ms": 1786579800000,
+            "issuer_key_id": "maple-test-issuer-2026-08-13",
+            "issuer_signature": "7pFcCius3oPkwbDWAGRWGHUxAUDN8MEOQYKgerl9+jANv21mToaaCpJ4wWT/PElhq1OFgR+o18xRo21BcI9xAg=="
+          },
+          "pair_authorization": {
+            "artifact_version": 1,
+            "subject_account_id": "11111111-1111-4111-8111-111111111111",
+            "subject_project_id": "22222222-2222-4222-8222-222222222222",
+            "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            "direction": "controller_to_host",
+            "execution_target_id": "77777777-7777-4777-8777-777777777777",
+            "controller": {
+              "registration_id": "44444444-4444-4444-8444-444444444444",
+              "device_id": "55555555-5555-4555-8555-555555555555",
+              "installation_id": "66666666-6666-4666-8666-666666666666",
+              "identity_algorithm": "ed25519",
+              "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+              "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+              "endpoint_epoch": 7
+            },
+            "host": {
+              "registration_id": "77777777-7777-4777-8777-777777777777",
+              "device_id": "88888888-8888-4888-8888-888888888888",
+              "installation_id": "99999999-9999-4999-8999-999999999999",
+              "identity_algorithm": "ed25519",
+              "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+              "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+              "endpoint_epoch": 4
+            },
+            "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+            "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+            "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+            "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+            "request_ticket_digest": "WI1pBGQBP/rBJqixOKw2NQK0tqwkFiFJ07C0KMzPfFY=",
+            "host_approval_operation_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+            "host_approval_expected_pairing_revision": 1,
+            "host_approval_nonce": "LCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCw=",
+            "host_approval_digest": "dAPgkh43ujVyqz93IQU6CDGUhn+SOVlOSSUhMfWupxQ=",
+            "host_approval_signature": "rWNkE2XHl1r9G5jSiRCKCgFzdjQItEC50M2J4LqwrB/1vMTjqkYP0q0gKeNU9aFMWMZxFVg3f0NQpvAi07wABA==",
+            "pairing_incarnation": 3,
+            "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+            "revocation_stream_generation": 5,
+            "protocol_min": 1,
+            "protocol_max": 1,
+            "approved_at_unix_ms": 1786579260000,
+            "issuer_key_id": "maple-test-issuer-2026-08-13",
+            "issuer_signature": "y0PKI2OlyTml7KGztmZgte2iPAn4xqnceHjtbsN91BWMTjaWLayST/b76mFYKehWNy9XtzYjOH8wh31t/c60Cg=="
+          },
+          "revocation": {
+            "artifact_version": 1,
+            "event_id": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+            "subject_account_id": "11111111-1111-4111-8111-111111111111",
+            "subject_project_id": "22222222-2222-4222-8222-222222222222",
+            "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+            "issuer_sequence": 13,
+            "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+            "revocation_stream_generation": 5,
+            "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            "direction": "controller_to_host",
+            "execution_target_id": "77777777-7777-4777-8777-777777777777",
+            "controller": {
+              "registration_id": "44444444-4444-4444-8444-444444444444",
+              "device_id": "55555555-5555-4555-8555-555555555555",
+              "installation_id": "66666666-6666-4666-8666-666666666666",
+              "identity_algorithm": "ed25519",
+              "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+              "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+              "endpoint_epoch": 7
+            },
+            "host": {
+              "registration_id": "77777777-7777-4777-8777-777777777777",
+              "device_id": "88888888-8888-4888-8888-888888888888",
+              "installation_id": "99999999-9999-4999-8999-999999999999",
+              "identity_algorithm": "ed25519",
+              "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+              "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+              "endpoint_epoch": 4
+            },
+            "pairing_incarnation": 3,
+            "pair_authorization_digest": "CQ/HPMinOZUsvf9kh5qmq8uOHtfoM45yj7HB/5704iQ=",
+            "revoked_by_registration_id": "44444444-4444-4444-8444-444444444444",
+            "revoked_by_role": "controller",
+            "reason_code": "user_removed_access",
+            "revoked_at_unix_ms": 1786579500000,
+            "issuer_key_id": "maple-test-issuer-2026-08-13",
+            "issuer_signature": "Xhq3BWK+ptQj1+CKePKek3/9icVQDcYTdJ/bps0E9rsixkVnAR1fgJtwmYQiv9xI/8gugyqyce4DDzkWW61TCQ=="
+          }
+        }
+      }
+    }
+  },
+  "list_pairings_request": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "query_id": "10101010-1010-4010-8010-101010101010",
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "actor_registration_id": "44444444-4444-4444-8444-444444444444",
+    "role": "controller",
+    "states": [
+      "pending",
+      "awaiting_host_commit",
+      "active",
+      "expired",
+      "revoked"
+    ],
+    "cursor": "dGVzdC1vcGFxdWUtcGFpcmVkLWN1cnNvcg",
+    "limit": 2,
+    "signature": "6gGSuERXMBPFdlsbuNZ57iB/yHunV/N1XwoeBMJjLW2kSRAZux3D2Co8ypOQm8eCI1IAn4BB0qwYIFMxRdeVDg=="
+  },
+  "list_pairings_request_transcript_hex": "73000000156f732e6d61706c652d706169722d6c6973742e76316a0000000200016a000000020001750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001010101010101040108010101010101010750000001044444444444444448444444444444444730000000a636f6e74726f6c6c65726a000000020005730000000770656e64696e6773000000146177616974696e675f686f73745f636f6d6d6974730000000661637469766573000000076578706972656473000000077265766f6b65643f000000010173000000226447567a64433176634746786457557463474670636d566b4c574e31636e4e7663676a000000020002",
+  "list_pairings_request_digest": "7+mtD5oey0hQgKk9Cjl2bTJdA3f2YGrj1Dra9aotZwM=",
+  "pairing_status_request": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "query_id": "12121212-1212-4212-8212-121212121212",
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "actor_registration_id": "44444444-4444-4444-8444-444444444444",
+    "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    "signature": "u/L4rn9PPa1hz/4o2rtpcu8OsJSDr73njKFAZqWeKt0qk3DMGNTxLmW2MwwUnkG8WKxQsPHX01QkOcNTx51OAw=="
+  },
+  "pairing_status_request_transcript_hex": "73000000176f732e6d61706c652d706169722d7374617475732e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010121212121212421282121212121212127500000010444444444444444484444444444444447500000010cccccccccccc4ccc8ccccccccccccccc",
+  "pairing_status_request_digest": "TuA2R7uRBmyV9Xe5po9+9vJD308dEy/uAoGXFvTp6NA=",
+  "revoke_request": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "operation_id": "abababab-abab-4bab-8bab-abababababab",
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "actor_registration_id": "44444444-4444-4444-8444-444444444444",
+    "actor_role": "controller",
+    "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    "expected_pairing_revision": 3,
+    "pairing_incarnation": 3,
+    "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+    "revocation_stream_generation": 5,
+    "reason_code": "user_removed_access",
+    "signature": "ZpfeVbpIr5c4EsFPkIoJlHqrkX35D+QPr90vVUahXkKUm2QtNJIFNaAVza1/18mmNQ5tVF/i/VwRDpkKKOV/AA=="
+  },
+  "revoke_request_transcript_hex": "73000000236f732e6d61706c652d706169722d7265766f636174696f6e2d726571756573742e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010abababababab4bab8bababababababab750000001044444444444444448444444444444444730000000a636f6e74726f6c6c65727500000010bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb7500000010cccccccccccc4ccc8ccccccccccccccc6c0000000800000000000000034c0000000800000000000000037500000010151515151515451585151515151515154c0000000800000000000000057300000013757365725f72656d6f7665645f616363657373",
+  "revoke_request_digest": "ajfI78GRspuXBK5T0PELOuB6v3IKqUcrynVRLY7uoVQ=",
+  "list_revocations_request": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "query_id": "13131313-1313-4313-8313-131313131313",
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+    "revocation_stream_generation": 5,
+    "after_issuer_sequence": 12,
+    "limit": 1,
+    "signature": "jw90yOOuReheZGDWf/sv4Het/DHTF0RUIscTT+MoPfjKFwZ6+jTSy/eLySAqm3eg3RUlx8cWo5hcllWg/L2uAA=="
+  },
+  "list_revocations_request_transcript_hex": "73000000206f732e6d61706c652d706169722d7265766f636174696f6e2d6c6973742e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010131313131313431383131313131313137500000010777777777777477787777777777777777500000010151515151515451585151515151515154c0000000800000000000000054c00000008000000000000000c6a000000020001",
+  "list_revocations_request_digest": "cGRPcQq4iA0NDv6T8YVKi0TQvW57nfaaj5w0nSnxJfU=",
+  "ack_revocation_request": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "operation_id": "14141414-1414-4414-8414-141414141414",
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+    "revocation_stream_generation": 5,
+    "event_id": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+    "issuer_sequence": 13,
+    "event_digest": "4lrFM92xupl0KgY4udnUuN3H4/CppSxT7d9IMmfSDOI=",
+    "expected_previous_issuer_sequence": 12,
+    "signature": "SwpUr+g+fdbqg9vdpwE/2T+VCnpV1NoxlJkYgIZCjGwCZeryUpZr6NHhfZ7jgMBpp3oa9exEV0Lmm37fjag7DQ=="
+  },
+  "ack_revocation_request_transcript_hex": "730000001f6f732e6d61706c652d706169722d7265766f636174696f6e2d61636b2e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010141414141414441484141414141414147500000010777777777777477787777777777777777500000010151515151515451585151515151515154c0000000800000000000000057500000010ffffffffffff4fff8fffffffffffffff4c00000008000000000000000d6200000020e25ac533ddb1ba99742a0638b9d9d4b8ddc7e3f0a9a52c53eddf483267d20ce24c00000008000000000000000c",
+  "ack_revocation_request_digest": "RGlccodmkOKIkI0V0h4DLQkCduUiIBLCkmEnZoJTdj8=",
+  "pair_revocation": {
+    "artifact_version": 1,
+    "event_id": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+    "subject_account_id": "11111111-1111-4111-8111-111111111111",
+    "subject_project_id": "22222222-2222-4222-8222-222222222222",
+    "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "issuer_sequence": 13,
+    "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+    "revocation_stream_generation": 5,
+    "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    "direction": "controller_to_host",
+    "execution_target_id": "77777777-7777-4777-8777-777777777777",
+    "controller": {
+      "registration_id": "44444444-4444-4444-8444-444444444444",
+      "device_id": "55555555-5555-4555-8555-555555555555",
+      "installation_id": "66666666-6666-4666-8666-666666666666",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+      "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+      "endpoint_epoch": 7
+    },
+    "host": {
+      "registration_id": "77777777-7777-4777-8777-777777777777",
+      "device_id": "88888888-8888-4888-8888-888888888888",
+      "installation_id": "99999999-9999-4999-8999-999999999999",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+      "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+      "endpoint_epoch": 4
+    },
+    "pairing_incarnation": 3,
+    "pair_authorization_digest": "CQ/HPMinOZUsvf9kh5qmq8uOHtfoM45yj7HB/5704iQ=",
+    "revoked_by_registration_id": "44444444-4444-4444-8444-444444444444",
+    "revoked_by_role": "controller",
+    "reason_code": "user_removed_access",
+    "revoked_at_unix_ms": 1786579500000,
+    "issuer_key_id": "maple-test-issuer-2026-08-13",
+    "issuer_signature": "Xhq3BWK+ptQj1+CKePKek3/9icVQDcYTdJ/bps0E9rsixkVnAR1fgJtwmYQiv9xI/8gugyqyce4DDzkWW61TCQ=="
+  },
+  "pair_revocation_transcript_hex": "730000001b6f732e6d61706c652d706169722d7265766f636174696f6e2e76316a0000000200017500000010ffffffffffff4fff8fffffffffffffff7500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010777777777777477787777777777777774c00000008000000000000000d7500000010151515151515451585151515151515154c0000000800000000000000057500000010bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb7500000010cccccccccccc4ccc8ccccccccccccccc7300000012636f6e74726f6c6c65725f746f5f686f73747500000010777777777777477787777777777777777500000010444444444444444484444444444444447500000010555555555555455585555555555555557500000010666666666666466686666666666666667300000007656432353531396200000020d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c97787376200000020d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c97787374c000000080000000000000007750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000044c0000000800000000000000036200000020090fc73cc8a739952cbdff64879aa6abcb8e1ed7e8338e728fb1c1ff9ef4e224750000001044444444444444448444444444444444730000000a636f6e74726f6c6c65727300000013757365725f72656d6f7665645f6163636573736c000000080000019ff86fbbe0730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+  "pair_revocation_digest": "4lrFM92xupl0KgY4udnUuN3H4/CppSxT7d9IMmfSDOI=",
+  "list_pairings_response": {
+    "protocol_version": 1,
+    "query_id": "10101010-1010-4010-8010-101010101010",
+    "role": "controller",
+    "pairings": [
+      {
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "state": "pending",
+        "revision": 1,
+        "pairing_incarnation": 3,
+        "revocation_stream_id": null,
+        "revocation_stream_generation": null,
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "controller_registration_id": "44444444-4444-4444-8444-444444444444",
+        "host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "created_at_unix_ms": 1786579200000,
+        "expires_at_unix_ms": 1786579800000,
+        "approved_at_unix_ms": null,
+        "activated_at_unix_ms": null,
+        "revoked_at_unix_ms": null,
+        "request_ticket": {
+          "artifact_version": 1,
+          "subject_account_id": "11111111-1111-4111-8111-111111111111",
+          "subject_project_id": "22222222-2222-4222-8222-222222222222",
+          "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          "direction": "controller_to_host",
+          "execution_target_id": "77777777-7777-4777-8777-777777777777",
+          "controller": {
+            "registration_id": "44444444-4444-4444-8444-444444444444",
+            "device_id": "55555555-5555-4555-8555-555555555555",
+            "installation_id": "66666666-6666-4666-8666-666666666666",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+            "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+            "endpoint_epoch": 7
+          },
+          "host": {
+            "registration_id": "77777777-7777-4777-8777-777777777777",
+            "device_id": "88888888-8888-4888-8888-888888888888",
+            "installation_id": "99999999-9999-4999-8999-999999999999",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+            "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+            "endpoint_epoch": 4
+          },
+          "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+          "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+          "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+          "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+          "pairing_incarnation": 3,
+          "protocol_min": 1,
+          "protocol_max": 1,
+          "created_at_unix_ms": 1786579200000,
+          "expires_at_unix_ms": 1786579800000,
+          "issuer_key_id": "maple-test-issuer-2026-08-13",
+          "issuer_signature": "7pFcCius3oPkwbDWAGRWGHUxAUDN8MEOQYKgerl9+jANv21mToaaCpJ4wWT/PElhq1OFgR+o18xRo21BcI9xAg=="
+        },
+        "pair_authorization": null,
+        "revocation": null
+      }
+    ],
+    "next_cursor": "dGVzdC1uZXh0LWN1cnNvcg",
+    "has_more": true
+  },
+  "pairing_status_response": {
+    "protocol_version": 1,
+    "query_id": "12121212-1212-4212-8212-121212121212",
+    "pairing": {
+      "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      "state": "active",
+      "revision": 3,
+      "pairing_incarnation": 3,
+      "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+      "revocation_stream_generation": 5,
+      "direction": "controller_to_host",
+      "execution_target_id": "77777777-7777-4777-8777-777777777777",
+      "controller_registration_id": "44444444-4444-4444-8444-444444444444",
+      "host_registration_id": "77777777-7777-4777-8777-777777777777",
+      "created_at_unix_ms": 1786579200000,
+      "expires_at_unix_ms": 1786579800000,
+      "approved_at_unix_ms": 1786579260000,
+      "activated_at_unix_ms": 1786579320000,
+      "revoked_at_unix_ms": null,
+      "request_ticket": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "controller": {
+          "registration_id": "44444444-4444-4444-8444-444444444444",
+          "device_id": "55555555-5555-4555-8555-555555555555",
+          "installation_id": "66666666-6666-4666-8666-666666666666",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+          "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+          "endpoint_epoch": 7
+        },
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 4
+        },
+        "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+        "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+        "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+        "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+        "pairing_incarnation": 3,
+        "protocol_min": 1,
+        "protocol_max": 1,
+        "created_at_unix_ms": 1786579200000,
+        "expires_at_unix_ms": 1786579800000,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "7pFcCius3oPkwbDWAGRWGHUxAUDN8MEOQYKgerl9+jANv21mToaaCpJ4wWT/PElhq1OFgR+o18xRo21BcI9xAg=="
+      },
+      "pair_authorization": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "controller": {
+          "registration_id": "44444444-4444-4444-8444-444444444444",
+          "device_id": "55555555-5555-4555-8555-555555555555",
+          "installation_id": "66666666-6666-4666-8666-666666666666",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+          "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+          "endpoint_epoch": 7
+        },
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 4
+        },
+        "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+        "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+        "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+        "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+        "request_ticket_digest": "WI1pBGQBP/rBJqixOKw2NQK0tqwkFiFJ07C0KMzPfFY=",
+        "host_approval_operation_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        "host_approval_expected_pairing_revision": 1,
+        "host_approval_nonce": "LCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCw=",
+        "host_approval_digest": "dAPgkh43ujVyqz93IQU6CDGUhn+SOVlOSSUhMfWupxQ=",
+        "host_approval_signature": "rWNkE2XHl1r9G5jSiRCKCgFzdjQItEC50M2J4LqwrB/1vMTjqkYP0q0gKeNU9aFMWMZxFVg3f0NQpvAi07wABA==",
+        "pairing_incarnation": 3,
+        "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+        "revocation_stream_generation": 5,
+        "protocol_min": 1,
+        "protocol_max": 1,
+        "approved_at_unix_ms": 1786579260000,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "y0PKI2OlyTml7KGztmZgte2iPAn4xqnceHjtbsN91BWMTjaWLayST/b76mFYKehWNy9XtzYjOH8wh31t/c60Cg=="
+      },
+      "revocation": null
+    }
+  },
+  "list_revocations_response": {
+    "protocol_version": 1,
+    "query_id": "13131313-1313-4313-8313-131313131313",
+    "revocation_sync": {
+      "security_epoch": 1,
+      "status": "revocations_pending",
+      "stream_checkpoint": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "security_epoch": 1,
+        "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+        "revocation_stream_generation": 5,
+        "last_issued_issuer_sequence": 13,
+        "last_acked_issuer_sequence": 12,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "Ocit/eWHm/PtJeyK2w9H/CyMOnjt1c4SZTyEjkaN06FDvYwxLkVq/eFJoKDqAvFBr1dpWhQAeKdZcx+yRNmIDA=="
+      },
+      "reset_clear_instruction": null
+    },
+    "events": [
+      {
+        "event_type": "pair_revocation",
+        "event": {
+          "artifact_version": 1,
+          "event_id": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+          "subject_account_id": "11111111-1111-4111-8111-111111111111",
+          "subject_project_id": "22222222-2222-4222-8222-222222222222",
+          "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+          "issuer_sequence": 13,
+          "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+          "revocation_stream_generation": 5,
+          "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          "direction": "controller_to_host",
+          "execution_target_id": "77777777-7777-4777-8777-777777777777",
+          "controller": {
+            "registration_id": "44444444-4444-4444-8444-444444444444",
+            "device_id": "55555555-5555-4555-8555-555555555555",
+            "installation_id": "66666666-6666-4666-8666-666666666666",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+            "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+            "endpoint_epoch": 7
+          },
+          "host": {
+            "registration_id": "77777777-7777-4777-8777-777777777777",
+            "device_id": "88888888-8888-4888-8888-888888888888",
+            "installation_id": "99999999-9999-4999-8999-999999999999",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+            "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+            "endpoint_epoch": 4
+          },
+          "pairing_incarnation": 3,
+          "pair_authorization_digest": "CQ/HPMinOZUsvf9kh5qmq8uOHtfoM45yj7HB/5704iQ=",
+          "revoked_by_registration_id": "44444444-4444-4444-8444-444444444444",
+          "revoked_by_role": "controller",
+          "reason_code": "user_removed_access",
+          "revoked_at_unix_ms": 1786579500000,
+          "issuer_key_id": "maple-test-issuer-2026-08-13",
+          "issuer_signature": "Xhq3BWK+ptQj1+CKePKek3/9icVQDcYTdJ/bps0E9rsixkVnAR1fgJtwmYQiv9xI/8gugyqyce4DDzkWW61TCQ=="
+        }
+      }
+    ],
+    "next_after_issuer_sequence": 13,
+    "has_more": false
+  },
+  "revoke_receipt": {
+    "protocol_version": 1,
+    "operation_id": "abababab-abab-4bab-8bab-abababababab",
+    "pairing": {
+      "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      "state": "revoked",
+      "revision": 4,
+      "pairing_incarnation": 3,
+      "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+      "revocation_stream_generation": 5,
+      "direction": "controller_to_host",
+      "execution_target_id": "77777777-7777-4777-8777-777777777777",
+      "controller_registration_id": "44444444-4444-4444-8444-444444444444",
+      "host_registration_id": "77777777-7777-4777-8777-777777777777",
+      "created_at_unix_ms": 1786579200000,
+      "expires_at_unix_ms": 1786579800000,
+      "approved_at_unix_ms": 1786579260000,
+      "activated_at_unix_ms": 1786579320000,
+      "revoked_at_unix_ms": 1786579500000,
+      "request_ticket": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "controller": {
+          "registration_id": "44444444-4444-4444-8444-444444444444",
+          "device_id": "55555555-5555-4555-8555-555555555555",
+          "installation_id": "66666666-6666-4666-8666-666666666666",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+          "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+          "endpoint_epoch": 7
+        },
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 4
+        },
+        "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+        "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+        "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+        "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+        "pairing_incarnation": 3,
+        "protocol_min": 1,
+        "protocol_max": 1,
+        "created_at_unix_ms": 1786579200000,
+        "expires_at_unix_ms": 1786579800000,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "7pFcCius3oPkwbDWAGRWGHUxAUDN8MEOQYKgerl9+jANv21mToaaCpJ4wWT/PElhq1OFgR+o18xRo21BcI9xAg=="
+      },
+      "pair_authorization": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "controller": {
+          "registration_id": "44444444-4444-4444-8444-444444444444",
+          "device_id": "55555555-5555-4555-8555-555555555555",
+          "installation_id": "66666666-6666-4666-8666-666666666666",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+          "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+          "endpoint_epoch": 7
+        },
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 4
+        },
+        "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+        "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+        "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+        "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+        "request_ticket_digest": "WI1pBGQBP/rBJqixOKw2NQK0tqwkFiFJ07C0KMzPfFY=",
+        "host_approval_operation_id": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        "host_approval_expected_pairing_revision": 1,
+        "host_approval_nonce": "LCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCw=",
+        "host_approval_digest": "dAPgkh43ujVyqz93IQU6CDGUhn+SOVlOSSUhMfWupxQ=",
+        "host_approval_signature": "rWNkE2XHl1r9G5jSiRCKCgFzdjQItEC50M2J4LqwrB/1vMTjqkYP0q0gKeNU9aFMWMZxFVg3f0NQpvAi07wABA==",
+        "pairing_incarnation": 3,
+        "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+        "revocation_stream_generation": 5,
+        "protocol_min": 1,
+        "protocol_max": 1,
+        "approved_at_unix_ms": 1786579260000,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "y0PKI2OlyTml7KGztmZgte2iPAn4xqnceHjtbsN91BWMTjaWLayST/b76mFYKehWNy9XtzYjOH8wh31t/c60Cg=="
+      },
+      "revocation": {
+        "artifact_version": 1,
+        "event_id": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "issuer_sequence": 13,
+        "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+        "revocation_stream_generation": 5,
+        "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        "direction": "controller_to_host",
+        "execution_target_id": "77777777-7777-4777-8777-777777777777",
+        "controller": {
+          "registration_id": "44444444-4444-4444-8444-444444444444",
+          "device_id": "55555555-5555-4555-8555-555555555555",
+          "installation_id": "66666666-6666-4666-8666-666666666666",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+          "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+          "endpoint_epoch": 7
+        },
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 4
+        },
+        "pairing_incarnation": 3,
+        "pair_authorization_digest": "CQ/HPMinOZUsvf9kh5qmq8uOHtfoM45yj7HB/5704iQ=",
+        "revoked_by_registration_id": "44444444-4444-4444-8444-444444444444",
+        "revoked_by_role": "controller",
+        "reason_code": "user_removed_access",
+        "revoked_at_unix_ms": 1786579500000,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "Xhq3BWK+ptQj1+CKePKek3/9icVQDcYTdJ/bps0E9rsixkVnAR1fgJtwmYQiv9xI/8gugyqyce4DDzkWW61TCQ=="
+      }
+    }
+  },
+  "ack_revocation_response": {
+    "protocol_version": 1,
+    "operation_id": "14141414-1414-4414-8414-141414141414",
+    "host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "stream_checkpoint": {
+      "artifact_version": 1,
+      "subject_account_id": "11111111-1111-4111-8111-111111111111",
+      "subject_project_id": "22222222-2222-4222-8222-222222222222",
+      "host": {
+        "registration_id": "77777777-7777-4777-8777-777777777777",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "installation_id": "99999999-9999-4999-8999-999999999999",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+        "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+        "endpoint_epoch": 5
+      },
+      "security_epoch": 1,
+      "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+      "revocation_stream_generation": 5,
+      "last_issued_issuer_sequence": 13,
+      "last_acked_issuer_sequence": 13,
+      "issuer_key_id": "maple-test-issuer-2026-08-13",
+      "issuer_signature": "1WhgTrap8buDfouy6y46EB8W4ri+nOD+dvvR4CB5qrIuejK8oO5sJXURDBxzymwAIOp5LgSGp4VnkiOqi+MaDg=="
+    },
+    "event_id": "ffffffff-ffff-4fff-8fff-ffffffffffff",
+    "issuer_sequence": 13,
+    "last_acked_issuer_sequence": 13,
+    "accepted_at_unix_ms": 1786579501000
+  },
+  "revocation_stream_checkpoint": {
+    "artifact_version": 1,
+    "subject_account_id": "11111111-1111-4111-8111-111111111111",
+    "subject_project_id": "22222222-2222-4222-8222-222222222222",
+    "host": {
+      "registration_id": "77777777-7777-4777-8777-777777777777",
+      "device_id": "88888888-8888-4888-8888-888888888888",
+      "installation_id": "99999999-9999-4999-8999-999999999999",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+      "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+      "endpoint_epoch": 5
+    },
+    "security_epoch": 1,
+    "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+    "revocation_stream_generation": 5,
+    "last_issued_issuer_sequence": 13,
+    "last_acked_issuer_sequence": 12,
+    "issuer_key_id": "maple-test-issuer-2026-08-13",
+    "issuer_signature": "Ocit/eWHm/PtJeyK2w9H/CyMOnjt1c4SZTyEjkaN06FDvYwxLkVq/eFJoKDqAvFBr1dpWhQAeKdZcx+yRNmIDA=="
+  },
+  "revocation_stream_checkpoint_transcript_hex": "73000000286f732e6d61706c652d7265766f636174696f6e2d73747265616d2d636865636b706f696e742e76316a000000020001750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000054c0000000800000000000000017500000010151515151515451585151515151515154c0000000800000000000000054c00000008000000000000000d4c00000008000000000000000c730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+  "revocation_stream_checkpoint_digest": "0B1+yREEpFC4epwXLroi30AXHhYAGib3xIppiyEWALQ=",
+  "ack_revocation_stream_checkpoint": {
+    "artifact_version": 1,
+    "subject_account_id": "11111111-1111-4111-8111-111111111111",
+    "subject_project_id": "22222222-2222-4222-8222-222222222222",
+    "host": {
+      "registration_id": "77777777-7777-4777-8777-777777777777",
+      "device_id": "88888888-8888-4888-8888-888888888888",
+      "installation_id": "99999999-9999-4999-8999-999999999999",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+      "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+      "endpoint_epoch": 5
+    },
+    "security_epoch": 1,
+    "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+    "revocation_stream_generation": 5,
+    "last_issued_issuer_sequence": 13,
+    "last_acked_issuer_sequence": 13,
+    "issuer_key_id": "maple-test-issuer-2026-08-13",
+    "issuer_signature": "1WhgTrap8buDfouy6y46EB8W4ri+nOD+dvvR4CB5qrIuejK8oO5sJXURDBxzymwAIOp5LgSGp4VnkiOqi+MaDg=="
+  },
+  "ack_revocation_stream_checkpoint_transcript_hex": "73000000286f732e6d61706c652d7265766f636174696f6e2d73747265616d2d636865636b706f696e742e76316a000000020001750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000054c0000000800000000000000017500000010151515151515451585151515151515154c0000000800000000000000054c00000008000000000000000d4c00000008000000000000000d730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+  "ack_revocation_stream_checkpoint_digest": "4P26DwwR7180VFxcE9n2mhQ4JCxMr8kRw3CiHWE0Wsg=",
+  "discovery_list_revocations_request": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "query_id": "18181818-1818-4818-8818-181818181818",
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "revocation_stream_id": "00000000-0000-0000-0000-000000000000",
+    "revocation_stream_generation": 0,
+    "after_issuer_sequence": 0,
+    "limit": 1,
+    "signature": "/dI46u4T3kyGgKQPZH767AZI+2NfL4WJ1eVTavAJnT4Tf78NCrYiLnfl0b0mmhu4k+QXui3GBD+s3Vj7cV52Dw=="
+  },
+  "discovery_list_revocations_request_transcript_hex": "73000000206f732e6d61706c652d706169722d7265766f636174696f6e2d6c6973742e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010181818181818481888181818181818187500000010777777777777477787777777777777777500000010000000000000000000000000000000004c0000000800000000000000004c0000000800000000000000006a000000020001",
+  "discovery_list_revocations_request_digest": "7DO/wi1SpRq+mxyQql00YQSQUQ18iEH1fSL0eXY+9hU=",
+  "discovery_revocation_stream_checkpoint": {
+    "artifact_version": 1,
+    "subject_account_id": "11111111-1111-4111-8111-111111111111",
+    "subject_project_id": "22222222-2222-4222-8222-222222222222",
+    "host": {
+      "registration_id": "77777777-7777-4777-8777-777777777777",
+      "device_id": "88888888-8888-4888-8888-888888888888",
+      "installation_id": "99999999-9999-4999-8999-999999999999",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+      "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+      "endpoint_epoch": 5
+    },
+    "security_epoch": 1,
+    "revocation_stream_id": "16161616-1616-4616-8616-161616161616",
+    "revocation_stream_generation": 6,
+    "last_issued_issuer_sequence": 0,
+    "last_acked_issuer_sequence": 0,
+    "issuer_key_id": "maple-test-issuer-2026-08-13",
+    "issuer_signature": "qXbXV/sML75iXbUVpP7Yu6qXRu6+DSE0iVBfpGk5p9dCVULlWUbVdAz8Mk6ZjiicDA1pSldc46dUxlKL3H4/Cg=="
+  },
+  "discovery_revocation_stream_checkpoint_transcript_hex": "73000000286f732e6d61706c652d7265766f636174696f6e2d73747265616d2d636865636b706f696e742e76316a000000020001750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000054c0000000800000000000000017500000010161616161616461686161616161616164c0000000800000000000000064c0000000800000000000000004c000000080000000000000000730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+  "discovery_revocation_stream_checkpoint_digest": "oLL2nnQztReZ6vCYtBxEw5eh+RuCZIa1Sk6NdYEeEsk=",
+  "discovery_list_revocations_response": {
+    "protocol_version": 1,
+    "query_id": "18181818-1818-4818-8818-181818181818",
+    "revocation_sync": {
+      "security_epoch": 1,
+      "status": "ready",
+      "stream_checkpoint": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "security_epoch": 1,
+        "revocation_stream_id": "16161616-1616-4616-8616-161616161616",
+        "revocation_stream_generation": 6,
+        "last_issued_issuer_sequence": 0,
+        "last_acked_issuer_sequence": 0,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "qXbXV/sML75iXbUVpP7Yu6qXRu6+DSE0iVBfpGk5p9dCVULlWUbVdAz8Mk6ZjiicDA1pSldc46dUxlKL3H4/Cg=="
+      },
+      "reset_clear_instruction": null
+    },
+    "events": [],
+    "next_after_issuer_sequence": 0,
+    "has_more": false
+  },
+  "reset_clear_admission_set_vectors": {
+    "empty": {
+      "artifact_version": 1,
+      "leaves": [],
+      "transcript_hex": "73000000256f732e6d61706c652d72657365742d636c6561722d61646d697373696f6e2d7365742e76316a0000000200016a000000020000",
+      "digest": "7wU8UwigHo6NmQ8LjGSKcoXG8g3aVUxDP4bl19AeDEk="
+    },
+    "max_128": {
+      "artifact_version": 1,
+      "leaves": [
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000000",
+          "pairing_incarnation": 1,
+          "pair_authorization_digest": "x4BdmpN+utoYeic3c+jZQdgmm0VZ3BPIJfVG80kYK8w="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000001",
+          "pairing_incarnation": 2,
+          "pair_authorization_digest": "pbFbwAu9SJKxSIUZacd/ovdBRAeP8smkE3xlBWDvyPQ="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000002",
+          "pairing_incarnation": 3,
+          "pair_authorization_digest": "3p8tPYGDxfq+iLCqRbTOjO9TyuoYFP+UANIPIvTI9vE="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000003",
+          "pairing_incarnation": 4,
+          "pair_authorization_digest": "JUJ9pl+tHGEoQmlWle1b91IYPud8kgclU2B88Gzc+5E="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000004",
+          "pairing_incarnation": 5,
+          "pair_authorization_digest": "wktHYEBXFJ0giuFmfBw6ul084lVKdSXgCLMplM6lWxs="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000005",
+          "pairing_incarnation": 6,
+          "pair_authorization_digest": "1XeOrtEnPlBFEvWKQDprHQ3vBNowAVGek7k3o2/DG8Q="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000006",
+          "pairing_incarnation": 7,
+          "pair_authorization_digest": "MVA1mB7SZ7XNDxyB06AKbaBdcR3NUo2FJVLbLJFMWuQ="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000007",
+          "pairing_incarnation": 8,
+          "pair_authorization_digest": "zwrXNv8XTnQ3+y6bPHyCAss692GFhKnI+FwrgBGLmjc="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000008",
+          "pairing_incarnation": 9,
+          "pair_authorization_digest": "cpHhEiBz+BBZ4rF97vn9RAhKSN5Ri9C6aovXu9M9xZk="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000009",
+          "pairing_incarnation": 10,
+          "pair_authorization_digest": "bEnOxyxYSAswHk59r1KuMWsmyLx1gX0s3Wu7fu97Fg4="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000000a",
+          "pairing_incarnation": 11,
+          "pair_authorization_digest": "lw4VVJwvFvtiTk0eUdBJ2wtzXaOSXYgraILnppMy4w4="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000000b",
+          "pairing_incarnation": 12,
+          "pair_authorization_digest": "xaXR0bOzB4UTQKP7TmhN8Ard61rVw6M9gBWtBrxOpM0="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000000c",
+          "pairing_incarnation": 13,
+          "pair_authorization_digest": "m0/0mm6qwgCZB2BbVbET5PtLG6srAkdbgoMy9k08brI="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000000d",
+          "pairing_incarnation": 14,
+          "pair_authorization_digest": "M9wxM3868Qg+nVPzqDSJZPnCb0AqhOK00RT4M1+wdeo="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000000e",
+          "pairing_incarnation": 15,
+          "pair_authorization_digest": "K8/8w9B0tRLXcvvp//eKqgKQaq2/67Np0gBBFUsro2g="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000000f",
+          "pairing_incarnation": 16,
+          "pair_authorization_digest": "hyVMYXCfnC4Gv1vuZahKongSPgPjBHoIIDZBMsu2b7A="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000010",
+          "pairing_incarnation": 17,
+          "pair_authorization_digest": "5uhDZEbt+ga4dHK1Dk5IHCzGfZ2qs1Zwbp8kzMH++fQ="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000011",
+          "pairing_incarnation": 18,
+          "pair_authorization_digest": "aqlP/p7BEQULuzA/DklJErra+r3nS6gRAU9f4IKay1U="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000012",
+          "pairing_incarnation": 19,
+          "pair_authorization_digest": "sryFnBhbGpGWPg9lEpV9wBbHnovqgW7zlryJB/36NWA="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000013",
+          "pairing_incarnation": 20,
+          "pair_authorization_digest": "Bs0sRq7ix4JAuhNaZiN+GEM+MSYEnehbwRDevF4oEdI="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000014",
+          "pairing_incarnation": 21,
+          "pair_authorization_digest": "iFY6LODjMhm3Qyu5HnUqDjtOFCXSZM7DCsDc7Pl5mF4="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000015",
+          "pairing_incarnation": 22,
+          "pair_authorization_digest": "L+1P38Y0JOjTIgsRivIXAEMnb7OBNZpPBzsXRjGJy6w="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000016",
+          "pairing_incarnation": 23,
+          "pair_authorization_digest": "3VkK6akpOti7+1HZAqhWV2YTYLHxMQX/+61qouvVQy4="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000017",
+          "pairing_incarnation": 24,
+          "pair_authorization_digest": "CTjHbFXLAug0yTgyUHBCa26GDq6bFLxs003ov3kqBTw="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000018",
+          "pairing_incarnation": 25,
+          "pair_authorization_digest": "qW7tFO3Rv11AhkQW26qe0qJaMmu/0AkJ8JwL5Z1r4J0="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000019",
+          "pairing_incarnation": 26,
+          "pair_authorization_digest": "tBS6cwSyQTzCRMVwZohDpjx8Qt8mpqud+6ZP+fAQEa4="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000001a",
+          "pairing_incarnation": 27,
+          "pair_authorization_digest": "9rdPVYq7GW7EzE/78wnav4+DVVXcpOlPHzZaDa5FCBc="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000001b",
+          "pairing_incarnation": 28,
+          "pair_authorization_digest": "pmYgil5bfe3SRM8aOsP1+O4rrew3ZiOTgtkRUILsUYY="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000001c",
+          "pairing_incarnation": 29,
+          "pair_authorization_digest": "P9lef6itSlSyGIvCCz0VqQT3iP9I2ys2m9Qek9CPQ30="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000001d",
+          "pairing_incarnation": 30,
+          "pair_authorization_digest": "q3QZVY5MATslC/vB11XP7jxkkWA+fcqQAsa8qNVJoH0="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000001e",
+          "pairing_incarnation": 31,
+          "pair_authorization_digest": "5Z+/dsRv9YxPnkYlnPWDZ9WOe3fi3psl0yqbDwX98E8="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000001f",
+          "pairing_incarnation": 32,
+          "pair_authorization_digest": "boT4DoCjqS5zhWBwazQr/YY8Z3Nn5lLMj7rv6eA7Hrc="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000020",
+          "pairing_incarnation": 33,
+          "pair_authorization_digest": "W0ShfC8JbeEFuYNRrwSdDaTD7B78WUqdWNIUTpnamSk="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000021",
+          "pairing_incarnation": 34,
+          "pair_authorization_digest": "FTMkqdOqxYOmG4l+WPyowyGloLbSeiFXcnVRrJ4VDpw="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000022",
+          "pairing_incarnation": 35,
+          "pair_authorization_digest": "sDmcUHxFpyl+ummwDUfWpA+nKBcwbQN802BCrI0qzjE="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000023",
+          "pairing_incarnation": 36,
+          "pair_authorization_digest": "Ekkc+radkx96NMYXlXAKelXo0Oz2rhEKKVlHYJMt0bE="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000024",
+          "pairing_incarnation": 37,
+          "pair_authorization_digest": "MS6x6oMliwS6iiPGKSkxbI+J7tkcr0oMmyfNzGu4LkQ="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000025",
+          "pairing_incarnation": 38,
+          "pair_authorization_digest": "OQmh8iH5g5OBDQsbzu/7iBKumnMUZirzniKn8AiDNOw="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000026",
+          "pairing_incarnation": 39,
+          "pair_authorization_digest": "6RiH7t03728X86zhx0SxNkpyAcWeXscb1Af6biqcfgw="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000027",
+          "pairing_incarnation": 40,
+          "pair_authorization_digest": "DVMLCbSrd5FFywo/Vd8xRIPsdTuhen2VvTlxB2jMtRo="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000028",
+          "pairing_incarnation": 41,
+          "pair_authorization_digest": "xe5HxZI3JZUDAVhy0yDkEwxI2DpqXIWNg+J94ujeWDo="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000029",
+          "pairing_incarnation": 42,
+          "pair_authorization_digest": "vCe2aanorpPwVqpBJBhIHfTYZm6lOx6M0y7x/4/BZ0Y="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000002a",
+          "pairing_incarnation": 43,
+          "pair_authorization_digest": "fCWtpj41IQLNIAdTTzZ5BwdU2cHsqRg0Y7xW9x0+HBY="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000002b",
+          "pairing_incarnation": 44,
+          "pair_authorization_digest": "Ni2LCm6pjlsd45JUNIMIPHW0xeTFo9XTjR9PqO2E0eU="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000002c",
+          "pairing_incarnation": 45,
+          "pair_authorization_digest": "2sbE23/yfoYS4m7h4hF8c9+g+LepizT86rRgBv5Dfcg="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000002d",
+          "pairing_incarnation": 46,
+          "pair_authorization_digest": "i3Css+SaTFFIPxFD8iUiGlqLJ5D5IqNxyLacJrIBvMU="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000002e",
+          "pairing_incarnation": 47,
+          "pair_authorization_digest": "viXjY7CD39D3ITJfr7PaBo0cJdL9w6O+v4bCxwulSN4="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000002f",
+          "pairing_incarnation": 48,
+          "pair_authorization_digest": "214mfOTzXkhH/HEgF9ud9OgZHTnlvz9Y39RKqVgc9+Y="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000030",
+          "pairing_incarnation": 49,
+          "pair_authorization_digest": "wzB4q4dyksb+sib3CN+C9PlsAxR9lf+kMHqBjI1c028="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000031",
+          "pairing_incarnation": 50,
+          "pair_authorization_digest": "7rKqSHLoum2COc/pdolUOQfdTlIUOVnMyDA5Li3+hQU="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000032",
+          "pairing_incarnation": 51,
+          "pair_authorization_digest": "ehpyDd/b4FIiaqB9dm9CMu+/aLe93qz6gfG9NhF1D98="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000033",
+          "pairing_incarnation": 52,
+          "pair_authorization_digest": "1HkFoL/IHJ/p/OLfmfSs2ROWeuUEAu95CvMRYrNWBQg="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000034",
+          "pairing_incarnation": 53,
+          "pair_authorization_digest": "lTskU6sQoj7lGo8jWbvO5ldssyP0QS0/nnb4ZKSzgYo="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000035",
+          "pairing_incarnation": 54,
+          "pair_authorization_digest": "HSm545hTdDbuM+lCejzV/cuBW/nPu66gDVsxR2mvWm0="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000036",
+          "pairing_incarnation": 55,
+          "pair_authorization_digest": "ggImAHY3Pa9FQVRURLj8S+27bqOwDScD0Q9qfklxN2c="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000037",
+          "pairing_incarnation": 56,
+          "pair_authorization_digest": "4pDeiVGIF5pDznwnyUNpzJ2tx5oLXHOXHNSDOwN3Dl0="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000038",
+          "pairing_incarnation": 57,
+          "pair_authorization_digest": "gM9v9wyiJzbE4UJGR0jBG4A1+YqB84pVtWx3dYau+MY="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000039",
+          "pairing_incarnation": 58,
+          "pair_authorization_digest": "r79sMOp4Os4aZF/VHhoEWTpExQJAbOfL3BnRi9Mb5C8="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000003a",
+          "pairing_incarnation": 59,
+          "pair_authorization_digest": "lnEmYSd/+RFbPvzC8XcxjjA5w9nLj2CRI7e9KRyTB8I="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000003b",
+          "pairing_incarnation": 60,
+          "pair_authorization_digest": "6f8VaYsH4ZjiNTSYJUA1GKXpwRyNKw513Kj8hKAGj0E="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000003c",
+          "pairing_incarnation": 61,
+          "pair_authorization_digest": "H0JPQ1TvO7uZxnPtIbgj7h+b3COXc0sFnvjoo4/BXes="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000003d",
+          "pairing_incarnation": 62,
+          "pair_authorization_digest": "4CrU0MyLfFgqfnZwC4eGhPS7pb93+/SlwIHmbenkj/w="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000003e",
+          "pairing_incarnation": 63,
+          "pair_authorization_digest": "ogfoyBAQcgFJMToDKdtM3FVNNqWQoA+4vHF1163ptkc="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000003f",
+          "pairing_incarnation": 64,
+          "pair_authorization_digest": "C1th6lnTdOnIc7iODztcTDCHCCwPl6N+8AxpFoZrTYo="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000040",
+          "pairing_incarnation": 65,
+          "pair_authorization_digest": "lEsuH4kbhKU15eHJEo9+dvT0t/292TxcV9pmzS/6KdI="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000041",
+          "pairing_incarnation": 66,
+          "pair_authorization_digest": "86BxPawnSHXD8y1avQChzZKu4RAOrZFtgxuVfs4zu7M="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000042",
+          "pairing_incarnation": 67,
+          "pair_authorization_digest": "nNgJ1H8dYMBLcb+J/+b3aUDiaSaSIpPhJvFLRdej5ts="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000043",
+          "pairing_incarnation": 68,
+          "pair_authorization_digest": "EJDwAXweNtev0B2kHHxnzVzYMqWr4zMw111pWqkXDTs="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000044",
+          "pairing_incarnation": 69,
+          "pair_authorization_digest": "3CqT0PSuLHJWy048nVky5IiDEFvIyKr5jQSf0ov+TJQ="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000045",
+          "pairing_incarnation": 70,
+          "pair_authorization_digest": "EC8BugX5wWfkjRvbryTbxdijt6+VIkrivfGRvF5lJbQ="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000046",
+          "pairing_incarnation": 71,
+          "pair_authorization_digest": "2YYb5eRW+noogP50ULzlkHLIsJ/AlKwx7tPUTm9kr5o="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000047",
+          "pairing_incarnation": 72,
+          "pair_authorization_digest": "ebLiiwp3KVQC2sOZk8PrygGzZc3Xs/b5MLlkBJ1p4YA="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000048",
+          "pairing_incarnation": 73,
+          "pair_authorization_digest": "Oo8LzoendX4bEPvVuhoZW/qZxOpNdwhHSSvOVVbyg08="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000049",
+          "pairing_incarnation": 74,
+          "pair_authorization_digest": "HD0pakY0Nlxbu+J5XV6S8+97F5gcrsY1BaKhBs+nWBI="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000004a",
+          "pairing_incarnation": 75,
+          "pair_authorization_digest": "+FzF3iQW80r8XDC8REphET/xhdfhwRA/HVklH3UCFE4="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000004b",
+          "pairing_incarnation": 76,
+          "pair_authorization_digest": "d1W/A7sw/4/S+PVS1q9XrzRMGfMCvi21tnZXvIfK3vc="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000004c",
+          "pairing_incarnation": 77,
+          "pair_authorization_digest": "q3V/thzQvOTS2bau6jcdGUD+wZts5jxsFDiEJv9d1+4="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000004d",
+          "pairing_incarnation": 78,
+          "pair_authorization_digest": "uI3Sy98A9aUnX36w605RUS/JqXRhH0hhjDnucFw1XM8="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000004e",
+          "pairing_incarnation": 79,
+          "pair_authorization_digest": "pnNhf+8Qecc2RuoQfKvyhrZACh0QHpRzKv9OorQGiiM="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000004f",
+          "pairing_incarnation": 80,
+          "pair_authorization_digest": "L7NiezgztufGuCcMXHh8NdSTXBEHAqINZJsjGz9XyAs="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000050",
+          "pairing_incarnation": 81,
+          "pair_authorization_digest": "SdHxiUcNgOGGgVBVTHczFhXLd8hT79CKk0iK6T3wKio="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000051",
+          "pairing_incarnation": 82,
+          "pair_authorization_digest": "y9EOEzRnr+3tZYvWToNTDdOsBMzksav1yuMDAXHN0/o="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000052",
+          "pairing_incarnation": 83,
+          "pair_authorization_digest": "7G/u0kbIAG7q4PRlfdLj9HiuLPKU7GaqlaWpENcCHhg="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000053",
+          "pairing_incarnation": 84,
+          "pair_authorization_digest": "UeEI7zWQyHOgj+ZeUupZkGiLZvCtJdPPWebebE9Y73U="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000054",
+          "pairing_incarnation": 85,
+          "pair_authorization_digest": "fVIHaxkxEl71ReyJTsH3RZstsokMlmFjsWt8g7NTAno="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000055",
+          "pairing_incarnation": 86,
+          "pair_authorization_digest": "tg4JQvsXE69YoLgTmUEEkOYNorYm2fQSCwpbWPqvYnw="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000056",
+          "pairing_incarnation": 87,
+          "pair_authorization_digest": "K28kqD7DYHTp3HF1qitJQFLc7tnbdLpoPQbBqie1a80="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000057",
+          "pairing_incarnation": 88,
+          "pair_authorization_digest": "RhPNI1vtIGktO7ptJDeF2EpIMQ8b0SEeAZpTsDZINdk="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000058",
+          "pairing_incarnation": 89,
+          "pair_authorization_digest": "JSrnLEF69zC67dCjlqnLH32yTFx4bGaOUFhkb5a57ws="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000059",
+          "pairing_incarnation": 90,
+          "pair_authorization_digest": "GV2X8TIaSQWcHyMgHu8587CWSsFKvOJUFlxdACWYYqs="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000005a",
+          "pairing_incarnation": 91,
+          "pair_authorization_digest": "/VE5HOdHN2auZZXjiCblwJM4d+Uof56PYGbxDaa3FF0="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000005b",
+          "pairing_incarnation": 92,
+          "pair_authorization_digest": "h+JPnDzqbURqa/L+sC5sxvkPpVAo9veZ0RjbM7iZONU="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000005c",
+          "pairing_incarnation": 93,
+          "pair_authorization_digest": "tq/hb/G3NofUPm+owaPM7Zo9Gk58IfNGdokXMEZPoTI="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000005d",
+          "pairing_incarnation": 94,
+          "pair_authorization_digest": "4AH6NaAOVvfRjRtbyR9bWWE7PHCWk69ebq4FLkSmAOs="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000005e",
+          "pairing_incarnation": 95,
+          "pair_authorization_digest": "yaWJZLx0CtidEaasMgO2IvDfXDwjzWGfhA0KhXYp01A="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000005f",
+          "pairing_incarnation": 96,
+          "pair_authorization_digest": "MiLjjH+WvpfVl+4hmi9KVVNa8H4NJ9N030BPBWr7L+8="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000060",
+          "pairing_incarnation": 97,
+          "pair_authorization_digest": "JZdQzCRdf333tPxY6Zq1LBthgwYR9SdEF37y7mdrItI="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000061",
+          "pairing_incarnation": 98,
+          "pair_authorization_digest": "OQSrmEWbWgPnPbHL2uWwssUec4m2ZVVO/1hHtSe5CNs="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000062",
+          "pairing_incarnation": 99,
+          "pair_authorization_digest": "v1BSsn1+oZaevKEkJ2KwprVQ21gZL04W3/COyLJ1b5U="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000063",
+          "pairing_incarnation": 100,
+          "pair_authorization_digest": "WiF5JoRy+Y8RMDwPRrzW1eLRIvLr6Aluoo+qBkCS7eo="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000064",
+          "pairing_incarnation": 101,
+          "pair_authorization_digest": "mDlP7+8TpaQOxtMKxdYsjl3SMrprOfukaUWuYSLxrWA="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000065",
+          "pairing_incarnation": 102,
+          "pair_authorization_digest": "G4or6G41sIviLkIjtGVD0UJPsTfMIETUwcxLtKQexmI="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000066",
+          "pairing_incarnation": 103,
+          "pair_authorization_digest": "DhaoypCU3uUjgouoyP+0B45pecg7VHmA+fJ0QzjlWfM="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000067",
+          "pairing_incarnation": 104,
+          "pair_authorization_digest": "w86jrMsRVMwzE1RvrGurg92a7zalu9fDOAR6wDLRxms="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000068",
+          "pairing_incarnation": 105,
+          "pair_authorization_digest": "japCi0iwLtl9ic2y5Rd/PQY+aaC+tSzNomVt+LBU1nc="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000069",
+          "pairing_incarnation": 106,
+          "pair_authorization_digest": "ks5wBkj3dGC7NBwlRGk4jntdrtOFNeh07m6JeJ66b3c="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000006a",
+          "pairing_incarnation": 107,
+          "pair_authorization_digest": "wkBtIOqG3LGWaAUQnj+fKLTdr/LZ5es+FpCkOMJF10k="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000006b",
+          "pairing_incarnation": 108,
+          "pair_authorization_digest": "3brbxJQX1JhHSxH/6NZ7oN+7oZzgMkmJBppUcUJFWuM="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000006c",
+          "pairing_incarnation": 109,
+          "pair_authorization_digest": "BmIqlZOxXxg1Ca5c29J/xWMOpgVHDxFcLvZMK5mTE/k="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000006d",
+          "pairing_incarnation": 110,
+          "pair_authorization_digest": "J2hPy6KcqU9S3Y3I+8+uxK3h/BsZX3whmPPUllzj0ZM="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000006e",
+          "pairing_incarnation": 111,
+          "pair_authorization_digest": "6DGH+ckzoD9VoJVULkkXl94/ReLBB0x96jo2jbYc+A8="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000006f",
+          "pairing_incarnation": 112,
+          "pair_authorization_digest": "y2YedtFJkfVXSOe9DfOottXXriqzRn+yq+W4fRVI5nA="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000070",
+          "pairing_incarnation": 113,
+          "pair_authorization_digest": "mLDlau+mVLjNEjyCddfbXsYsJ7PHpbWFqxkwbFVptng="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000071",
+          "pairing_incarnation": 114,
+          "pair_authorization_digest": "PJq5LGeH17n94t66ijowrbnVnB6j0p7hoeU75tU8KFY="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000072",
+          "pairing_incarnation": 115,
+          "pair_authorization_digest": "gIlcvrhRS430F+BTJia7iPEXNJfiyyHjFV10wnTXt+o="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000073",
+          "pairing_incarnation": 116,
+          "pair_authorization_digest": "RBTNZYtMWe1D9PQouj3J6EGtTcbd1jNbOcLjsNlP2gw="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000074",
+          "pairing_incarnation": 117,
+          "pair_authorization_digest": "n1eWm8m7hIv0Vy2WMphIXUmlOYk1rJ/fw2KpaXk5ezc="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000075",
+          "pairing_incarnation": 118,
+          "pair_authorization_digest": "AaUHz9vrCB0MuFHM5ddycjHwepu2mUX4LQT7vlY7bcs="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000076",
+          "pairing_incarnation": 119,
+          "pair_authorization_digest": "sjhKqFp/PO6X5Oyhk8G13KkOOPRVsqoXC6EUDPqiohk="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000077",
+          "pairing_incarnation": 120,
+          "pair_authorization_digest": "Y3Jfw9VpQpmJ3+Aq3ymx374KOrxvZErhiVEiKJhyakw="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000078",
+          "pairing_incarnation": 121,
+          "pair_authorization_digest": "8r+zdYi2tLMNkESnJHNKMP0KgpqACiJkZtL13TrnGCI="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-000000000079",
+          "pairing_incarnation": 122,
+          "pair_authorization_digest": "OluMY5327WfMjaISAKGSPLyYDyiwc4hyNSXB7C4X5tI="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000007a",
+          "pairing_incarnation": 123,
+          "pair_authorization_digest": "AA553XApBzq3YzvjW5OyMGMLGzpItkLAIu+xt3/scAc="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000007b",
+          "pairing_incarnation": 124,
+          "pair_authorization_digest": "kHoILe5evZVwpQjgr2+iqYcNgjma8VWGBsidwawQk7Q="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000007c",
+          "pairing_incarnation": 125,
+          "pair_authorization_digest": "zzXvvSs0mjZ1+18QhV046ab2TNnn+3v83GtVm00EHyM="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000007d",
+          "pairing_incarnation": 126,
+          "pair_authorization_digest": "6eYfkgRTD5RNB1qEjdfq6b2H0UM9efZUAHGQPhlJGfA="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000007e",
+          "pairing_incarnation": 127,
+          "pair_authorization_digest": "QUCWfz82DLqLOk+rXlzGgZy7QFYgb8svnKhV8+vUFSc="
+        },
+        {
+          "pair_id": "a1000000-0000-4000-8000-00000000007f",
+          "pairing_incarnation": 128,
+          "pair_authorization_digest": "34HtsuU3fJkzdQDIadUA2VE1sr/XVwTldzqoB8Pi/fM="
+        }
+      ],
+      "transcript_hex": "73000000256f732e6d61706c652d72657365742d636c6561722d61646d697373696f6e2d7365742e76316a0000000200016a0000000200807500000010a10000000000400080000000000000004c0000000800000000000000016200000020c7805d9a937ebada187a273773e8d941d8269b4559dc13c825f546f349182bcc7500000010a10000000000400080000000000000014c0000000800000000000000026200000020a5b15bc00bbd4892b148851969c77fa2f74144078ff2c9a4137c650560efc8f47500000010a10000000000400080000000000000024c0000000800000000000000036200000020de9f2d3d8183c5fabe88b0aa45b4ce8cef53caea1814ff9400d20f22f4c8f6f17500000010a10000000000400080000000000000034c000000080000000000000004620000002025427da65fad1c612842695695ed5bf752183ee77c92072553607cf06cdcfb917500000010a10000000000400080000000000000044c0000000800000000000000056200000020c24b47604057149d208ae1667c1c3aba5d3ce2554a7525e008b32994cea55b1b7500000010a10000000000400080000000000000054c0000000800000000000000066200000020d5778eaed1273e504512f58a403a6b1d0def04da3001519e93b937a36fc31bc47500000010a10000000000400080000000000000064c0000000800000000000000076200000020315035981ed267b5cd0f1c81d3a00a6da05d711dcd528d852552db2c914c5ae47500000010a10000000000400080000000000000074c0000000800000000000000086200000020cf0ad736ff174e7437fb2e9b3c7c8202cb3af7618584a9c8f85c2b80118b9a377500000010a10000000000400080000000000000084c00000008000000000000000962000000207291e1122073f81059e2b17deef9fd44084a48de518bd0ba6a8bd7bbd33dc5997500000010a10000000000400080000000000000094c00000008000000000000000a62000000206c49cec72c58480b301e4e7daf52ae316b26c8bc75817d2cdd6bbb7eef7b160e7500000010a100000000004000800000000000000a4c00000008000000000000000b6200000020970e15549c2f16fb624e4d1e51d049db0b735da3925d882b6882e7a69332e30e7500000010a100000000004000800000000000000b4c00000008000000000000000c6200000020c5a5d1d1b3b307851340a3fb4e684df00addeb5ad5c3a33d8015ad06bc4ea4cd7500000010a100000000004000800000000000000c4c00000008000000000000000d62000000209b4ff49a6eaac2009907605b55b113e4fb4b1bab2b02475b828332f64d3c6eb27500000010a100000000004000800000000000000d4c00000008000000000000000e620000002033dc31337f3af1083e9d53f3a8348964f9c26f402a84e2b4d114f8335fb075ea7500000010a100000000004000800000000000000e4c00000008000000000000000f62000000202bcffcc3d074b512d772fbe9fff78aaa02906aadbfebb369d20041154b2ba3687500000010a100000000004000800000000000000f4c000000080000000000000010620000002087254c61709f9c2e06bf5bee65a84aa278123e03e3047a0820364132cbb66fb07500000010a10000000000400080000000000000104c0000000800000000000000116200000020e6e8436446edfa06b87472b50e4e481c2cc67d9daab356706e9f24ccc1fef9f47500000010a10000000000400080000000000000114c00000008000000000000001262000000206aa94ffe9ec111050bbb303f0e494912badafabde74ba811014f5fe0829acb557500000010a10000000000400080000000000000124c0000000800000000000000136200000020b2bc859c185b1a91963e0f6512957dc016c79e8bea816ef396bc8907fdfa35607500000010a10000000000400080000000000000134c000000080000000000000014620000002006cd2c46aee2c78240ba135a66237e18433e3126049de85bc110debc5e2811d27500000010a10000000000400080000000000000144c000000080000000000000015620000002088563a2ce0e33219b7432bb91e752a0e3b4e1425d264cec30ac0dcecf979985e7500000010a10000000000400080000000000000154c00000008000000000000001662000000202fed4fdfc63424e8d3220b118af2170043276fb381359a4f073b17463189cbac7500000010a10000000000400080000000000000164c0000000800000000000000176200000020dd590ae9a9293ad8bbfb51d902a85657661360b1f13105fffbad6aa2ebd5432e7500000010a10000000000400080000000000000174c00000008000000000000001862000000200938c76c55cb02e834c938325070426b6e860eae9b14bc6cd34de8bf792a053c7500000010a10000000000400080000000000000184c0000000800000000000000196200000020a96eed14edd1bf5d40864416dbaa9ed2a25a326bbfd00909f09c0be59d6be09d7500000010a10000000000400080000000000000194c00000008000000000000001a6200000020b414ba7304b2413cc244c570668843a63c7c42df26a6ab9dfba64ff9f01011ae7500000010a100000000004000800000000000001a4c00000008000000000000001b6200000020f6b74f558abb196ec4cc4ffbf309dabf8f835555dca4e94f1f365a0dae4508177500000010a100000000004000800000000000001b4c00000008000000000000001c6200000020a666208a5e5b7dedd244cf1a3ac3f5f8ee2badec3766239382d9115082ec51867500000010a100000000004000800000000000001c4c00000008000000000000001d62000000203fd95e7fa8ad4a54b2188bc20b3d15a904f788ff48db2b369bd41e93d08f437d7500000010a100000000004000800000000000001d4c00000008000000000000001e6200000020ab7419558e4c013b250bfbc1d755cfee3c6491603e7dca9002c6bca8d549a07d7500000010a100000000004000800000000000001e4c00000008000000000000001f6200000020e59fbf76c46ff58c4f9e46259cf58367d58e7b77e2de9b25d32a9b0f05fdf04f7500000010a100000000004000800000000000001f4c00000008000000000000002062000000206e84f80e80a3a92e738560706b342bfd863c677367e652cc8fbaefe9e03b1eb77500000010a10000000000400080000000000000204c00000008000000000000002162000000205b44a17c2f096de105b98351af049d0da4c3ec1efc594a9d58d2144e99da99297500000010a10000000000400080000000000000214c0000000800000000000000226200000020153324a9d3aac583a61b897e58fca8c321a5a0b6d27a2157727551ac9e150e9c7500000010a10000000000400080000000000000224c0000000800000000000000236200000020b0399c507c45a7297eba69b00d47d6a40fa72817306d037cd36042ac8d2ace317500000010a10000000000400080000000000000234c000000080000000000000024620000002012491cfab69d931f7a34c61795700a7a55e8d0ecf6ae110a29594760932dd1b17500000010a10000000000400080000000000000244c0000000800000000000000256200000020312eb1ea83258b04ba8a23c62929316c8f89eed91caf4a0c9b27cdcc6bb82e447500000010a10000000000400080000000000000254c00000008000000000000002662000000203909a1f221f98393810d0b1bceeffb8812ae9a7314662af39e22a7f0088334ec7500000010a10000000000400080000000000000264c0000000800000000000000276200000020e91887eedd37ef6f17f3ace1c744b1364a7201c59e5ec71bd407fa6e2a9c7e0c7500000010a10000000000400080000000000000274c00000008000000000000002862000000200d530b09b4ab779145cb0a3f55df314483ec753ba17a7d95bd39710768ccb51a7500000010a10000000000400080000000000000284c0000000800000000000000296200000020c5ee47c59237259503015872d320e4130c48d83a6a5c858d83e27de2e8de583a7500000010a10000000000400080000000000000294c00000008000000000000002a6200000020bc27b669a9e8ae93f056aa412418481df4d8666ea53b1e8cd32ef1ff8fc167467500000010a100000000004000800000000000002a4c00000008000000000000002b62000000207c25ada63e352102cd2007534f3679070754d9c1eca9183463bc56f71d3e1c167500000010a100000000004000800000000000002b4c00000008000000000000002c6200000020362d8b0a6ea98e5b1de392543483083c75b4c5e4c5a3d5d38d1f4fa8ed84d1e57500000010a100000000004000800000000000002c4c00000008000000000000002d6200000020dac6c4db7ff27e8612e26ee1e2117c73dfa0f8b7a98b34fceab46006fe437dc87500000010a100000000004000800000000000002d4c00000008000000000000002e62000000208b70acb3e49a4c51483f1143f225221a5a8b2790f922a371c8b69c26b201bcc57500000010a100000000004000800000000000002e4c00000008000000000000002f6200000020be25e363b083dfd0f721325fafb3da068d1c25d2fdc3a3bebf86c2c70ba548de7500000010a100000000004000800000000000002f4c0000000800000000000000306200000020db5e267ce4f35e4847fc712017db9df4e8191d39e5bf3f58dfd44aa9581cf7e67500000010a10000000000400080000000000000304c0000000800000000000000316200000020c33078ab877292c6feb226f708df82f4f96c03147d95ffa4307a818c8d5cd36f7500000010a10000000000400080000000000000314c0000000800000000000000326200000020eeb2aa4872e8ba6d8239cfe97689543907dd4e52143959ccc830392e2dfe85057500000010a10000000000400080000000000000324c00000008000000000000003362000000207a1a720ddfdbe052226aa07d766f4232efbf68b7bddeacfa81f1bd3611750fdf7500000010a10000000000400080000000000000334c0000000800000000000000346200000020d47905a0bfc81c9fe9fce2df99f4acd913967ae50402ef790af31162b35605087500000010a10000000000400080000000000000344c0000000800000000000000356200000020953b2453ab10a23ee51a8f2359bbcee6576cb323f4412d3f9e76f864a4b3818a7500000010a10000000000400080000000000000354c00000008000000000000003662000000201d29b9e398537436ee33e9427a3cd5fdcb815bf9cfbbaea00d5b314769af5a6d7500000010a10000000000400080000000000000364c00000008000000000000003762000000208202260076373daf4541545444b8fc4bedbb6ea3b00d2703d10f6a7e497137677500000010a10000000000400080000000000000374c0000000800000000000000386200000020e290de895188179a43ce7c27c94369cc9dadc79a0b5c73971cd4833b03770e5d7500000010a10000000000400080000000000000384c000000080000000000000039620000002080cf6ff70ca22736c4e142464748c11b8035f98a81f38a55b56c777586aef8c67500000010a10000000000400080000000000000394c00000008000000000000003a6200000020afbf6c30ea783ace1a645fd51e1a04593a44c502406ce7cbdc19d18bd31be42f7500000010a100000000004000800000000000003a4c00000008000000000000003b620000002096712661277ff9115b3efcc2f177318e3039c3d9cb8f609123b7bd291c9307c27500000010a100000000004000800000000000003b4c00000008000000000000003c6200000020e9ff15698b07e198e235349825403518a5e9c11c8d2b0e75dca8fc84a0068f417500000010a100000000004000800000000000003c4c00000008000000000000003d62000000201f424f4354ef3bbb99c673ed21b823ee1f9bdc2397734b059ef8e8a38fc15deb7500000010a100000000004000800000000000003d4c00000008000000000000003e6200000020e02ad4d0cc8b7c582a7e76700b878684f4bba5bf77fbf4a5c081e66de9e48ffc7500000010a100000000004000800000000000003e4c00000008000000000000003f6200000020a207e8c81010720149313a0329db4cdc554d36a590a00fb8bc7175d7ade9b6477500000010a100000000004000800000000000003f4c00000008000000000000004062000000200b5b61ea59d374e9c873b88e0f3b5c4c3087082c0f97a37ef00c6916866b4d8a7500000010a10000000000400080000000000000404c0000000800000000000000416200000020944b2e1f891b84a535e5e1c9128f7e76f4f4b7fdbdd93c5c57da66cd2ffa29d27500000010a10000000000400080000000000000414c0000000800000000000000426200000020f3a0713dac274875c3f32d5abd00a1cd92aee1100ead916d831b957ece33bbb37500000010a10000000000400080000000000000424c00000008000000000000004362000000209cd809d47f1d60c04b71bf89ffe6f76940e26926922293e126f14b45d7a3e6db7500000010a10000000000400080000000000000434c00000008000000000000004462000000201090f0017c1e36d7afd01da41c7c67cd5cd832a5abe33330d75d695aa9170d3b7500000010a10000000000400080000000000000444c0000000800000000000000456200000020dc2a93d0f4ae2c7256cb4e3c9d5932e48883105bc8c8aaf98d049fd28bfe4c947500000010a10000000000400080000000000000454c0000000800000000000000466200000020102f01ba05f9c167e48d1bdbaf24dbc5d8a3b7af95224ae2bdf191bc5e6525b47500000010a10000000000400080000000000000464c0000000800000000000000476200000020d9861be5e456fa7a2880fe7450bce59072c8b09fc094ac31eed3d44e6f64af9a7500000010a10000000000400080000000000000474c000000080000000000000048620000002079b2e28b0a77295402dac39993c3ebca01b365cdd7b3f6f930b964049d69e1807500000010a10000000000400080000000000000484c00000008000000000000004962000000203a8f0bce87a7757e1b10fbd5ba1a195bfa99c4ea4d770847492bce5556f2834f7500000010a10000000000400080000000000000494c00000008000000000000004a62000000201c3d296a4634365c5bbbe2795d5e92f3ef7b17981caec63505a2a106cfa758127500000010a100000000004000800000000000004a4c00000008000000000000004b6200000020f85cc5de2416f34afc5c30bc444a61113ff185d7e1c1103f1d59251f7502144e7500000010a100000000004000800000000000004b4c00000008000000000000004c62000000207755bf03bb30ff8fd2f8f552d6af57af344c19f302be2db5b67657bc87cadef77500000010a100000000004000800000000000004c4c00000008000000000000004d6200000020ab757fb61cd0bce4d2d9b6aeea371d1940fec19b6ce63c6c14388426ff5dd7ee7500000010a100000000004000800000000000004d4c00000008000000000000004e6200000020b88dd2cbdf00f5a5275f7eb0eb4e51512fc9a974611f48618c39ee705c355ccf7500000010a100000000004000800000000000004e4c00000008000000000000004f6200000020a673617fef1079c73646ea107cabf286b6400a1d101e94732aff4ea2b4068a237500000010a100000000004000800000000000004f4c00000008000000000000005062000000202fb3627b3833b6e7c6b8270c5c787c35d4935c110702a20d649b231b3f57c80b7500000010a10000000000400080000000000000504c000000080000000000000051620000002049d1f189470d80e1868150554c77331615cb77c853efd08a93488ae93df02a2a7500000010a10000000000400080000000000000514c0000000800000000000000526200000020cbd10e133467afeded658bd64e83530dd3ac04cce4b1abf5cae3030171cdd3fa7500000010a10000000000400080000000000000524c0000000800000000000000536200000020ec6feed246c8006eeae0f4657dd2e3f478ae2cf294ec66aa95a5a910d7021e187500000010a10000000000400080000000000000534c000000080000000000000054620000002051e108ef3590c873a08fe65e52ea5990688b66f0ad25d3cf59e6de6c4f58ef757500000010a10000000000400080000000000000544c00000008000000000000005562000000207d52076b1931125ef545ec894ec1f7459b2db2890c966163b16b7c83b353027a7500000010a10000000000400080000000000000554c0000000800000000000000566200000020b60e0942fb1713af58a0b81399410490e60da2b626d9f4120b0a5b58faaf627c7500000010a10000000000400080000000000000564c00000008000000000000005762000000202b6f24a83ec36074e9dc7175aa2b494052dceed9db74ba683d06c1aa27b56bcd7500000010a10000000000400080000000000000574c00000008000000000000005862000000204613cd235bed20692d3bba6d243785d84a48310f1bd1211e019a53b0364835d97500000010a10000000000400080000000000000584c0000000800000000000000596200000020252ae72c417af730baedd0a396a9cb1f7db24c5c786c668e5058646f96b9ef0b7500000010a10000000000400080000000000000594c00000008000000000000005a6200000020195d97f1321a49059c1f23201eef39f3b0964ac14abce254165c5d00259862ab7500000010a100000000004000800000000000005a4c00000008000000000000005b6200000020fd51391ce7473766ae6595e38826e5c0933877e5287f9e8f6066f10da6b7145d7500000010a100000000004000800000000000005b4c00000008000000000000005c620000002087e24f9c3cea6d446a6bf2feb02e6cc6f90fa55028f6f799d118db33b89938d57500000010a100000000004000800000000000005c4c00000008000000000000005d6200000020b6afe16ff1b73687d43e6fa8c1a3cced9a3d1a4e7c21f34676891730464fa1327500000010a100000000004000800000000000005d4c00000008000000000000005e6200000020e001fa35a00e56f7d18d1b5bc91f5b59613b3c709693af5e6eae052e44a600eb7500000010a100000000004000800000000000005e4c00000008000000000000005f6200000020c9a58964bc740ad89d11a6ac3203b622f0df5c3c23cd619f840d0a857629d3507500000010a100000000004000800000000000005f4c00000008000000000000006062000000203222e38c7f96be97d597ee219a2f4a55535af07e0d27d374df404f056afb2fef7500000010a10000000000400080000000000000604c0000000800000000000000616200000020259750cc245d7f7df7b4fc58e99ab52c1b61830611f52744177ef2ee676b22d27500000010a10000000000400080000000000000614c00000008000000000000006262000000203904ab98459b5a03e73db1cbdae5b0b2c51e7389b665554eff5847b527b908db7500000010a10000000000400080000000000000624c0000000800000000000000636200000020bf5052b27d7ea1969ebca1242762b0a6b550db58192f4e16dff08ec8b2756f957500000010a10000000000400080000000000000634c00000008000000000000006462000000205a2179268472f98f11303c0f46bcd6d5e2d122f2ebe8096ea28faa064092edea7500000010a10000000000400080000000000000644c000000080000000000000065620000002098394fefef13a5a40ec6d30ac5d62c8e5dd232ba6b39fba46945ae6122f1ad607500000010a10000000000400080000000000000654c00000008000000000000006662000000201b8a2be86e35b08be22e4223b46543d1424fb137cc2044d4c1cc4bb4a41ec6627500000010a10000000000400080000000000000664c00000008000000000000006762000000200e16a8ca9094dee523828ba8c8ffb4078e6979c83b547980f9f2744338e559f37500000010a10000000000400080000000000000674c0000000800000000000000686200000020c3cea3accb1154cc3313546fac6bab83dd9aef36a5bbd7c338047ac032d1c66b7500000010a10000000000400080000000000000684c00000008000000000000006962000000208daa428b48b02ed97d89cdb2e5177f3d063e69a0beb52ccda2656df8b054d6777500000010a10000000000400080000000000000694c00000008000000000000006a620000002092ce700648f77460bb341c254469388e7b5daed38535e874ee6e89789eba6f777500000010a100000000004000800000000000006a4c00000008000000000000006b6200000020c2406d20ea86dcb1966805109e3f9f28b4ddaff2d9e5eb3e1690a438c245d7497500000010a100000000004000800000000000006b4c00000008000000000000006c6200000020ddbadbc49417d498474b11ffe8d67ba0dfbba19ce0324989069a547142455ae37500000010a100000000004000800000000000006c4c00000008000000000000006d620000002006622a9593b15f183509ae5cdbd27fc5630ea605470f115c2ef64c2b999313f97500000010a100000000004000800000000000006d4c00000008000000000000006e620000002027684fcba29ca94f52dd8dc8fbcfaec4ade1fc1b195f7c2198f3d4965ce3d1937500000010a100000000004000800000000000006e4c00000008000000000000006f6200000020e83187f9c933a03f55a095542e491797de3f45e2c1074c7dea3a368db61cf80f7500000010a100000000004000800000000000006f4c0000000800000000000000706200000020cb661e76d14991f55748e7bd0df3a8b6d5d7ae2ab3467fb2abe5b87d1548e6707500000010a10000000000400080000000000000704c000000080000000000000071620000002098b0e56aefa654b8cd123c8275d7db5ec62c27b3c7a5b585ab19306c5569b6787500000010a10000000000400080000000000000714c00000008000000000000007262000000203c9ab92c6787d7b9fde2deba8a3a30adb9d59c1ea3d29ee1a1e53be6d53c28567500000010a10000000000400080000000000000724c000000080000000000000073620000002080895cbeb8514b8df417e0532626bb88f1173497e2cb21e3155d74c274d7b7ea7500000010a10000000000400080000000000000734c00000008000000000000007462000000204414cd658b4c59ed43f4f428ba3dc9e841ad4dc6ddd6335b39c2e3b0d94fda0c7500000010a10000000000400080000000000000744c00000008000000000000007562000000209f57969bc9bb848bf4572d963298485d49a5398935ac9fdfc362a96979397b377500000010a10000000000400080000000000000754c000000080000000000000076620000002001a507cfdbeb081d0cb851cce5d7727231f07a9bb69945f82d04fbbe563b6dcb7500000010a10000000000400080000000000000764c0000000800000000000000776200000020b2384aa85a7f3cee97e4eca193c1b5dca90e38f455b2aa170ba1140cfaa2a2197500000010a10000000000400080000000000000774c000000080000000000000078620000002063725fc3d569429989dfe02adf29b1dfbe0a3abc6f644ae18951222898726a4c7500000010a10000000000400080000000000000784c0000000800000000000000796200000020f2bfb37588b6b4b30d9044a724734a30fd0a829a800a226466d2f5dd3ae718227500000010a10000000000400080000000000000794c00000008000000000000007a62000000203a5b8c639df6ed67cc8da21200a1923cbc980f28b07388723525c1ec2e17e6d27500000010a100000000004000800000000000007a4c00000008000000000000007b6200000020000e79dd7029073ab7633be35b93b230630b1b3a48b642c022efb1b77fec70077500000010a100000000004000800000000000007b4c00000008000000000000007c6200000020907a082dee5ebd9570a508e0af6fa2a9870d82399af1558606c89dc1ac1093b47500000010a100000000004000800000000000007c4c00000008000000000000007d6200000020cf35efbd2b349a3675fb5f10855d38e9a6f64cd9e7fb7bfcdc6b559b4d041f237500000010a100000000004000800000000000007d4c00000008000000000000007e6200000020e9e61f9204530f944d075a848dd7eae9bd87d1433d79f6540071903e194919f07500000010a100000000004000800000000000007e4c00000008000000000000007f62000000204140967f3f360cba8b3a4fab5e5cc6819cbb4056206fcb2f9ca855f3ebd415277500000010a100000000004000800000000000007f4c0000000800000000000000806200000020df81edb2e5377c99337500c869d500d95135b2bfd75704e5773aa807c3e2fdf3",
+      "digest": "5MZmKvI3pDpvRQlfkt/Pi8JBF+iZ8yVl+xvFC5Q2WfE="
+    }
+  },
+  "reset_clear_three_reset_chain": [
+    {
+      "instruction": {
+        "artifact_version": 1,
+        "event_id": "81000000-0000-4000-8000-000000000001",
+        "reset_id": "91000000-0000-4000-8000-000000000001",
+        "reset_generation": 1,
+        "cumulative_reset_count": 1,
+        "source_security_epoch": 1,
+        "security_epoch": 2,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "issuer_sequence": 1,
+        "source_revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+        "source_revocation_stream_generation": 5,
+        "revocation_stream_id": "26262626-2626-4626-8626-262626262626",
+        "revocation_stream_generation": 6,
+        "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+        "admission_count": 0,
+        "admission_set_digest": "7wU8UwigHo6NmQ8LjGSKcoXG8g3aVUxDP4bl19AeDEk=",
+        "previous_reset_clear_event_id": null,
+        "previous_instruction_material_digest": null,
+        "previous_chain_digest": null,
+        "reset_at_unix_ms": 1786579700000,
+        "instruction_material_digest": "Obkz1xv05HlwsOK5whR+j3RI6adghrAsS8QB5ovE6M4=",
+        "chain_digest": "XY5Vm8BkPxs6hsy1cq4UM4tbcXsJRjo2meXfv/GdfDY=",
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "ksYMEh96b2Caq/cL8JubJFrqCB7AoU/0vlfdV3zVKpZK9zhyE4grU3h240A4RpuO/1zNAneUjWshHCvTpt6qBA=="
+      },
+      "instruction_material_transcript_hex": "730000002c6f732e6d61706c652d72657365742d636c6561722d696e737472756374696f6e2d6d6174657269616c2e76316a0000000200017500000010810000000000400080000000000000017500000010910000000000400080000000000000014c0000000800000000000000014c0000000800000000000000014c0000000800000000000000014c000000080000000000000002750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001077777777777747778777777777777777750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000054c0000000800000000000000017500000010151515151515451585151515151515154c0000000800000000000000057500000010262626262626462686262626262626264c000000080000000000000006730000003d616c6c5f706169725f617574686f72697a6174696f6e735f666f725f6163636f756e745f70726f6a6563745f686f73745f696e7374616c6c6174696f6e6a0000000200006200000020ef053c5308a01e8e8d990f0b8c648a7285c6f20dda554c433f86e5d7d01e0c493f00000001006c000000080000019ff872c920",
+      "instruction_material_digest": "Obkz1xv05HlwsOK5whR+j3RI6adghrAsS8QB5ovE6M4=",
+      "chain_transcript_hex": "730000001d6f732e6d61706c652d72657365742d636c6561722d636861696e2e76316a0000000200013f00000001007500000010910000000000400080000000000000017500000010810000000000400080000000000000014c000000080000000000000001620000002039b933d71bf4e47970b0e2b9c2147e8f7448e9a76086b02c4bc401e68bc4e8ce4c000000080000000000000001",
+      "chain_digest": "XY5Vm8BkPxs6hsy1cq4UM4tbcXsJRjo2meXfv/GdfDY=",
+      "signed_transcript_hex": "73000000206f732e6d61706c652d72657365742d636c6561722d72657175697265642e76316a0000000200017500000010810000000000400080000000000000017500000010910000000000400080000000000000014c0000000800000000000000014c0000000800000000000000014c0000000800000000000000014c000000080000000000000002750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001077777777777747778777777777777777750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000054c0000000800000000000000017500000010151515151515451585151515151515154c0000000800000000000000057500000010262626262626462686262626262626264c000000080000000000000006730000003d616c6c5f706169725f617574686f72697a6174696f6e735f666f725f6163636f756e745f70726f6a6563745f686f73745f696e7374616c6c6174696f6e6a0000000200006200000020ef053c5308a01e8e8d990f0b8c648a7285c6f20dda554c433f86e5d7d01e0c493f00000001006c000000080000019ff872c920620000002039b933d71bf4e47970b0e2b9c2147e8f7448e9a76086b02c4bc401e68bc4e8ce4c00000008000000000000000162000000205d8e559bc0643f1b3a86ccb572ae14338b5b717b09463a3699e5dfbff19d7c36730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+      "event_digest": "A6BsYNMtXCWqXZnJOC9J2umTf4miRs2/v7zb4x/Uffo="
+    },
+    {
+      "instruction": {
+        "artifact_version": 1,
+        "event_id": "82000000-0000-4000-8000-000000000002",
+        "reset_id": "92000000-0000-4000-8000-000000000002",
+        "reset_generation": 2,
+        "cumulative_reset_count": 2,
+        "source_security_epoch": 2,
+        "security_epoch": 3,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "issuer_sequence": 1,
+        "source_revocation_stream_id": "26262626-2626-4626-8626-262626262626",
+        "source_revocation_stream_generation": 6,
+        "revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+        "revocation_stream_generation": 7,
+        "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+        "admission_count": 1,
+        "admission_set_digest": "qx4XnJgJNXFQBPtImg3iBZBXu8NDBkFXUnqKPJZSiAY=",
+        "previous_reset_clear_event_id": "81000000-0000-4000-8000-000000000001",
+        "previous_instruction_material_digest": "Obkz1xv05HlwsOK5whR+j3RI6adghrAsS8QB5ovE6M4=",
+        "previous_chain_digest": "XY5Vm8BkPxs6hsy1cq4UM4tbcXsJRjo2meXfv/GdfDY=",
+        "reset_at_unix_ms": 1786579710000,
+        "instruction_material_digest": "uPNOA4E94Xk2jkIKtcBl/8ndQ/k6+BG2NHWKtFRqMl0=",
+        "chain_digest": "PBtKwOcbxzOO7b43q8tJfk5Gb9TmqxyYbgIJu5vOMvY=",
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "4rj3i0AnNDPNzHZh6X/2VRDxNPQ19NmSC+tF2Cmg5A/UWgdgsV2lFIYRukdLT+AMp95OAwJjzrOFlSUCxVy3Cg=="
+      },
+      "instruction_material_transcript_hex": "730000002c6f732e6d61706c652d72657365742d636c6561722d696e737472756374696f6e2d6d6174657269616c2e76316a0000000200017500000010820000000000400080000000000000027500000010920000000000400080000000000000024c0000000800000000000000024c0000000800000000000000024c0000000800000000000000024c000000080000000000000003750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001077777777777747778777777777777777750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000054c0000000800000000000000017500000010262626262626462686262626262626264c0000000800000000000000067500000010272727272727472787272727272727274c000000080000000000000007730000003d616c6c5f706169725f617574686f72697a6174696f6e735f666f725f6163636f756e745f70726f6a6563745f686f73745f696e7374616c6c6174696f6e6a0000000200016200000020ab1e179c980935715004fb489a0de2059057bbc343064157527a8a3c965288063f0000000101750000001081000000000040008000000000000001620000002039b933d71bf4e47970b0e2b9c2147e8f7448e9a76086b02c4bc401e68bc4e8ce62000000205d8e559bc0643f1b3a86ccb572ae14338b5b717b09463a3699e5dfbff19d7c366c000000080000019ff872f030",
+      "instruction_material_digest": "uPNOA4E94Xk2jkIKtcBl/8ndQ/k6+BG2NHWKtFRqMl0=",
+      "chain_transcript_hex": "730000001d6f732e6d61706c652d72657365742d636c6561722d636861696e2e76316a0000000200013f000000010162000000205d8e559bc0643f1b3a86ccb572ae14338b5b717b09463a3699e5dfbff19d7c36750000001081000000000040008000000000000001620000002039b933d71bf4e47970b0e2b9c2147e8f7448e9a76086b02c4bc401e68bc4e8ce7500000010920000000000400080000000000000027500000010820000000000400080000000000000024c0000000800000000000000026200000020b8f34e03813de179368e420ab5c065ffc9dd43f93af811b634758ab4546a325d4c000000080000000000000002",
+      "chain_digest": "PBtKwOcbxzOO7b43q8tJfk5Gb9TmqxyYbgIJu5vOMvY=",
+      "signed_transcript_hex": "73000000206f732e6d61706c652d72657365742d636c6561722d72657175697265642e76316a0000000200017500000010820000000000400080000000000000027500000010920000000000400080000000000000024c0000000800000000000000024c0000000800000000000000024c0000000800000000000000024c000000080000000000000003750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001077777777777747778777777777777777750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000054c0000000800000000000000017500000010262626262626462686262626262626264c0000000800000000000000067500000010272727272727472787272727272727274c000000080000000000000007730000003d616c6c5f706169725f617574686f72697a6174696f6e735f666f725f6163636f756e745f70726f6a6563745f686f73745f696e7374616c6c6174696f6e6a0000000200016200000020ab1e179c980935715004fb489a0de2059057bbc343064157527a8a3c965288063f0000000101750000001081000000000040008000000000000001620000002039b933d71bf4e47970b0e2b9c2147e8f7448e9a76086b02c4bc401e68bc4e8ce62000000205d8e559bc0643f1b3a86ccb572ae14338b5b717b09463a3699e5dfbff19d7c366c000000080000019ff872f0306200000020b8f34e03813de179368e420ab5c065ffc9dd43f93af811b634758ab4546a325d4c00000008000000000000000262000000203c1b4ac0e71bc7338eedbe37abcb497e4e466fd4e6ab1c986e0209bb9bce32f6730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+      "event_digest": "sjhPXcPLWqYTn6OxZ1WwaWZKVOua6sic+WJVIeboSms="
+    },
+    {
+      "instruction": {
+        "artifact_version": 1,
+        "event_id": "83000000-0000-4000-8000-000000000003",
+        "reset_id": "93000000-0000-4000-8000-000000000003",
+        "reset_generation": 3,
+        "cumulative_reset_count": 3,
+        "source_security_epoch": 3,
+        "security_epoch": 4,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "issuer_sequence": 1,
+        "source_revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+        "source_revocation_stream_generation": 7,
+        "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+        "revocation_stream_generation": 8,
+        "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+        "admission_count": 128,
+        "admission_set_digest": "5MZmKvI3pDpvRQlfkt/Pi8JBF+iZ8yVl+xvFC5Q2WfE=",
+        "previous_reset_clear_event_id": "82000000-0000-4000-8000-000000000002",
+        "previous_instruction_material_digest": "uPNOA4E94Xk2jkIKtcBl/8ndQ/k6+BG2NHWKtFRqMl0=",
+        "previous_chain_digest": "PBtKwOcbxzOO7b43q8tJfk5Gb9TmqxyYbgIJu5vOMvY=",
+        "reset_at_unix_ms": 1786579720000,
+        "instruction_material_digest": "nokyFmkWXg8f96cootoMKOHa2R7gqt1t8q3fF77zLbY=",
+        "chain_digest": "IS0NULQtQ4D0uQ8EiHt3WMKfPhmWMDTJ6SjVSoQqOSo=",
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "uc6/a1kMJvQ+NpOGluSh7gtLWLSZ5FgGGRuSveIQWZUCXl6NmSFFApN3tC6SyM+jRDSDYG2hy1Ph8/abGywRAg=="
+      },
+      "instruction_material_transcript_hex": "730000002c6f732e6d61706c652d72657365742d636c6561722d696e737472756374696f6e2d6d6174657269616c2e76316a0000000200017500000010830000000000400080000000000000037500000010930000000000400080000000000000034c0000000800000000000000034c0000000800000000000000034c0000000800000000000000034c000000080000000000000004750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001077777777777747778777777777777777750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000054c0000000800000000000000017500000010272727272727472787272727272727274c0000000800000000000000077500000010282828282828482888282828282828284c000000080000000000000008730000003d616c6c5f706169725f617574686f72697a6174696f6e735f666f725f6163636f756e745f70726f6a6563745f686f73745f696e7374616c6c6174696f6e6a0000000200806200000020e4c6662af237a43a6f45095f92dfcf8bc24117e899f32565fb1bc50b943659f13f00000001017500000010820000000000400080000000000000026200000020b8f34e03813de179368e420ab5c065ffc9dd43f93af811b634758ab4546a325d62000000203c1b4ac0e71bc7338eedbe37abcb497e4e466fd4e6ab1c986e0209bb9bce32f66c000000080000019ff8731740",
+      "instruction_material_digest": "nokyFmkWXg8f96cootoMKOHa2R7gqt1t8q3fF77zLbY=",
+      "chain_transcript_hex": "730000001d6f732e6d61706c652d72657365742d636c6561722d636861696e2e76316a0000000200013f000000010162000000203c1b4ac0e71bc7338eedbe37abcb497e4e466fd4e6ab1c986e0209bb9bce32f67500000010820000000000400080000000000000026200000020b8f34e03813de179368e420ab5c065ffc9dd43f93af811b634758ab4546a325d7500000010930000000000400080000000000000037500000010830000000000400080000000000000034c00000008000000000000000362000000209e89321669165e0f1ff7a728a2da0c28e1dad91ee0aadd6df2addf17bef32db64c000000080000000000000003",
+      "chain_digest": "IS0NULQtQ4D0uQ8EiHt3WMKfPhmWMDTJ6SjVSoQqOSo=",
+      "signed_transcript_hex": "73000000206f732e6d61706c652d72657365742d636c6561722d72657175697265642e76316a0000000200017500000010830000000000400080000000000000037500000010930000000000400080000000000000034c0000000800000000000000034c0000000800000000000000034c0000000800000000000000034c000000080000000000000004750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001077777777777747778777777777777777750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000054c0000000800000000000000017500000010272727272727472787272727272727274c0000000800000000000000077500000010282828282828482888282828282828284c000000080000000000000008730000003d616c6c5f706169725f617574686f72697a6174696f6e735f666f725f6163636f756e745f70726f6a6563745f686f73745f696e7374616c6c6174696f6e6a0000000200806200000020e4c6662af237a43a6f45095f92dfcf8bc24117e899f32565fb1bc50b943659f13f00000001017500000010820000000000400080000000000000026200000020b8f34e03813de179368e420ab5c065ffc9dd43f93af811b634758ab4546a325d62000000203c1b4ac0e71bc7338eedbe37abcb497e4e466fd4e6ab1c986e0209bb9bce32f66c000000080000019ff873174062000000209e89321669165e0f1ff7a728a2da0c28e1dad91ee0aadd6df2addf17bef32db64c0000000800000000000000036200000020212d0d50b42d4380f4b90f04887b7758c29f3e19963034c9e928d54a842a392a730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+      "event_digest": "fH7PgfZv5S+Mesfkhoa7m97t9HcaPgjuVF28SuTcMls="
+    }
+  ],
+  "reset_clear_successor_vectors": {
+    "exact_full_host_claim_fields": [
+      "registration_id",
+      "device_id",
+      "installation_id",
+      "identity_algorithm",
+      "identity_public_key",
+      "endpoint_id",
+      "endpoint_epoch"
+    ],
+    "predecessor": {
+      "artifact_version": 1,
+      "event_id": "81000000-0000-4000-8000-000000000001",
+      "reset_id": "91000000-0000-4000-8000-000000000001",
+      "reset_generation": 1,
+      "cumulative_reset_count": 1,
+      "source_security_epoch": 1,
+      "security_epoch": 2,
+      "subject_account_id": "11111111-1111-4111-8111-111111111111",
+      "subject_project_id": "22222222-2222-4222-8222-222222222222",
+      "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+      "host": {
+        "registration_id": "77777777-7777-4777-8777-777777777777",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "installation_id": "99999999-9999-4999-8999-999999999999",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+        "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+        "endpoint_epoch": 5
+      },
+      "issuer_sequence": 1,
+      "source_revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+      "source_revocation_stream_generation": 5,
+      "revocation_stream_id": "26262626-2626-4626-8626-262626262626",
+      "revocation_stream_generation": 6,
+      "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+      "admission_count": 0,
+      "admission_set_digest": "7wU8UwigHo6NmQ8LjGSKcoXG8g3aVUxDP4bl19AeDEk=",
+      "previous_reset_clear_event_id": null,
+      "previous_instruction_material_digest": null,
+      "previous_chain_digest": null,
+      "reset_at_unix_ms": 1786579700000,
+      "instruction_material_digest": "Obkz1xv05HlwsOK5whR+j3RI6adghrAsS8QB5ovE6M4=",
+      "chain_digest": "XY5Vm8BkPxs6hsy1cq4UM4tbcXsJRjo2meXfv/GdfDY=",
+      "issuer_key_id": "maple-test-issuer-2026-08-13",
+      "issuer_signature": "ksYMEh96b2Caq/cL8JubJFrqCB7AoU/0vlfdV3zVKpZK9zhyE4grU3h240A4RpuO/1zNAneUjWshHCvTpt6qBA=="
+    },
+    "accepted": {
+      "instruction": {
+        "artifact_version": 1,
+        "event_id": "82000000-0000-4000-8000-000000000002",
+        "reset_id": "92000000-0000-4000-8000-000000000002",
+        "reset_generation": 2,
+        "cumulative_reset_count": 2,
+        "source_security_epoch": 2,
+        "security_epoch": 3,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "issuer_sequence": 1,
+        "source_revocation_stream_id": "26262626-2626-4626-8626-262626262626",
+        "source_revocation_stream_generation": 6,
+        "revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+        "revocation_stream_generation": 7,
+        "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+        "admission_count": 1,
+        "admission_set_digest": "qx4XnJgJNXFQBPtImg3iBZBXu8NDBkFXUnqKPJZSiAY=",
+        "previous_reset_clear_event_id": "81000000-0000-4000-8000-000000000001",
+        "previous_instruction_material_digest": "Obkz1xv05HlwsOK5whR+j3RI6adghrAsS8QB5ovE6M4=",
+        "previous_chain_digest": "XY5Vm8BkPxs6hsy1cq4UM4tbcXsJRjo2meXfv/GdfDY=",
+        "reset_at_unix_ms": 1786579710000,
+        "instruction_material_digest": "uPNOA4E94Xk2jkIKtcBl/8ndQ/k6+BG2NHWKtFRqMl0=",
+        "chain_digest": "PBtKwOcbxzOO7b43q8tJfk5Gb9TmqxyYbgIJu5vOMvY=",
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "4rj3i0AnNDPNzHZh6X/2VRDxNPQ19NmSC+tF2Cmg5A/UWgdgsV2lFIYRukdLT+AMp95OAwJjzrOFlSUCxVy3Cg=="
+      },
+      "checkpoint": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "security_epoch": 3,
+        "revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+        "revocation_stream_generation": 7,
+        "last_issued_issuer_sequence": 1,
+        "last_acked_issuer_sequence": 0,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "CJgmMT8VhEISt4io4ibCj39VkAPq2UjECnMpGXxUKPkY2gmgICqpRPsI4sFD0qr1Jxin+O6jLvlkGLO3/oDuDg=="
+      },
+      "expected": "accepted"
+    },
+    "changed_host": {
+      "instruction": {
+        "artifact_version": 1,
+        "event_id": "82000000-0000-4000-8000-000000000002",
+        "reset_id": "92000000-0000-4000-8000-000000000002",
+        "reset_generation": 2,
+        "cumulative_reset_count": 2,
+        "source_security_epoch": 2,
+        "security_epoch": 3,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 6
+        },
+        "issuer_sequence": 1,
+        "source_revocation_stream_id": "26262626-2626-4626-8626-262626262626",
+        "source_revocation_stream_generation": 6,
+        "revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+        "revocation_stream_generation": 7,
+        "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+        "admission_count": 1,
+        "admission_set_digest": "qx4XnJgJNXFQBPtImg3iBZBXu8NDBkFXUnqKPJZSiAY=",
+        "previous_reset_clear_event_id": "81000000-0000-4000-8000-000000000001",
+        "previous_instruction_material_digest": "Obkz1xv05HlwsOK5whR+j3RI6adghrAsS8QB5ovE6M4=",
+        "previous_chain_digest": "XY5Vm8BkPxs6hsy1cq4UM4tbcXsJRjo2meXfv/GdfDY=",
+        "reset_at_unix_ms": 1786579710000,
+        "instruction_material_digest": "6fMGpxp9hkvOC+nM26v7vnmMygckP+n1Z9ZHy/z+QZQ=",
+        "chain_digest": "SKVXffrGj0ElYnoRUsW35ZOjRqYKeUqPeoR8u4HSUMs=",
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "ZPK/GRgYCP1LfmrUwJxhvwG8B9D7ZQZyz7dNlOC+ZlfAKCt/sDGJIp6B7yGrxnf2aM9tZa3Bl86xh5QA6PcSCQ=="
+      },
+      "checkpoint": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 6
+        },
+        "security_epoch": 3,
+        "revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+        "revocation_stream_generation": 7,
+        "last_issued_issuer_sequence": 1,
+        "last_acked_issuer_sequence": 0,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "/fPoLWAA4coUa8BPo/IDv5MuBuMGkIu+xmhhHTvzigadHusjFbUcrtZh3nhQNwYXl3BY+IuVU9MDftM+ptHhDw=="
+      },
+      "expected": "reset_clear_successor_binding_rejected"
+    }
+  },
+  "two_host_ack_namespace_vectors": {
+    "namespace_fields": [
+      "asserted_account_id",
+      "asserted_project_id",
+      "host_registration_id",
+      "operation_id"
+    ],
+    "shared_operation_id": "45454545-4545-4545-8545-454545454545",
+    "host_a": {
+      "request": {
+        "protocol_version": 1,
+        "transcript_version": 1,
+        "operation_id": "45454545-4545-4545-8545-454545454545",
+        "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+        "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+        "host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "revocation_stream_id": "a5000000-0000-4000-8000-000000000001",
+        "revocation_stream_generation": 8,
+        "event_id": "a1000000-0000-4000-8000-000000000001",
+        "issuer_sequence": 1,
+        "event_digest": "xc9aXK6CjzEgo8+a6Q75ShUGaA/S6ph+BzdBtvkkdbs=",
+        "expected_previous_issuer_sequence": 0,
+        "signature": "rdN+5/DF6ipYLt7DgTUNybCZVOIsSvTOtrvMB60UqVUMfjY3kBY+16R8qSZPCkJ2qz1v7KcvH3ywFe5+0/DQCg=="
+      },
+      "request_transcript_hex": "730000001f6f732e6d61706c652d706169722d7265766f636174696f6e2d61636b2e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010454545454545454585454545454545457500000010777777777777477787777777777777777500000010a50000000000400080000000000000014c0000000800000000000000087500000010a10000000000400080000000000000014c0000000800000000000000016200000020c5cf5a5cae828f3120a3cf9ae90ef94a1506680fd2ea987e073741b6f92475bb4c000000080000000000000000",
+      "request_digest": "p0xWsQuPeuDx/qt+Yq1mF3SOLI/Tuoi04JHBOaszWng=",
+      "response": {
+        "protocol_version": 1,
+        "operation_id": "45454545-4545-4545-8545-454545454545",
+        "host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "stream_checkpoint": {
+          "artifact_version": 1,
+          "subject_account_id": "11111111-1111-4111-8111-111111111111",
+          "subject_project_id": "22222222-2222-4222-8222-222222222222",
+          "host": {
+            "registration_id": "77777777-7777-4777-8777-777777777777",
+            "device_id": "88888888-8888-4888-8888-888888888888",
+            "installation_id": "99999999-9999-4999-8999-999999999999",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+            "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+            "endpoint_epoch": 5
+          },
+          "security_epoch": 4,
+          "revocation_stream_id": "a5000000-0000-4000-8000-000000000001",
+          "revocation_stream_generation": 8,
+          "last_issued_issuer_sequence": 1,
+          "last_acked_issuer_sequence": 1,
+          "issuer_key_id": "maple-test-issuer-2026-08-13",
+          "issuer_signature": "D/lUJcRYrcGV1pUPCjquu2pi7M25rtOdBk1TR4mpIVX4n4nzkfIQcO2ZNIrOf1h0C7JkisgpylOjywrJISA5DA=="
+        },
+        "event_id": "a1000000-0000-4000-8000-000000000001",
+        "issuer_sequence": 1,
+        "last_acked_issuer_sequence": 1,
+        "accepted_at_unix_ms": 1786579731000
+      }
+    },
+    "host_b": {
+      "request": {
+        "protocol_version": 1,
+        "transcript_version": 1,
+        "operation_id": "45454545-4545-4545-8545-454545454545",
+        "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+        "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+        "host_registration_id": "a7777777-7777-4777-8777-777777777777",
+        "revocation_stream_id": "b5000000-0000-4000-8000-000000000001",
+        "revocation_stream_generation": 8,
+        "event_id": "b1000000-0000-4000-8000-000000000001",
+        "issuer_sequence": 1,
+        "event_digest": "t0rNuBrUSpd8Va5mvutzhqBHjBtlAAGj/AxbqiWlJrY=",
+        "expected_previous_issuer_sequence": 0,
+        "signature": "0OWkDrK2kCPHSYliR7ToDT7ZctuuxDVZmc7y6boLBtjHNnn+jB+Cf42BIUqednc2bOp+qEbVgxgv0Y3gd+RoCg=="
+      },
+      "request_transcript_hex": "730000001f6f732e6d61706c652d706169722d7265766f636174696f6e2d61636b2e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010454545454545454585454545454545457500000010a77777777777477787777777777777777500000010b50000000000400080000000000000014c0000000800000000000000087500000010b10000000000400080000000000000014c0000000800000000000000016200000020b74acdb81ad44a977c55ae66beeb7386a0478c1b650001a3fc0c5baa25a526b64c000000080000000000000000",
+      "request_digest": "9WCs/gxhmNwaft86Pj5gJDa13yPoT9SmX+MGlrhKeL0=",
+      "response": {
+        "protocol_version": 1,
+        "operation_id": "45454545-4545-4545-8545-454545454545",
+        "host_registration_id": "a7777777-7777-4777-8777-777777777777",
+        "stream_checkpoint": {
+          "artifact_version": 1,
+          "subject_account_id": "11111111-1111-4111-8111-111111111111",
+          "subject_project_id": "22222222-2222-4222-8222-222222222222",
+          "host": {
+            "registration_id": "a7777777-7777-4777-8777-777777777777",
+            "device_id": "a8888888-8888-4888-8888-888888888888",
+            "installation_id": "a9999999-9999-4999-8999-999999999999",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": "LISK2GZO5lHkiWwTqEqJopZKyl63eouIHmDe1cgbTp0=",
+            "endpoint_id": "2c848ad8664ee651e4896c13a84a89a2964aca5eb77a8b881e60ded5c81b4e9d",
+            "endpoint_epoch": 2
+          },
+          "security_epoch": 4,
+          "revocation_stream_id": "b5000000-0000-4000-8000-000000000001",
+          "revocation_stream_generation": 8,
+          "last_issued_issuer_sequence": 1,
+          "last_acked_issuer_sequence": 1,
+          "issuer_key_id": "maple-test-issuer-2026-08-13",
+          "issuer_signature": "fa6U/JQxrrrKKkzvSwQtKdWlc8YlQFHdsAKpnBXmZMuKw1EfU5QvctA46nrbmEM0n7kBlYyngGjMDppEpMRCBg=="
+        },
+        "event_id": "b1000000-0000-4000-8000-000000000001",
+        "issuer_sequence": 1,
+        "last_acked_issuer_sequence": 1,
+        "accepted_at_unix_ms": 1786579731000
+      }
+    },
+    "same_host_replay": "byte_identical",
+    "cross_host_request_response_binding": "rejected"
+  },
+  "issuer_rotation_vectors": {
+    "artifact_signed_by_initial": {
+      "artifact_version": 1,
+      "subject_account_id": "11111111-1111-4111-8111-111111111111",
+      "subject_project_id": "22222222-2222-4222-8222-222222222222",
+      "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      "direction": "controller_to_host",
+      "execution_target_id": "77777777-7777-4777-8777-777777777777",
+      "controller": {
+        "registration_id": "44444444-4444-4444-8444-444444444444",
+        "device_id": "55555555-5555-4555-8555-555555555555",
+        "installation_id": "66666666-6666-4666-8666-666666666666",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+        "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+        "endpoint_epoch": 7
+      },
+      "host": {
+        "registration_id": "77777777-7777-4777-8777-777777777777",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "installation_id": "99999999-9999-4999-8999-999999999999",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+        "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+        "endpoint_epoch": 4
+      },
+      "pairing_request_nonce": "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE=",
+      "controller_request_operation_id": "33333333-3333-4333-8333-333333333333",
+      "controller_request_digest": "lNmGBN77EGCP5jskKV4y48fINkn/O/pX6/wBpnxWwz8=",
+      "controller_request_signature": "5t5vmZn8wMcpyC6XpcvIU6nXG/Vr4FpD9t/kHKu/k0e3eYADBHOSMpN5+AC6+lxum3jkOYPCDfw09QsY/w+qBg==",
+      "pairing_incarnation": 3,
+      "protocol_min": 1,
+      "protocol_max": 1,
+      "created_at_unix_ms": 1786579200000,
+      "expires_at_unix_ms": 1786579800000,
+      "issuer_key_id": "maple-test-issuer-2026-08-13",
+      "issuer_signature": "7pFcCius3oPkwbDWAGRWGHUxAUDN8MEOQYKgerl9+jANv21mToaaCpJ4wWT/PElhq1OFgR+o18xRo21BcI9xAg=="
+    },
+    "initial": {
+      "keyset": {
+        "version": 1,
+        "keys": [
+          {
+            "key_id": "maple-test-issuer-2026-08-13",
+            "algorithm": "ed25519",
+            "public_key": "a3NKjv8kb+c0s41ARsFI7uXwT+h7OgpCOVWneVbeBms="
+          }
+        ]
+      },
+      "wire_verification_expected": "accepted",
+      "registry_reconciliation_expected": "accepted_initial"
+    },
+    "rotated_retaining_previous": {
+      "keyset": {
+        "version": 1,
+        "keys": [
+          {
+            "key_id": "maple-test-issuer-2026-08-13",
+            "algorithm": "ed25519",
+            "public_key": "a3NKjv8kb+c0s41ARsFI7uXwT+h7OgpCOVWneVbeBms="
+          },
+          {
+            "key_id": "maple-test-issuer-2026-08-14",
+            "algorithm": "ed25519",
+            "public_key": "iyN9eI6Oqu9VDG0SWCP6RfH9X8KbLIi9+HERlHH8ExI="
+          }
+        ]
+      },
+      "wire_verification_expected": "accepted",
+      "registry_reconciliation_expected": "append_accepted"
+    },
+    "rotated_without_previous": {
+      "keyset": {
+        "version": 1,
+        "keys": [
+          {
+            "key_id": "maple-test-issuer-2026-08-14",
+            "algorithm": "ed25519",
+            "public_key": "iyN9eI6Oqu9VDG0SWCP6RfH9X8KbLIi9+HERlHH8ExI="
+          }
+        ]
+      },
+      "wire_verification_expected": "unknown_issuer",
+      "registry_reconciliation_expected": "MaplePairingIssuerConfigurationConflict"
+    },
+    "remapped_previous_key_id": {
+      "keyset": {
+        "version": 1,
+        "keys": [
+          {
+            "key_id": "maple-test-issuer-2026-08-13",
+            "algorithm": "ed25519",
+            "public_key": "sqlC/0yYcYvtduJVmH9tWbGnLTss0lEAA+YXCsY6n/s="
+          },
+          {
+            "key_id": "maple-test-issuer-2026-08-14",
+            "algorithm": "ed25519",
+            "public_key": "iyN9eI6Oqu9VDG0SWCP6RfH9X8KbLIi9+HERlHH8ExI="
+          }
+        ]
+      },
+      "wire_verification_expected": "invalid_signature",
+      "registry_reconciliation_expected": "MaplePairingIssuerConfigurationConflict"
+    },
+    "retained_registry_rule": "existing_key_id_must_retain_exact_public_key"
+  },
+  "reset_clear_pending_checkpoint": {
+    "artifact_version": 1,
+    "subject_account_id": "11111111-1111-4111-8111-111111111111",
+    "subject_project_id": "22222222-2222-4222-8222-222222222222",
+    "host": {
+      "registration_id": "77777777-7777-4777-8777-777777777777",
+      "device_id": "88888888-8888-4888-8888-888888888888",
+      "installation_id": "99999999-9999-4999-8999-999999999999",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+      "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+      "endpoint_epoch": 5
+    },
+    "security_epoch": 4,
+    "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+    "revocation_stream_generation": 8,
+    "last_issued_issuer_sequence": 1,
+    "last_acked_issuer_sequence": 0,
+    "issuer_key_id": "maple-test-issuer-2026-08-13",
+    "issuer_signature": "1NMOM0FubdOh3m4ihP4pmgRRNhFcflMV+jFd5yV5lpo/EX8quTDwg4HGveQV+0KOcWH1jXJDZr9xYV8HmdDOCg=="
+  },
+  "reset_clear_pending_checkpoint_transcript_hex": "73000000286f732e6d61706c652d7265766f636174696f6e2d73747265616d2d636865636b706f696e742e76316a000000020001750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000054c0000000800000000000000047500000010282828282828482888282828282828284c0000000800000000000000084c0000000800000000000000014c000000080000000000000000730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+  "reset_clear_pending_checkpoint_digest": "YmDBq7Tl9/F02FEYnpPsWhY+OzUJ/CpD7ONOcZROxUM=",
+  "reset_clear_pending_sync": {
+    "security_epoch": 4,
+    "status": "reset_clear_required",
+    "stream_checkpoint": {
+      "artifact_version": 1,
+      "subject_account_id": "11111111-1111-4111-8111-111111111111",
+      "subject_project_id": "22222222-2222-4222-8222-222222222222",
+      "host": {
+        "registration_id": "77777777-7777-4777-8777-777777777777",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "installation_id": "99999999-9999-4999-8999-999999999999",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+        "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+        "endpoint_epoch": 5
+      },
+      "security_epoch": 4,
+      "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+      "revocation_stream_generation": 8,
+      "last_issued_issuer_sequence": 1,
+      "last_acked_issuer_sequence": 0,
+      "issuer_key_id": "maple-test-issuer-2026-08-13",
+      "issuer_signature": "1NMOM0FubdOh3m4ihP4pmgRRNhFcflMV+jFd5yV5lpo/EX8quTDwg4HGveQV+0KOcWH1jXJDZr9xYV8HmdDOCg=="
+    },
+    "reset_clear_instruction": {
+      "artifact_version": 1,
+      "event_id": "83000000-0000-4000-8000-000000000003",
+      "reset_id": "93000000-0000-4000-8000-000000000003",
+      "reset_generation": 3,
+      "cumulative_reset_count": 3,
+      "source_security_epoch": 3,
+      "security_epoch": 4,
+      "subject_account_id": "11111111-1111-4111-8111-111111111111",
+      "subject_project_id": "22222222-2222-4222-8222-222222222222",
+      "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+      "host": {
+        "registration_id": "77777777-7777-4777-8777-777777777777",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "installation_id": "99999999-9999-4999-8999-999999999999",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+        "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+        "endpoint_epoch": 5
+      },
+      "issuer_sequence": 1,
+      "source_revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+      "source_revocation_stream_generation": 7,
+      "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+      "revocation_stream_generation": 8,
+      "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+      "admission_count": 128,
+      "admission_set_digest": "5MZmKvI3pDpvRQlfkt/Pi8JBF+iZ8yVl+xvFC5Q2WfE=",
+      "previous_reset_clear_event_id": "82000000-0000-4000-8000-000000000002",
+      "previous_instruction_material_digest": "uPNOA4E94Xk2jkIKtcBl/8ndQ/k6+BG2NHWKtFRqMl0=",
+      "previous_chain_digest": "PBtKwOcbxzOO7b43q8tJfk5Gb9TmqxyYbgIJu5vOMvY=",
+      "reset_at_unix_ms": 1786579720000,
+      "instruction_material_digest": "nokyFmkWXg8f96cootoMKOHa2R7gqt1t8q3fF77zLbY=",
+      "chain_digest": "IS0NULQtQ4D0uQ8EiHt3WMKfPhmWMDTJ6SjVSoQqOSo=",
+      "issuer_key_id": "maple-test-issuer-2026-08-13",
+      "issuer_signature": "uc6/a1kMJvQ+NpOGluSh7gtLWLSZ5FgGGRuSveIQWZUCXl6NmSFFApN3tC6SyM+jRDSDYG2hy1Ph8/abGywRAg=="
+    }
+  },
+  "reset_clear_list_revocations_request": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "query_id": "31313131-3131-4131-8131-313131313131",
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+    "revocation_stream_generation": 8,
+    "after_issuer_sequence": 0,
+    "limit": 1,
+    "signature": "9uPWCMYlk5OgR8t0SwbI+J92I/tcyn4rXcU5U99ttYyzzwvuFcAOXWApQ1Yw7SNtxTn6juWGG7+Aq+8l5KcEBw=="
+  },
+  "reset_clear_list_revocations_request_transcript_hex": "73000000206f732e6d61706c652d706169722d7265766f636174696f6e2d6c6973742e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010313131313131413181313131313131317500000010777777777777477787777777777777777500000010282828282828482888282828282828284c0000000800000000000000084c0000000800000000000000006a000000020001",
+  "reset_clear_list_revocations_request_digest": "H3l1+aRdTOZQDAR32n6W5xkuJMhvtRqrDJPKkYxxaZo=",
+  "reset_clear_list_revocations_response": {
+    "protocol_version": 1,
+    "query_id": "31313131-3131-4131-8131-313131313131",
+    "revocation_sync": {
+      "security_epoch": 4,
+      "status": "reset_clear_required",
+      "stream_checkpoint": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "security_epoch": 4,
+        "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+        "revocation_stream_generation": 8,
+        "last_issued_issuer_sequence": 1,
+        "last_acked_issuer_sequence": 0,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "1NMOM0FubdOh3m4ihP4pmgRRNhFcflMV+jFd5yV5lpo/EX8quTDwg4HGveQV+0KOcWH1jXJDZr9xYV8HmdDOCg=="
+      },
+      "reset_clear_instruction": {
+        "artifact_version": 1,
+        "event_id": "83000000-0000-4000-8000-000000000003",
+        "reset_id": "93000000-0000-4000-8000-000000000003",
+        "reset_generation": 3,
+        "cumulative_reset_count": 3,
+        "source_security_epoch": 3,
+        "security_epoch": 4,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "issuer_sequence": 1,
+        "source_revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+        "source_revocation_stream_generation": 7,
+        "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+        "revocation_stream_generation": 8,
+        "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+        "admission_count": 128,
+        "admission_set_digest": "5MZmKvI3pDpvRQlfkt/Pi8JBF+iZ8yVl+xvFC5Q2WfE=",
+        "previous_reset_clear_event_id": "82000000-0000-4000-8000-000000000002",
+        "previous_instruction_material_digest": "uPNOA4E94Xk2jkIKtcBl/8ndQ/k6+BG2NHWKtFRqMl0=",
+        "previous_chain_digest": "PBtKwOcbxzOO7b43q8tJfk5Gb9TmqxyYbgIJu5vOMvY=",
+        "reset_at_unix_ms": 1786579720000,
+        "instruction_material_digest": "nokyFmkWXg8f96cootoMKOHa2R7gqt1t8q3fF77zLbY=",
+        "chain_digest": "IS0NULQtQ4D0uQ8EiHt3WMKfPhmWMDTJ6SjVSoQqOSo=",
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "uc6/a1kMJvQ+NpOGluSh7gtLWLSZ5FgGGRuSveIQWZUCXl6NmSFFApN3tC6SyM+jRDSDYG2hy1Ph8/abGywRAg=="
+      }
+    },
+    "events": [
+      {
+        "event_type": "reset_clear_required",
+        "event": {
+          "artifact_version": 1,
+          "event_id": "83000000-0000-4000-8000-000000000003",
+          "reset_id": "93000000-0000-4000-8000-000000000003",
+          "reset_generation": 3,
+          "cumulative_reset_count": 3,
+          "source_security_epoch": 3,
+          "security_epoch": 4,
+          "subject_account_id": "11111111-1111-4111-8111-111111111111",
+          "subject_project_id": "22222222-2222-4222-8222-222222222222",
+          "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+          "host": {
+            "registration_id": "77777777-7777-4777-8777-777777777777",
+            "device_id": "88888888-8888-4888-8888-888888888888",
+            "installation_id": "99999999-9999-4999-8999-999999999999",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+            "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+            "endpoint_epoch": 5
+          },
+          "issuer_sequence": 1,
+          "source_revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+          "source_revocation_stream_generation": 7,
+          "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+          "revocation_stream_generation": 8,
+          "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+          "admission_count": 128,
+          "admission_set_digest": "5MZmKvI3pDpvRQlfkt/Pi8JBF+iZ8yVl+xvFC5Q2WfE=",
+          "previous_reset_clear_event_id": "82000000-0000-4000-8000-000000000002",
+          "previous_instruction_material_digest": "uPNOA4E94Xk2jkIKtcBl/8ndQ/k6+BG2NHWKtFRqMl0=",
+          "previous_chain_digest": "PBtKwOcbxzOO7b43q8tJfk5Gb9TmqxyYbgIJu5vOMvY=",
+          "reset_at_unix_ms": 1786579720000,
+          "instruction_material_digest": "nokyFmkWXg8f96cootoMKOHa2R7gqt1t8q3fF77zLbY=",
+          "chain_digest": "IS0NULQtQ4D0uQ8EiHt3WMKfPhmWMDTJ6SjVSoQqOSo=",
+          "issuer_key_id": "maple-test-issuer-2026-08-13",
+          "issuer_signature": "uc6/a1kMJvQ+NpOGluSh7gtLWLSZ5FgGGRuSveIQWZUCXl6NmSFFApN3tC6SyM+jRDSDYG2hy1Ph8/abGywRAg=="
+        }
+      }
+    ],
+    "next_after_issuer_sequence": 1,
+    "has_more": false
+  },
+  "reset_clear_ack_request": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "operation_id": "32323232-3232-4232-8232-323232323232",
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+    "revocation_stream_generation": 8,
+    "event_id": "83000000-0000-4000-8000-000000000003",
+    "issuer_sequence": 1,
+    "event_digest": "fH7PgfZv5S+Mesfkhoa7m97t9HcaPgjuVF28SuTcMls=",
+    "expected_previous_issuer_sequence": 0,
+    "signature": "xxioxePHKbzywvcrpbhdpUAc1Noq9dDJvZQKRORWE2KokTPfPH/jpbpCRj/uGciUsDVJrSPiU8JOs9TsBHkYAg=="
+  },
+  "reset_clear_ack_request_transcript_hex": "730000001f6f732e6d61706c652d706169722d7265766f636174696f6e2d61636b2e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010323232323232423282323232323232327500000010777777777777477787777777777777777500000010282828282828482888282828282828284c0000000800000000000000087500000010830000000000400080000000000000034c00000008000000000000000162000000207c7ecf81f66fe52f8c7ac7e48686bb9bdeedf4771a3e08ee545dbc4ae4dc325b4c000000080000000000000000",
+  "reset_clear_ack_request_digest": "/zFewDh7aGI+4NdKePfM7RojQ4nYdptu4CR4gysa/As=",
+  "reset_clear_acked_checkpoint": {
+    "artifact_version": 1,
+    "subject_account_id": "11111111-1111-4111-8111-111111111111",
+    "subject_project_id": "22222222-2222-4222-8222-222222222222",
+    "host": {
+      "registration_id": "77777777-7777-4777-8777-777777777777",
+      "device_id": "88888888-8888-4888-8888-888888888888",
+      "installation_id": "99999999-9999-4999-8999-999999999999",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+      "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+      "endpoint_epoch": 5
+    },
+    "security_epoch": 4,
+    "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+    "revocation_stream_generation": 8,
+    "last_issued_issuer_sequence": 1,
+    "last_acked_issuer_sequence": 1,
+    "issuer_key_id": "maple-test-issuer-2026-08-13",
+    "issuer_signature": "uWhCXh7TI15oJyONERZbGs+5Jr23jIvUyzJzBtv5xWRv0wQaGs4U8Kd6xa8y02p2MUAjM176+3WOu4Jq1X+ZAQ=="
+  },
+  "reset_clear_acked_checkpoint_transcript_hex": "73000000286f732e6d61706c652d7265766f636174696f6e2d73747265616d2d636865636b706f696e742e76316a000000020001750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000054c0000000800000000000000047500000010282828282828482888282828282828284c0000000800000000000000084c0000000800000000000000014c000000080000000000000001730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+  "reset_clear_acked_checkpoint_digest": "EfixdxEjW1jd2OGeM3d0EtdmDB2reabDxAOqElbjxJY=",
+  "reset_clear_ack_response": {
+    "protocol_version": 1,
+    "operation_id": "32323232-3232-4232-8232-323232323232",
+    "host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "stream_checkpoint": {
+      "artifact_version": 1,
+      "subject_account_id": "11111111-1111-4111-8111-111111111111",
+      "subject_project_id": "22222222-2222-4222-8222-222222222222",
+      "host": {
+        "registration_id": "77777777-7777-4777-8777-777777777777",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "installation_id": "99999999-9999-4999-8999-999999999999",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+        "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+        "endpoint_epoch": 5
+      },
+      "security_epoch": 4,
+      "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+      "revocation_stream_generation": 8,
+      "last_issued_issuer_sequence": 1,
+      "last_acked_issuer_sequence": 1,
+      "issuer_key_id": "maple-test-issuer-2026-08-13",
+      "issuer_signature": "uWhCXh7TI15oJyONERZbGs+5Jr23jIvUyzJzBtv5xWRv0wQaGs4U8Kd6xa8y02p2MUAjM176+3WOu4Jq1X+ZAQ=="
+    },
+    "event_id": "83000000-0000-4000-8000-000000000003",
+    "issuer_sequence": 1,
+    "last_acked_issuer_sequence": 1,
+    "accepted_at_unix_ms": 1786579721000
+  },
+  "reset_clear_historical_acked_response": {
+    "protocol_version": 1,
+    "query_id": "31313131-3131-4131-8131-313131313131",
+    "revocation_sync": {
+      "security_epoch": 4,
+      "status": "ready",
+      "stream_checkpoint": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "security_epoch": 4,
+        "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+        "revocation_stream_generation": 8,
+        "last_issued_issuer_sequence": 1,
+        "last_acked_issuer_sequence": 1,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "uWhCXh7TI15oJyONERZbGs+5Jr23jIvUyzJzBtv5xWRv0wQaGs4U8Kd6xa8y02p2MUAjM176+3WOu4Jq1X+ZAQ=="
+      },
+      "reset_clear_instruction": null
+    },
+    "events": [
+      {
+        "event_type": "reset_clear_required",
+        "event": {
+          "artifact_version": 1,
+          "event_id": "83000000-0000-4000-8000-000000000003",
+          "reset_id": "93000000-0000-4000-8000-000000000003",
+          "reset_generation": 3,
+          "cumulative_reset_count": 3,
+          "source_security_epoch": 3,
+          "security_epoch": 4,
+          "subject_account_id": "11111111-1111-4111-8111-111111111111",
+          "subject_project_id": "22222222-2222-4222-8222-222222222222",
+          "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+          "host": {
+            "registration_id": "77777777-7777-4777-8777-777777777777",
+            "device_id": "88888888-8888-4888-8888-888888888888",
+            "installation_id": "99999999-9999-4999-8999-999999999999",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+            "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+            "endpoint_epoch": 5
+          },
+          "issuer_sequence": 1,
+          "source_revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+          "source_revocation_stream_generation": 7,
+          "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+          "revocation_stream_generation": 8,
+          "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+          "admission_count": 128,
+          "admission_set_digest": "5MZmKvI3pDpvRQlfkt/Pi8JBF+iZ8yVl+xvFC5Q2WfE=",
+          "previous_reset_clear_event_id": "82000000-0000-4000-8000-000000000002",
+          "previous_instruction_material_digest": "uPNOA4E94Xk2jkIKtcBl/8ndQ/k6+BG2NHWKtFRqMl0=",
+          "previous_chain_digest": "PBtKwOcbxzOO7b43q8tJfk5Gb9TmqxyYbgIJu5vOMvY=",
+          "reset_at_unix_ms": 1786579720000,
+          "instruction_material_digest": "nokyFmkWXg8f96cootoMKOHa2R7gqt1t8q3fF77zLbY=",
+          "chain_digest": "IS0NULQtQ4D0uQ8EiHt3WMKfPhmWMDTJ6SjVSoQqOSo=",
+          "issuer_key_id": "maple-test-issuer-2026-08-13",
+          "issuer_signature": "uc6/a1kMJvQ+NpOGluSh7gtLWLSZ5FgGGRuSveIQWZUCXl6NmSFFApN3tC6SyM+jRDSDYG2hy1Ph8/abGywRAg=="
+        }
+      }
+    ],
+    "next_after_issuer_sequence": 1,
+    "has_more": false
+  },
+  "reset_clear_later_pair_revocation": {
+    "artifact_version": 1,
+    "event_id": "33333333-0000-4333-8333-333333333333",
+    "subject_account_id": "11111111-1111-4111-8111-111111111111",
+    "subject_project_id": "22222222-2222-4222-8222-222222222222",
+    "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "issuer_sequence": 2,
+    "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+    "revocation_stream_generation": 8,
+    "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    "direction": "controller_to_host",
+    "execution_target_id": "77777777-7777-4777-8777-777777777777",
+    "controller": {
+      "registration_id": "44444444-4444-4444-8444-444444444444",
+      "device_id": "55555555-5555-4555-8555-555555555555",
+      "installation_id": "66666666-6666-4666-8666-666666666666",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+      "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+      "endpoint_epoch": 7
+    },
+    "host": {
+      "registration_id": "77777777-7777-4777-8777-777777777777",
+      "device_id": "88888888-8888-4888-8888-888888888888",
+      "installation_id": "99999999-9999-4999-8999-999999999999",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+      "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+      "endpoint_epoch": 4
+    },
+    "pairing_incarnation": 3,
+    "pair_authorization_digest": "CQ/HPMinOZUsvf9kh5qmq8uOHtfoM45yj7HB/5704iQ=",
+    "revoked_by_registration_id": "44444444-4444-4444-8444-444444444444",
+    "revoked_by_role": "controller",
+    "reason_code": "user_removed_access",
+    "revoked_at_unix_ms": 1786579722000,
+    "issuer_key_id": "maple-test-issuer-2026-08-13",
+    "issuer_signature": "v5dC7EZBFM1Ksh+R9/m+apIutyzMVeZqHcofCbstK7+xZrZPc3NKfvIrTYbZpfT0GXUe88v3PH/D2olPKvh6Bw=="
+  },
+  "reset_clear_later_pair_revocation_transcript_hex": "730000001b6f732e6d61706c652d706169722d7265766f636174696f6e2e76316a0000000200017500000010333333330000433383333333333333337500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010777777777777477787777777777777774c0000000800000000000000027500000010282828282828482888282828282828284c0000000800000000000000087500000010bbbbbbbbbbbb4bbb8bbbbbbbbbbbbbbb7500000010cccccccccccc4ccc8ccccccccccccccc7300000012636f6e74726f6c6c65725f746f5f686f73747500000010777777777777477787777777777777777500000010444444444444444484444444444444447500000010555555555555455585555555555555557500000010666666666666466686666666666666667300000007656432353531396200000020d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c97787376200000020d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c97787374c000000080000000000000007750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000044c0000000800000000000000036200000020090fc73cc8a739952cbdff64879aa6abcb8e1ed7e8338e728fb1c1ff9ef4e224750000001044444444444444448444444444444444730000000a636f6e74726f6c6c65727300000013757365725f72656d6f7665645f6163636573736c000000080000019ff8731f10730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+  "reset_clear_later_pair_revocation_digest": "WjPnnGkUUrQBLi764cLay5EV/FwvtJwziqq+/y1CdQQ=",
+  "reset_clear_later_checkpoint": {
+    "artifact_version": 1,
+    "subject_account_id": "11111111-1111-4111-8111-111111111111",
+    "subject_project_id": "22222222-2222-4222-8222-222222222222",
+    "host": {
+      "registration_id": "77777777-7777-4777-8777-777777777777",
+      "device_id": "88888888-8888-4888-8888-888888888888",
+      "installation_id": "99999999-9999-4999-8999-999999999999",
+      "identity_algorithm": "ed25519",
+      "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+      "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+      "endpoint_epoch": 5
+    },
+    "security_epoch": 4,
+    "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+    "revocation_stream_generation": 8,
+    "last_issued_issuer_sequence": 2,
+    "last_acked_issuer_sequence": 1,
+    "issuer_key_id": "maple-test-issuer-2026-08-13",
+    "issuer_signature": "ncgLg604IpnAlnbQwtYNpdOI9mQCDam3mHo7PNK7m+JXJXg9+e5JzBxlhD16tzIsqhvVWsXJm9OKjporZu0PDQ=="
+  },
+  "reset_clear_later_checkpoint_transcript_hex": "73000000286f732e6d61706c652d7265766f636174696f6e2d73747265616d2d636865636b706f696e742e76316a000000020001750000001011111111111141118111111111111111750000001022222222222242228222222222222222750000001077777777777747778777777777777777750000001088888888888848888888888888888888750000001099999999999949998999999999999999730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000054c0000000800000000000000047500000010282828282828482888282828282828284c0000000800000000000000084c0000000800000000000000024c000000080000000000000001730000001c6d61706c652d746573742d6973737565722d323032362d30382d3133",
+  "reset_clear_later_checkpoint_digest": "WR+/LS4W5s9YEHZ4e12ephu0qU/KHI44jK9MfCINJPk=",
+  "reset_clear_historical_later_request": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "query_id": "34343434-3434-4434-8434-343434343434",
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "host_registration_id": "77777777-7777-4777-8777-777777777777",
+    "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+    "revocation_stream_generation": 8,
+    "after_issuer_sequence": 0,
+    "limit": 2,
+    "signature": "d+jqt6YKlEgU5NZFJ/QPRGIul5kIGwFg0WDiQtz+7ibaI9Po2UmsZo26RJ4Q0czAOiWyxnsOmqg8W0Drtjn+BA=="
+  },
+  "reset_clear_historical_later_request_transcript_hex": "73000000206f732e6d61706c652d706169722d7265766f636174696f6e2d6c6973742e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222227500000010343434343434443484343434343434347500000010777777777777477787777777777777777500000010282828282828482888282828282828284c0000000800000000000000084c0000000800000000000000006a000000020002",
+  "reset_clear_historical_later_request_digest": "cJONqRfKGLxpmrOtr88hoyYGyEoF2fJE5AC2m9dOVZ8=",
+  "reset_clear_historical_later_response": {
+    "protocol_version": 1,
+    "query_id": "34343434-3434-4434-8434-343434343434",
+    "revocation_sync": {
+      "security_epoch": 4,
+      "status": "revocations_pending",
+      "stream_checkpoint": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "security_epoch": 4,
+        "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+        "revocation_stream_generation": 8,
+        "last_issued_issuer_sequence": 2,
+        "last_acked_issuer_sequence": 1,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "ncgLg604IpnAlnbQwtYNpdOI9mQCDam3mHo7PNK7m+JXJXg9+e5JzBxlhD16tzIsqhvVWsXJm9OKjporZu0PDQ=="
+      },
+      "reset_clear_instruction": null
+    },
+    "events": [
+      {
+        "event_type": "reset_clear_required",
+        "event": {
+          "artifact_version": 1,
+          "event_id": "83000000-0000-4000-8000-000000000003",
+          "reset_id": "93000000-0000-4000-8000-000000000003",
+          "reset_generation": 3,
+          "cumulative_reset_count": 3,
+          "source_security_epoch": 3,
+          "security_epoch": 4,
+          "subject_account_id": "11111111-1111-4111-8111-111111111111",
+          "subject_project_id": "22222222-2222-4222-8222-222222222222",
+          "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+          "host": {
+            "registration_id": "77777777-7777-4777-8777-777777777777",
+            "device_id": "88888888-8888-4888-8888-888888888888",
+            "installation_id": "99999999-9999-4999-8999-999999999999",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+            "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+            "endpoint_epoch": 5
+          },
+          "issuer_sequence": 1,
+          "source_revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+          "source_revocation_stream_generation": 7,
+          "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+          "revocation_stream_generation": 8,
+          "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+          "admission_count": 128,
+          "admission_set_digest": "5MZmKvI3pDpvRQlfkt/Pi8JBF+iZ8yVl+xvFC5Q2WfE=",
+          "previous_reset_clear_event_id": "82000000-0000-4000-8000-000000000002",
+          "previous_instruction_material_digest": "uPNOA4E94Xk2jkIKtcBl/8ndQ/k6+BG2NHWKtFRqMl0=",
+          "previous_chain_digest": "PBtKwOcbxzOO7b43q8tJfk5Gb9TmqxyYbgIJu5vOMvY=",
+          "reset_at_unix_ms": 1786579720000,
+          "instruction_material_digest": "nokyFmkWXg8f96cootoMKOHa2R7gqt1t8q3fF77zLbY=",
+          "chain_digest": "IS0NULQtQ4D0uQ8EiHt3WMKfPhmWMDTJ6SjVSoQqOSo=",
+          "issuer_key_id": "maple-test-issuer-2026-08-13",
+          "issuer_signature": "uc6/a1kMJvQ+NpOGluSh7gtLWLSZ5FgGGRuSveIQWZUCXl6NmSFFApN3tC6SyM+jRDSDYG2hy1Ph8/abGywRAg=="
+        }
+      },
+      {
+        "event_type": "pair_revocation",
+        "event": {
+          "artifact_version": 1,
+          "event_id": "33333333-0000-4333-8333-333333333333",
+          "subject_account_id": "11111111-1111-4111-8111-111111111111",
+          "subject_project_id": "22222222-2222-4222-8222-222222222222",
+          "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+          "issuer_sequence": 2,
+          "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+          "revocation_stream_generation": 8,
+          "pairing_request_id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          "pair_id": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          "direction": "controller_to_host",
+          "execution_target_id": "77777777-7777-4777-8777-777777777777",
+          "controller": {
+            "registration_id": "44444444-4444-4444-8444-444444444444",
+            "device_id": "55555555-5555-4555-8555-555555555555",
+            "installation_id": "66666666-6666-4666-8666-666666666666",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+            "endpoint_id": "d04ab232742bb4ab3a1368bd4615e4e6d0224ab71a016baf8520a332c9778737",
+            "endpoint_epoch": 7
+          },
+          "host": {
+            "registration_id": "77777777-7777-4777-8777-777777777777",
+            "device_id": "88888888-8888-4888-8888-888888888888",
+            "installation_id": "99999999-9999-4999-8999-999999999999",
+            "identity_algorithm": "ed25519",
+            "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+            "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+            "endpoint_epoch": 4
+          },
+          "pairing_incarnation": 3,
+          "pair_authorization_digest": "CQ/HPMinOZUsvf9kh5qmq8uOHtfoM45yj7HB/5704iQ=",
+          "revoked_by_registration_id": "44444444-4444-4444-8444-444444444444",
+          "revoked_by_role": "controller",
+          "reason_code": "user_removed_access",
+          "revoked_at_unix_ms": 1786579722000,
+          "issuer_key_id": "maple-test-issuer-2026-08-13",
+          "issuer_signature": "v5dC7EZBFM1Ksh+R9/m+apIutyzMVeZqHcofCbstK7+xZrZPc3NKfvIrTYbZpfT0GXUe88v3PH/D2olPKvh6Bw=="
+        }
+      }
+    ],
+    "next_after_issuer_sequence": 2,
+    "has_more": false
+  },
+  "register_device_request_epoch_1": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "operation_id": "35353535-3535-4535-8535-353535353535",
+    "device_id": "88888888-8888-4888-8888-888888888888",
+    "installation_id": "99999999-9999-4999-8999-999999999999",
+    "expected_revision": 5,
+    "known_security_epoch": 1,
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "identity_algorithm": "ed25519",
+    "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+    "iroh_endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+    "endpoint_epoch": 5,
+    "iroh_endpoint_addr": {
+      "relay_urls": [
+        "https://relay.example.test/"
+      ],
+      "direct_addresses": [
+        "127.0.0.1:7777"
+      ]
+    },
+    "platform": "macos",
+    "display_name": "Maple fixture host",
+    "capabilities": [
+      "pairing",
+      "agent.remote"
+    ],
+    "signature": "21unvuFe1Slam9u1UyPmBjxjgmJ3kmwjd7MpeFdNWm6v25Lahgg/DFb2nt1sBkZX2SJf9WNLtzNBH5YJfi2ZCQ=="
+  },
+  "register_device_request_epoch_1_transcript_hex": "730000001f6f732e6d61706c652d6465766963652d726567697374726174696f6e2e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222224c0000000800000000000000017500000010353535353535453585353535353535357500000010888888888888488888888888888888887500000010999999999999499989999999999999993f00000001016c000000080000000000000005730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000056a000000020001730000001b68747470733a2f2f72656c61792e6578616d706c652e746573742f6a000000020001730000000e3132372e302e302e313a3737373773000000056d61636f7373000000124d61706c65206669787475726520686f73746a000000020002730000000c6167656e742e72656d6f7465730000000770616972696e67",
+  "register_device_request_epoch_1_digest": "GAwWqYAgoy1Oo3X7CE/qPlPaJGMdDpTKWSceGXVlFvw=",
+  "register_device_request_epoch_4": {
+    "protocol_version": 1,
+    "transcript_version": 1,
+    "operation_id": "36363636-3636-4636-8636-363636363636",
+    "device_id": "88888888-8888-4888-8888-888888888888",
+    "installation_id": "99999999-9999-4999-8999-999999999999",
+    "expected_revision": 5,
+    "known_security_epoch": 4,
+    "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+    "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+    "identity_algorithm": "ed25519",
+    "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+    "iroh_endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+    "endpoint_epoch": 5,
+    "iroh_endpoint_addr": {
+      "relay_urls": [
+        "https://relay.example.test/"
+      ],
+      "direct_addresses": [
+        "127.0.0.1:7777"
+      ]
+    },
+    "platform": "macos",
+    "display_name": "Maple fixture host",
+    "capabilities": [
+      "pairing",
+      "agent.remote"
+    ],
+    "signature": "aIqbvLn5kqip44Wcwc+MC9gjG2+/hVppZOU/4xR5PGBhMirWOF/C8s0XooxJDe3N4wzbfWp08B9elpZUGXJ4CQ=="
+  },
+  "register_device_request_epoch_4_transcript_hex": "730000001f6f732e6d61706c652d6465766963652d726567697374726174696f6e2e76316a0000000200016a0000000200017500000010111111111111411181111111111111117500000010222222222222422282222222222222224c0000000800000000000000047500000010363636363636463686363636363636367500000010888888888888488888888888888888887500000010999999999999499989999999999999993f00000001016c000000080000000000000005730000000765643235353139620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc620000002031debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc4c0000000800000000000000056a000000020001730000001b68747470733a2f2f72656c61792e6578616d706c652e746573742f6a000000020001730000000e3132372e302e302e313a3737373773000000056d61636f7373000000124d61706c65206669787475726520686f73746a000000020002730000000c6167656e742e72656d6f7465730000000770616972696e67",
+  "register_device_request_epoch_4_digest": "/Li7XsV6/wQFqnd3EPEl6NtAWw+HT2/5j0td0nOamzs=",
+  "register_device_response_ready": {
+    "protocol_version": 1,
+    "operation_id": "35353535-3535-4535-8535-353535353535",
+    "registration_id": "77777777-7777-4777-8777-777777777777",
+    "device_id": "88888888-8888-4888-8888-888888888888",
+    "revision": 6,
+    "accepted_at": "2026-08-13T00:00:00Z",
+    "security_epoch": 1,
+    "revocation_sync": {
+      "security_epoch": 1,
+      "status": "ready",
+      "stream_checkpoint": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "security_epoch": 1,
+        "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+        "revocation_stream_generation": 5,
+        "last_issued_issuer_sequence": 12,
+        "last_acked_issuer_sequence": 12,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "Ppo1GUSOUL1BktTU4FwgQ/fHcLNLejAD+ySpFvctppOFhe0XEWZ4FnSIaAVUKpQpKe8vt6AVXhpulgCXJjPDCg=="
+      },
+      "reset_clear_instruction": null
+    }
+  },
+  "register_device_response_revocations_pending": {
+    "protocol_version": 1,
+    "operation_id": "35353535-3535-4535-8535-353535353535",
+    "registration_id": "77777777-7777-4777-8777-777777777777",
+    "device_id": "88888888-8888-4888-8888-888888888888",
+    "revision": 6,
+    "accepted_at": "2026-08-13T00:00:00Z",
+    "security_epoch": 1,
+    "revocation_sync": {
+      "security_epoch": 1,
+      "status": "revocations_pending",
+      "stream_checkpoint": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "security_epoch": 1,
+        "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+        "revocation_stream_generation": 5,
+        "last_issued_issuer_sequence": 13,
+        "last_acked_issuer_sequence": 12,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "Ocit/eWHm/PtJeyK2w9H/CyMOnjt1c4SZTyEjkaN06FDvYwxLkVq/eFJoKDqAvFBr1dpWhQAeKdZcx+yRNmIDA=="
+      },
+      "reset_clear_instruction": null
+    }
+  },
+  "register_device_response_reset_clear_required": {
+    "protocol_version": 1,
+    "operation_id": "36363636-3636-4636-8636-363636363636",
+    "registration_id": "77777777-7777-4777-8777-777777777777",
+    "device_id": "88888888-8888-4888-8888-888888888888",
+    "revision": 6,
+    "accepted_at": "2026-08-13T00:08:40.500Z",
+    "security_epoch": 4,
+    "revocation_sync": {
+      "security_epoch": 4,
+      "status": "reset_clear_required",
+      "stream_checkpoint": {
+        "artifact_version": 1,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "security_epoch": 4,
+        "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+        "revocation_stream_generation": 8,
+        "last_issued_issuer_sequence": 1,
+        "last_acked_issuer_sequence": 0,
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "1NMOM0FubdOh3m4ihP4pmgRRNhFcflMV+jFd5yV5lpo/EX8quTDwg4HGveQV+0KOcWH1jXJDZr9xYV8HmdDOCg=="
+      },
+      "reset_clear_instruction": {
+        "artifact_version": 1,
+        "event_id": "83000000-0000-4000-8000-000000000003",
+        "reset_id": "93000000-0000-4000-8000-000000000003",
+        "reset_generation": 3,
+        "cumulative_reset_count": 3,
+        "source_security_epoch": 3,
+        "security_epoch": 4,
+        "subject_account_id": "11111111-1111-4111-8111-111111111111",
+        "subject_project_id": "22222222-2222-4222-8222-222222222222",
+        "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+        "host": {
+          "registration_id": "77777777-7777-4777-8777-777777777777",
+          "device_id": "88888888-8888-4888-8888-888888888888",
+          "installation_id": "99999999-9999-4999-8999-999999999999",
+          "identity_algorithm": "ed25519",
+          "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+          "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+          "endpoint_epoch": 5
+        },
+        "issuer_sequence": 1,
+        "source_revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+        "source_revocation_stream_generation": 7,
+        "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+        "revocation_stream_generation": 8,
+        "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+        "admission_count": 128,
+        "admission_set_digest": "5MZmKvI3pDpvRQlfkt/Pi8JBF+iZ8yVl+xvFC5Q2WfE=",
+        "previous_reset_clear_event_id": "82000000-0000-4000-8000-000000000002",
+        "previous_instruction_material_digest": "uPNOA4E94Xk2jkIKtcBl/8ndQ/k6+BG2NHWKtFRqMl0=",
+        "previous_chain_digest": "PBtKwOcbxzOO7b43q8tJfk5Gb9TmqxyYbgIJu5vOMvY=",
+        "reset_at_unix_ms": 1786579720000,
+        "instruction_material_digest": "nokyFmkWXg8f96cootoMKOHa2R7gqt1t8q3fF77zLbY=",
+        "chain_digest": "IS0NULQtQ4D0uQ8EiHt3WMKfPhmWMDTJ6SjVSoQqOSo=",
+        "issuer_key_id": "maple-test-issuer-2026-08-13",
+        "issuer_signature": "uc6/a1kMJvQ+NpOGluSh7gtLWLSZ5FgGGRuSveIQWZUCXl6NmSFFApN3tC6SyM+jRDSDYG2hy1Ph8/abGywRAg=="
+      }
+    }
+  },
+  "list_devices_response_security_epoch": {
+    "protocol_version": 1,
+    "security_epoch": 4,
+    "devices": [],
+    "next_cursor": null,
+    "has_more": false
+  },
+  "post_ack_registration_outcome_vectors": {
+    "exact_pre_reset_replay": {
+      "request": {
+        "protocol_version": 1,
+        "transcript_version": 1,
+        "operation_id": "35353535-3535-4535-8535-353535353535",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "installation_id": "99999999-9999-4999-8999-999999999999",
+        "expected_revision": 5,
+        "known_security_epoch": 1,
+        "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+        "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+        "iroh_endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+        "endpoint_epoch": 5,
+        "iroh_endpoint_addr": {
+          "relay_urls": [
+            "https://relay.example.test/"
+          ],
+          "direct_addresses": [
+            "127.0.0.1:7777"
+          ]
+        },
+        "platform": "macos",
+        "display_name": "Maple fixture host",
+        "capabilities": [
+          "pairing",
+          "agent.remote"
+        ],
+        "signature": "21unvuFe1Slam9u1UyPmBjxjgmJ3kmwjd7MpeFdNWm6v25Lahgg/DFb2nt1sBkZX2SJf9WNLtzNBH5YJfi2ZCQ=="
+      },
+      "response": {
+        "protocol_version": 1,
+        "operation_id": "35353535-3535-4535-8535-353535353535",
+        "registration_id": "77777777-7777-4777-8777-777777777777",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "revision": 6,
+        "accepted_at": "2026-08-13T00:00:00Z",
+        "security_epoch": 1,
+        "revocation_sync": {
+          "security_epoch": 1,
+          "status": "ready",
+          "stream_checkpoint": {
+            "artifact_version": 1,
+            "subject_account_id": "11111111-1111-4111-8111-111111111111",
+            "subject_project_id": "22222222-2222-4222-8222-222222222222",
+            "host": {
+              "registration_id": "77777777-7777-4777-8777-777777777777",
+              "device_id": "88888888-8888-4888-8888-888888888888",
+              "installation_id": "99999999-9999-4999-8999-999999999999",
+              "identity_algorithm": "ed25519",
+              "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+              "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+              "endpoint_epoch": 5
+            },
+            "security_epoch": 1,
+            "revocation_stream_id": "15151515-1515-4515-8515-151515151515",
+            "revocation_stream_generation": 5,
+            "last_issued_issuer_sequence": 12,
+            "last_acked_issuer_sequence": 12,
+            "issuer_key_id": "maple-test-issuer-2026-08-13",
+            "issuer_signature": "Ppo1GUSOUL1BktTU4FwgQ/fHcLNLejAD+ySpFvctppOFhe0XEWZ4FnSIaAVUKpQpKe8vt6AVXhpulgCXJjPDCg=="
+          },
+          "reset_clear_instruction": null
+        }
+      },
+      "expected": "frozen_ready_replay"
+    },
+    "changed_pre_reset_same_operation": {
+      "request": {
+        "protocol_version": 1,
+        "transcript_version": 1,
+        "operation_id": "35353535-3535-4535-8535-353535353535",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "installation_id": "99999999-9999-4999-8999-999999999999",
+        "expected_revision": 5,
+        "known_security_epoch": 1,
+        "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+        "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+        "iroh_endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+        "endpoint_epoch": 5,
+        "iroh_endpoint_addr": {
+          "relay_urls": [
+            "https://relay.example.test/"
+          ],
+          "direct_addresses": [
+            "127.0.0.1:7777"
+          ]
+        },
+        "platform": "macos",
+        "display_name": "changed pre-reset request",
+        "capabilities": [
+          "pairing",
+          "agent.remote"
+        ],
+        "signature": "B7EJbUvoZVElvMFgAk8VJIexFV3jiUQfL/aydQ7QtrfCC9NpNCkvgvVWTxvgvus9O3b3YVRTpNUyt9+l6/bXAQ=="
+      },
+      "response": null,
+      "expected": "conflict"
+    },
+    "exact_pending_reset_replay": {
+      "request": {
+        "protocol_version": 1,
+        "transcript_version": 1,
+        "operation_id": "36363636-3636-4636-8636-363636363636",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "installation_id": "99999999-9999-4999-8999-999999999999",
+        "expected_revision": 5,
+        "known_security_epoch": 4,
+        "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+        "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+        "iroh_endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+        "endpoint_epoch": 5,
+        "iroh_endpoint_addr": {
+          "relay_urls": [
+            "https://relay.example.test/"
+          ],
+          "direct_addresses": [
+            "127.0.0.1:7777"
+          ]
+        },
+        "platform": "macos",
+        "display_name": "Maple fixture host",
+        "capabilities": [
+          "pairing",
+          "agent.remote"
+        ],
+        "signature": "aIqbvLn5kqip44Wcwc+MC9gjG2+/hVppZOU/4xR5PGBhMirWOF/C8s0XooxJDe3N4wzbfWp08B9elpZUGXJ4CQ=="
+      },
+      "response": {
+        "protocol_version": 1,
+        "operation_id": "36363636-3636-4636-8636-363636363636",
+        "registration_id": "77777777-7777-4777-8777-777777777777",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "revision": 6,
+        "accepted_at": "2026-08-13T00:08:40.500Z",
+        "security_epoch": 4,
+        "revocation_sync": {
+          "security_epoch": 4,
+          "status": "reset_clear_required",
+          "stream_checkpoint": {
+            "artifact_version": 1,
+            "subject_account_id": "11111111-1111-4111-8111-111111111111",
+            "subject_project_id": "22222222-2222-4222-8222-222222222222",
+            "host": {
+              "registration_id": "77777777-7777-4777-8777-777777777777",
+              "device_id": "88888888-8888-4888-8888-888888888888",
+              "installation_id": "99999999-9999-4999-8999-999999999999",
+              "identity_algorithm": "ed25519",
+              "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+              "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+              "endpoint_epoch": 5
+            },
+            "security_epoch": 4,
+            "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+            "revocation_stream_generation": 8,
+            "last_issued_issuer_sequence": 1,
+            "last_acked_issuer_sequence": 0,
+            "issuer_key_id": "maple-test-issuer-2026-08-13",
+            "issuer_signature": "1NMOM0FubdOh3m4ihP4pmgRRNhFcflMV+jFd5yV5lpo/EX8quTDwg4HGveQV+0KOcWH1jXJDZr9xYV8HmdDOCg=="
+          },
+          "reset_clear_instruction": {
+            "artifact_version": 1,
+            "event_id": "83000000-0000-4000-8000-000000000003",
+            "reset_id": "93000000-0000-4000-8000-000000000003",
+            "reset_generation": 3,
+            "cumulative_reset_count": 3,
+            "source_security_epoch": 3,
+            "security_epoch": 4,
+            "subject_account_id": "11111111-1111-4111-8111-111111111111",
+            "subject_project_id": "22222222-2222-4222-8222-222222222222",
+            "recipient_host_registration_id": "77777777-7777-4777-8777-777777777777",
+            "host": {
+              "registration_id": "77777777-7777-4777-8777-777777777777",
+              "device_id": "88888888-8888-4888-8888-888888888888",
+              "installation_id": "99999999-9999-4999-8999-999999999999",
+              "identity_algorithm": "ed25519",
+              "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+              "endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+              "endpoint_epoch": 5
+            },
+            "issuer_sequence": 1,
+            "source_revocation_stream_id": "27272727-2727-4727-8727-272727272727",
+            "source_revocation_stream_generation": 7,
+            "revocation_stream_id": "28282828-2828-4828-8828-282828282828",
+            "revocation_stream_generation": 8,
+            "clear_scope": "all_pair_authorizations_for_account_project_host_installation",
+            "admission_count": 128,
+            "admission_set_digest": "5MZmKvI3pDpvRQlfkt/Pi8JBF+iZ8yVl+xvFC5Q2WfE=",
+            "previous_reset_clear_event_id": "82000000-0000-4000-8000-000000000002",
+            "previous_instruction_material_digest": "uPNOA4E94Xk2jkIKtcBl/8ndQ/k6+BG2NHWKtFRqMl0=",
+            "previous_chain_digest": "PBtKwOcbxzOO7b43q8tJfk5Gb9TmqxyYbgIJu5vOMvY=",
+            "reset_at_unix_ms": 1786579720000,
+            "instruction_material_digest": "nokyFmkWXg8f96cootoMKOHa2R7gqt1t8q3fF77zLbY=",
+            "chain_digest": "IS0NULQtQ4D0uQ8EiHt3WMKfPhmWMDTJ6SjVSoQqOSo=",
+            "issuer_key_id": "maple-test-issuer-2026-08-13",
+            "issuer_signature": "uc6/a1kMJvQ+NpOGluSh7gtLWLSZ5FgGGRuSveIQWZUCXl6NmSFFApN3tC6SyM+jRDSDYG2hy1Ph8/abGywRAg=="
+          }
+        }
+      },
+      "expected": "reset_clear_required_replay"
+    },
+    "changed_pending_reset_same_operation": {
+      "request": {
+        "protocol_version": 1,
+        "transcript_version": 1,
+        "operation_id": "36363636-3636-4636-8636-363636363636",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "installation_id": "99999999-9999-4999-8999-999999999999",
+        "expected_revision": 5,
+        "known_security_epoch": 4,
+        "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+        "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+        "iroh_endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+        "endpoint_epoch": 5,
+        "iroh_endpoint_addr": {
+          "relay_urls": [
+            "https://relay.example.test/"
+          ],
+          "direct_addresses": [
+            "127.0.0.1:7777"
+          ]
+        },
+        "platform": "macos",
+        "display_name": "changed pending-reset request",
+        "capabilities": [
+          "pairing",
+          "agent.remote"
+        ],
+        "signature": "7J5F/RR9qdFJawBbeyww51HuZchpz5RDgZDvhee2XZosualSE9qsqu/fgoPKw9/ARztj+jlI2zqdM9P70/RVCg=="
+      },
+      "response": null,
+      "expected": "conflict"
+    },
+    "fresh_operation_retired_installation": {
+      "request": {
+        "protocol_version": 1,
+        "transcript_version": 1,
+        "operation_id": "37373737-3737-4737-8737-373737373737",
+        "device_id": "88888888-8888-4888-8888-888888888888",
+        "installation_id": "99999999-9999-4999-8999-999999999999",
+        "expected_revision": 5,
+        "known_security_epoch": 4,
+        "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+        "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "Md6+VdN8cidosTcTHKpghwgLLgtguUvXhdFFdc+kmLw=",
+        "iroh_endpoint_id": "31debe55d37c722768b137131caa6087080b2e0b60b94bd785d14575cfa498bc",
+        "endpoint_epoch": 5,
+        "iroh_endpoint_addr": {
+          "relay_urls": [
+            "https://relay.example.test/"
+          ],
+          "direct_addresses": [
+            "127.0.0.1:7777"
+          ]
+        },
+        "platform": "macos",
+        "display_name": "Maple fixture host",
+        "capabilities": [
+          "pairing",
+          "agent.remote"
+        ],
+        "signature": "f09xl+DXkLMglMgyhelyMM4y6wYbJMKEWrp6y+GU/7CGWcqK3Wm45WqdwNRPa/olVA+hEpfAAj0gcGfJqJazAQ=="
+      },
+      "response": null,
+      "expected": "MapleInstallationRetired"
+    },
+    "fresh_installation_current_epoch": {
+      "request": {
+        "protocol_version": 1,
+        "transcript_version": 1,
+        "operation_id": "56565656-5656-4656-8656-565656565656",
+        "device_id": "58585858-5858-4858-8858-585858585858",
+        "installation_id": "59595959-5959-4959-8959-595959595959",
+        "expected_revision": null,
+        "known_security_epoch": 4,
+        "asserted_account_id": "11111111-1111-4111-8111-111111111111",
+        "asserted_project_id": "22222222-2222-4222-8222-222222222222",
+        "identity_algorithm": "ed25519",
+        "identity_public_key": "+kg0FH9uaQw2k+/2EzYEZAPNiuKhTzGzxAc1hWkjlWU=",
+        "iroh_endpoint_id": "fa4834147f6e690c3693eff61336046403cd8ae2a14f31b3c407358569239565",
+        "endpoint_epoch": 1,
+        "iroh_endpoint_addr": {
+          "relay_urls": [
+            "https://relay.example.test/"
+          ],
+          "direct_addresses": [
+            "127.0.0.1:7777"
+          ]
+        },
+        "platform": "macos",
+        "display_name": "Fresh Maple fixture host",
+        "capabilities": [
+          "pairing",
+          "agent.remote"
+        ],
+        "signature": "5z+kZwKtxfZHiYfxKKzJ6UTZ1qXudNXdgHBtf7ciqXgtGNntmGNsbNow38mLELKSMFLgZ0O8mJMxjTllQOtoCA=="
+      },
+      "response": {
+        "protocol_version": 1,
+        "operation_id": "56565656-5656-4656-8656-565656565656",
+        "registration_id": "57575757-5757-4757-8757-575757575757",
+        "device_id": "58585858-5858-4858-8858-585858585858",
+        "revision": 1,
+        "accepted_at": "2026-08-13T00:08:42Z",
+        "security_epoch": 4,
+        "revocation_sync": {
+          "security_epoch": 4,
+          "status": "ready",
+          "stream_checkpoint": {
+            "artifact_version": 1,
+            "subject_account_id": "11111111-1111-4111-8111-111111111111",
+            "subject_project_id": "22222222-2222-4222-8222-222222222222",
+            "host": {
+              "registration_id": "57575757-5757-4757-8757-575757575757",
+              "device_id": "58585858-5858-4858-8858-585858585858",
+              "installation_id": "59595959-5959-4959-8959-595959595959",
+              "identity_algorithm": "ed25519",
+              "identity_public_key": "+kg0FH9uaQw2k+/2EzYEZAPNiuKhTzGzxAc1hWkjlWU=",
+              "endpoint_id": "fa4834147f6e690c3693eff61336046403cd8ae2a14f31b3c407358569239565",
+              "endpoint_epoch": 1
+            },
+            "security_epoch": 4,
+            "revocation_stream_id": "59590000-0000-4000-8000-000000000001",
+            "revocation_stream_generation": 1,
+            "last_issued_issuer_sequence": 0,
+            "last_acked_issuer_sequence": 0,
+            "issuer_key_id": "maple-test-issuer-2026-08-13",
+            "issuer_signature": "ysvnlh9v4MrsxCoDLHywF2jJ3gWoMN2gouZpf0C4/84oC2Y3syoTkADrRQ9DpdQQESpkJnfZYuiS4ZPho8SoAQ=="
+          },
+          "reset_clear_instruction": null
+        }
+      },
+      "expected": "ready"
+    },
+    "operation_replay_precedes_retirement_and_epoch_gates": true
+  },
+  "maple_security_epoch_stale_error": {
+    "status": 409,
+    "message": "Maple device security epoch is stale; refresh device state and retry.",
+    "code": "MapleSecurityEpochStale"
+  },
+  "maple_pairing_reset_clear_required_error": {
+    "status": 409,
+    "message": "Maple remote access must be cleared on the host before this operation can continue.",
+    "code": "MaplePairingResetClearRequired"
+  },
+  "maple_installation_retired_error": {
+    "status": 409,
+    "message": "This Maple installation enrollment is retired; reset Remote access on this device and enroll it again.",
+    "code": "MapleInstallationRetired"
+  },
+  "security_epoch_outcome_vectors": [
+    {
+      "name": "known_epoch_stale",
+      "known_security_epoch": 1,
+      "current_security_epoch": 4,
+      "pending_reset_clear": true,
+      "registration_operation_accepted": false,
+      "outcome": "MapleSecurityEpochStale"
+    },
+    {
+      "name": "known_epoch_ahead",
+      "known_security_epoch": 5,
+      "current_security_epoch": 4,
+      "pending_reset_clear": true,
+      "registration_operation_accepted": false,
+      "outcome": "conflict"
+    },
+    {
+      "name": "current_epoch_pending_reset_dominates",
+      "known_security_epoch": 4,
+      "current_security_epoch": 4,
+      "pending_reset_clear": true,
+      "registration_operation_accepted": true,
+      "outcome": "reset_clear_required"
+    },
+    {
+      "name": "fresh_current_epoch_after_ack",
+      "known_security_epoch": 4,
+      "current_security_epoch": 4,
+      "pending_reset_clear": false,
+      "registration_operation_accepted": true,
+      "outcome": "ready"
+    }
+  ],
+  "registration_operation_tombstone_vectors": {
+    "storage": {
+      "operation_lookup_digest": "hmac_only",
+      "raw_operation_id_stored": false,
+      "request_binding": "request_mac",
+      "frozen_response_retained": true
+    },
+    "exact_old_request": "frozen_ready_replay",
+    "changed_request_same_operation_lookup": "conflict",
+    "exact_pending_reset_request_after_ack": "reset_clear_required_replay",
+    "changed_pending_reset_request_after_ack": "conflict",
+    "fresh_operation_retired_installation": "MapleInstallationRetired",
+    "fresh_installation_current_epoch": "ready"
+  },
+  "wire_structural_assertions": {
+    "list_devices_security_epoch_source": "authenticated_encrypted_account_authority_head",
+    "list_devices_response_signed": false,
+    "reset_event_json_key_order": [
+      "event_type",
+      "event"
+    ],
+    "pending_reset_checkpoint": {
+      "last_issued_issuer_sequence": 1,
+      "last_acked_issuer_sequence": 0
+    },
+    "historical_reset_event_allowed_after_ack": true,
+    "historical_reset_event_allowed_when_later_events_exist": true,
+    "reset_admission_public_shape": [
+      "admission_count",
+      "admission_set_digest"
+    ],
+    "retained_admission_leaves_cross_wire": false,
+    "fixture_pretty_indent_spaces": 2,
+    "fixture_trailing_newline_count": 1,
+    "sdk_fixture_copy": "explicit_reviewed_byte_copy"
+  }
+}


### PR DESCRIPTION
## Summary

- add the Rust SDK contract for account-scoped Maple device enrollment and bounded device discovery
- add explicitly directed controller-to-host pairing request, approval, host commit, status, revocation, acknowledgement, reset-clear, and installation-retirement flows
- verify TEE-issued tickets, authorizations, receipts, checkpoints, and revocations against an explicit issuer key set with bounded time, cursor, transcript, and replay behavior
- add redacted authority wrappers and frozen backend/SDK protocol vectors so cross-repository signatures and digests remain byte-for-byte compatible
- classify exact Maple control-plane errors and restrict ambiguous pairing mutation replay to an explicit stale attested-session response

## Historical receipt hardening

- treat exact-operation APPROVE and CONFIRM responses as historical-capable receipts rather than current lifecycle state
- expose APPROVE authorization only through a durable non-admitting stage type
- require a fresh verified host STATUS in `awaiting_host_commit` with an exact staged authorization and revocation-namespace match before constructing CONFIRM
- require a second fresh verified host STATUS in `active` with the same exact match before producing admission-ready material
- fail closed on revoked, expired, wrong-role, wrong-namespace, or staged-material mismatches; ambiguous network results remain non-admitting and retryable
- add compile-time boundaries so historical receipts cannot mint confirm-ready or admission-ready capabilities

## Validation

Passed locally in the pinned Nix environment:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-features`
- `cargo test --all-features --lib` — 120 passed
- `cargo test --doc --all-features` — four authority-boundary compile-fail tests passed, one unrelated example ignored
- `cargo doc --no-deps --all-features`
- `git diff --check`

The full `cargo test --all-features` command requires the repository integration credentials and an OpenSecret service. GitHub CI supplies that environment; the initial draft revision passed its credentialed suite, and the updated revision is running it again.

## Integration status

This is an SDK foundation draft. It does not publish a crate or package and does not deploy anything. The matching OpenSecret backend and Maple application integration are being reviewed in separate draft PRs.