### PR TITLE
Allow React model discovery before sign-in

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1189,22 +1189,36 @@ export type ModelCatalogResponse = {
 
 /**
  * Fetches available AI models from the OpenAI-compatible API
- * @param apiKey - Optional API key to use instead of JWT token
+ * @param apiKey - Optional API key to use instead of a stored JWT token
  * @returns A promise resolving to an array of Model objects
  * @throws {Error} If:
- * - The user is not authenticated (no JWT token or API key)
  * - The request fails
  * - The response format is invalid
+ *
+ * When no API key or stored JWT is available, the request uses the attested
+ * encrypted session without an Authorization header. Credential-bearing calls
+ * stay on the authenticated path and are never retried anonymously if
+ * validation fails.
  */
 export async function fetchModels(apiKey?: string): Promise<Model[]> {
   try {
-    const response = await openAiAuthenticatedApiCall<void, ModelsListResponse>(
-      `${apiUrl}/v1/models`,
-      "GET",
-      undefined,
-      "Failed to fetch models",
-      apiKey
-    );
+    const hasIdentityCredential =
+      apiKey !== undefined || window.localStorage.getItem("access_token") !== null;
+    const response = hasIdentityCredential
+      ? await openAiAuthenticatedApiCall<void, ModelsListResponse>(
+          `${apiUrl}/v1/models`,
+          "GET",
+          undefined,
+          "Failed to fetch models",
+          apiKey
+        )
+      : await encryptedApiCall<void, ModelsListResponse>(
+          `${apiUrl}/v1/models`,
+          "GET",
+          undefined,
+          undefined,
+          "Failed to fetch models"
+        );
 
     // Validate response structure
     if (!response || typeof response !== "object") {

--- a/src/lib/main.tsx
+++ b/src/lib/main.tsx
@@ -489,14 +489,13 @@ export type OpenSecretContextType = {
    * Fetches available AI models from the OpenAI-compatible API
    * @returns A promise resolving to an array of Model objects
    * @throws {Error} If:
-   * - The user is not authenticated
    * - The request fails
    *
    *
    * - Returns a list of available AI models from the configured OpenAI-compatible API
    * - Response is encrypted and automatically decrypted
-   * - Guest users will receive a 401 Unauthorized error
-   * - Requires an active authentication session
+   * - Before sign-in, uses an attested encrypted session without identity authorization
+   * - When a JWT or API key is present, preserves authenticated model filtering
    */
   fetchModels: () => Promise<Model[]>;
 

--- a/src/lib/test/models.test.ts
+++ b/src/lib/test/models.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { encryptMessage } from "../encryption";
+import { cacheAttestationSessionForTesting } from "../getAttestation";
+import type { PcrConfig } from "../pcr";
+import { fetchModelCatalog, fetchModels, getApiPcrConfig, getApiUrl, setApiUrl } from "../api";
+
+const apiUrl = "https://models.example.com";
+const sessionId = "models-session-id";
+const sessionKey = new Uint8Array(32).fill(23);
+const verifiedPcr0 =
+  "eeddbb58f57c38894d6d5af5e575fbe791c5bf3bbcfb5df8da8cfcf0c2e1da1913108e6a762112444740b88c163d7f4b";
+const pcrConfig: PcrConfig = { pcr0Values: [verifiedPcr0], remoteAttestation: false };
+const modelsResponse = {
+  object: "list" as const,
+  data: [
+    {
+      id: "test-model",
+      object: "model" as const,
+      created: 0,
+      owned_by: "opensecret"
+    }
+  ]
+};
+
+const originalFetch = globalThis.fetch;
+const originalApiUrl = getApiUrl();
+const originalApiPcrConfig = getApiPcrConfig();
+
+beforeEach(async () => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  setApiUrl(apiUrl, pcrConfig);
+  await cacheAttestationSessionForTesting(
+    apiUrl,
+    pcrConfig,
+    { sessionKey, sessionId },
+    verifiedPcr0
+  );
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  setApiUrl(originalApiUrl, originalApiPcrConfig);
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+function encryptedModelsResponse() {
+  return new Response(
+    JSON.stringify({
+      encrypted: encryptMessage(sessionKey, JSON.stringify(modelsResponse))
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+test("fetchModels uses the encrypted session before sign-in", async () => {
+  globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    expect(input.toString()).toBe(`${apiUrl}/v1/models`);
+    expect(init?.method).toBe("GET");
+    expect(init?.body).toBeUndefined();
+
+    const headers = new Headers(init?.headers);
+    expect(headers.get("x-session-id")).toBe(sessionId);
+    expect(headers.has("Authorization")).toBe(false);
+
+    return encryptedModelsResponse();
+  }) as typeof fetch;
+
+  await expect(fetchModels()).resolves.toEqual(modelsResponse.data);
+});
+
+test("fetchModels preserves stored JWT authentication", async () => {
+  window.localStorage.setItem("access_token", "models-access-token");
+
+  globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer models-access-token");
+    expect(headers.get("x-session-id")).toBe(sessionId);
+    return encryptedModelsResponse();
+  }) as typeof fetch;
+
+  await expect(fetchModels()).resolves.toEqual(modelsResponse.data);
+});
+
+test("fetchModels never downgrades a rejected stored JWT to anonymous access", async () => {
+  let requestCount = 0;
+  window.localStorage.setItem("access_token", "rejected-access-token");
+
+  globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+    requestCount += 1;
+    const headers = new Headers(init?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer rejected-access-token");
+
+    return Response.json({ message: "Invalid JWT" }, { status: 401 });
+  }) as typeof fetch;
+
+  await expect(fetchModels()).rejects.toThrow("No refresh token available");
+  expect(requestCount).toBe(1);
+});
+
+test("fetchModels never downgrades a rejected API key to anonymous access", async () => {
+  let requestCount = 0;
+  window.localStorage.setItem("access_token", "stored-jwt");
+
+  globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+    requestCount += 1;
+    const headers = new Headers(init?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer invalid-api-key");
+
+    return Response.json({ message: "Invalid API key" }, { status: 401 });
+  }) as typeof fetch;
+
+  await expect(fetchModels("invalid-api-key")).rejects.toThrow("Invalid API key");
+  expect(requestCount).toBe(1);
+});
+
+test("fetchModels does not interpret an explicitly empty API key as anonymous", async () => {
+  const fetchMock = mock(async () => encryptedModelsResponse());
+  globalThis.fetch = fetchMock as typeof fetch;
+
+  await expect(fetchModels("")).rejects.toThrow("No access token available");
+  expect(fetchMock).toHaveBeenCalledTimes(0);
+});
+
+test("fetchModelCatalog remains authentication-required", async () => {
+  const fetchMock = mock(async () => encryptedModelsResponse());
+  globalThis.fetch = fetchMock as typeof fetch;
+
+  await expect(fetchModelCatalog()).rejects.toThrow("No access token available");
+  expect(fetchMock).toHaveBeenCalledTimes(0);
+});


### PR DESCRIPTION
## Summary

- route `fetchModels` through the existing attested encrypted-session transport when neither an API key nor stored JWT is present
- preserve the existing JWT refresh and explicit API-key paths, with no anonymous fallback after credential rejection
- update the React context documentation and add deterministic encrypted transport coverage for anonymous, JWT, API-key, and catalog behavior

## Validation

- `bun test src/lib/test/models.test.ts src/lib/test/encryptedApi.test.ts src/lib/test/recovery.test.ts src/lib/test/customFetch.test.ts src/lib/test/getAttestationSecurity.test.ts src/lib/test/testPcrEnvironment.test.ts --timeout 30000` — 75 passed on the stacked tree
- `bun run format:check`
- `bun run build`
- `bun audit --audit-level=high` — no vulnerabilities
- `bun pm pack --dry-run`
- `git diff --check`
- GitHub CI — all 8 checks passed on the stacked revision, including the credential-backed Library Tests suite

## Integration status

- Draft follow-up to OpenSecretCloud/opensecret#282
- stacked on #108; merge #108 first, then retarget/rebase this PR onto `master`
- this PR contributes one commit and only the three model-discovery files above #108
- no version bump or package publication in this PR