### PR TITLE
Retry recoverable encrypted requests once

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -183,6 +183,52 @@ enum AuthHeaderMode {
     ApiKeyOrJwt,
 }
 
+const ERROR_CONTRACT_HEADER: &str = "x-opensecret-error-contract";
+const ERROR_CODE_HEADER: &str = "x-opensecret-error-code";
+const ERROR_CONTRACT_VERSION: &[u8] = b"1";
+const SESSION_NOT_FOUND_ERROR_CODE: &[u8] = b"session_not_found";
+const ACCESS_TOKEN_EXPIRED_ERROR_CODE: &[u8] = b"access_token_expired";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoveryAction {
+    Reattest,
+    RefreshAccessToken,
+}
+
+fn classify_response_recovery(
+    status: reqwest::StatusCode,
+    headers: &HeaderMap,
+) -> Option<RecoveryAction> {
+    let mut contract_values = headers.get_all(ERROR_CONTRACT_HEADER).iter();
+    let Some(contract_version) = contract_values.next() else {
+        return match status {
+            reqwest::StatusCode::BAD_REQUEST => Some(RecoveryAction::Reattest),
+            reqwest::StatusCode::UNAUTHORIZED => Some(RecoveryAction::RefreshAccessToken),
+            _ => None,
+        };
+    };
+
+    if contract_values.next().is_some() || contract_version.as_bytes() != ERROR_CONTRACT_VERSION {
+        return None;
+    }
+
+    let mut code_values = headers.get_all(ERROR_CODE_HEADER).iter();
+    let code = code_values.next()?;
+    if code_values.next().is_some() {
+        return None;
+    }
+
+    match (status, code.as_bytes()) {
+        (reqwest::StatusCode::BAD_REQUEST, SESSION_NOT_FOUND_ERROR_CODE) => {
+            Some(RecoveryAction::Reattest)
+        }
+        (reqwest::StatusCode::UNAUTHORIZED, ACCESS_TOKEN_EXPIRED_ERROR_CODE) => {
+            Some(RecoveryAction::RefreshAccessToken)
+        }
+        _ => None,
+    }
+}
+
 fn is_allowed_inference_endpoint(method: &http::Method, path: &str) -> bool {
     matches!(
         (method.as_str(), path),
@@ -733,17 +779,17 @@ impl OpenSecretClient {
         response.text().await.map_err(Into::into)
     }
 
-    async fn encrypted_api_call<T: Serialize + Clone, U: DeserializeOwned>(
+    async fn encrypted_api_call<T: Serialize, U: DeserializeOwned>(
         &self,
         endpoint: &str,
         method: &str,
         data: Option<T>,
     ) -> Result<U> {
-        self.retry_encrypted_json_call_without_refresh(endpoint, method, data, AuthHeaderMode::None)
+        self.retry_encrypted_json_call_without_refresh(endpoint, method, data)
             .await
     }
 
-    async fn authenticated_api_call<T: Serialize + Clone, U: DeserializeOwned>(
+    async fn authenticated_api_call<T: Serialize, U: DeserializeOwned>(
         &self,
         endpoint: &str,
         method: &str,
@@ -753,35 +799,49 @@ impl OpenSecretClient {
             .await
     }
 
-    async fn retry_encrypted_json_call_without_refresh<
-        T: Serialize + Clone,
-        U: DeserializeOwned,
-    >(
+    async fn retry_encrypted_json_call_without_refresh<T: Serialize, U: DeserializeOwned>(
         &self,
         endpoint: &str,
         method: &str,
         data: Option<T>,
-        auth_mode: AuthHeaderMode,
     ) -> Result<U> {
-        let mut retried_attestation = false;
+        let plaintext = data
+            .map(|data| serde_json::to_vec(&data).map(Bytes::from))
+            .transpose()?;
+        let mut replayed = false;
+        let mut recovered_missing_session = false;
 
-        loop {
-            let auth = self.resolve_auth(auth_mode)?;
+        let (response, session_key) = loop {
+            let auth = self.resolve_auth(AuthHeaderMode::None)?;
             match self
-                .encrypted_json_call_inner(endpoint, method, data.clone(), &auth)
+                .send_encrypted_request(endpoint, method, plaintext.as_deref(), &auth, false)
                 .await
             {
-                Ok(result) => return Ok(result),
-                Err(error) if !retried_attestation && Self::is_attestation_retryable(&error) => {
+                Ok((response, session_key)) if response.status().is_success() => {
+                    break (response, session_key)
+                }
+                Ok((response, _session_key)) => {
+                    let recovery =
+                        classify_response_recovery(response.status(), response.headers());
+                    if replayed || recovery != Some(RecoveryAction::Reattest) {
+                        return Err(Self::api_error_from_response(response).await);
+                    }
+
                     self.perform_attestation_handshake().await?;
-                    retried_attestation = true;
+                    replayed = true;
+                }
+                Err(Error::Session(_)) if !recovered_missing_session => {
+                    self.perform_attestation_handshake().await?;
+                    recovered_missing_session = true;
                 }
                 Err(error) => return Err(error),
             }
-        }
+        };
+
+        Self::decrypt_json_response(response, session_key).await
     }
 
-    async fn retry_encrypted_json_call<T: Serialize + Clone, U: DeserializeOwned>(
+    async fn retry_encrypted_json_call<T: Serialize, U: DeserializeOwned>(
         &self,
         endpoint: &str,
         method: &str,
@@ -789,53 +849,74 @@ impl OpenSecretClient {
         auth_mode: AuthHeaderMode,
         allow_refresh: bool,
     ) -> Result<U> {
-        let mut retried_attestation = false;
-        let mut retried_refresh = false;
+        let plaintext = data
+            .map(|data| serde_json::to_vec(&data).map(Bytes::from))
+            .transpose()?;
+        let mut replayed = false;
+        let mut recovered_missing_session = false;
 
-        loop {
+        let (response, session_key) = loop {
             let auth = self.resolve_auth(auth_mode)?;
             match self
-                .encrypted_json_call_inner(endpoint, method, data.clone(), &auth)
+                .send_encrypted_request(endpoint, method, plaintext.as_deref(), &auth, false)
                 .await
             {
-                Ok(result) => return Ok(result),
-                Err(error) if !retried_attestation && Self::is_attestation_retryable(&error) => {
-                    self.perform_attestation_handshake().await?;
-                    retried_attestation = true;
+                Ok((response, session_key)) if response.status().is_success() => {
+                    break (response, session_key)
                 }
-                Err(error @ Error::Api { status: 401, .. })
-                    if allow_refresh && !retried_refresh =>
-                {
-                    if self
-                        .recover_auth_after_unauthorized(auth_mode, &auth)
-                        .await?
-                    {
-                        retried_refresh = true;
-                    } else {
-                        return Err(error);
+                Ok((response, _session_key)) => {
+                    let recovery =
+                        classify_response_recovery(response.status(), response.headers());
+                    if replayed {
+                        return Err(Self::api_error_from_response(response).await);
                     }
+
+                    match recovery {
+                        Some(RecoveryAction::Reattest) => {
+                            self.perform_attestation_handshake().await?;
+                            replayed = true;
+                        }
+                        Some(RecoveryAction::RefreshAccessToken) if allow_refresh => {
+                            if self
+                                .recover_auth_after_unauthorized(auth_mode, &auth)
+                                .await?
+                            {
+                                replayed = true;
+                            } else {
+                                return Err(Self::api_error_from_response(response).await);
+                            }
+                        }
+                        _ => return Err(Self::api_error_from_response(response).await),
+                    }
+                }
+                Err(Error::Session(_)) if !recovered_missing_session => {
+                    self.perform_attestation_handshake().await?;
+                    recovered_missing_session = true;
                 }
                 Err(error) => return Err(error),
             }
-        }
+        };
+
+        Self::decrypt_json_response(response, session_key).await
     }
 
-    async fn encrypted_json_call_inner<T: Serialize, U: DeserializeOwned>(
-        &self,
-        endpoint: &str,
-        method: &str,
-        data: Option<T>,
-        auth: &ResolvedAuth,
+    async fn decrypt_json_response<U: DeserializeOwned>(
+        response: reqwest::Response,
+        session_key: [u8; 32],
     ) -> Result<U> {
-        let (response, session_key) = self
-            .send_encrypted_request(endpoint, method, data, auth, false)
-            .await?;
         let encrypted_response: EncryptedResponse<U> = response.json().await?;
         let decrypted =
             crypto::decrypt_data(&session_key, &BASE64.decode(&encrypted_response.encrypted)?)?;
-        let result: U = serde_json::from_slice(&decrypted)?;
+        Ok(serde_json::from_slice(&decrypted)?)
+    }
 
-        Ok(result)
+    async fn api_error_from_response(response: reqwest::Response) -> Error {
+        let status = response.status().as_u16();
+        let message = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        Error::Api { status, message }
     }
 
     /// Sends a lossless encrypted request to an OpenSecret inference endpoint.
@@ -882,8 +963,8 @@ impl OpenSecretClient {
             .as_str()
             .to_string();
         let headers = sanitize_inference_request_headers(&parts.headers);
-        let mut retried_attestation = false;
-        let mut retried_refresh = false;
+        let mut replayed = false;
+        let mut recovered_missing_session = false;
 
         loop {
             let auth = self.resolve_auth(AuthHeaderMode::ApiKeyOrJwt)?;
@@ -898,36 +979,41 @@ impl OpenSecretClient {
                 .await;
 
             match result {
-                // OpenSecret currently uses the same 400 for stale sessions and
-                // pre-provider validation. Preserve the legacy one-retry behavior
-                // until the backend exposes an explicit re-attestation signal.
-                Ok((response, _session_key))
-                    if response.status() == reqwest::StatusCode::BAD_REQUEST
-                        && !retried_attestation =>
-                {
-                    self.perform_attestation_handshake().await?;
-                    retried_attestation = true;
-                }
-                Ok((response, session_key))
-                    if response.status() == reqwest::StatusCode::UNAUTHORIZED
-                        && !retried_refresh =>
-                {
-                    if matches!(
-                        self.recover_auth_after_unauthorized(AuthHeaderMode::ApiKeyOrJwt, &auth,)
-                            .await,
-                        Ok(true)
-                    ) {
-                        retried_refresh = true;
-                    } else {
-                        return self.finish_inference_response(response, session_key).await;
-                    }
-                }
-                Ok((response, session_key)) => {
+                Ok((response, session_key)) if response.status().is_success() => {
                     return self.finish_inference_response(response, session_key).await
                 }
-                Err(error) if !retried_attestation && Self::is_attestation_retryable(&error) => {
+                Ok((response, session_key)) => {
+                    let recovery =
+                        classify_response_recovery(response.status(), response.headers());
+                    if replayed {
+                        return self.finish_inference_response(response, session_key).await;
+                    }
+
+                    match recovery {
+                        Some(RecoveryAction::Reattest) => {
+                            self.perform_attestation_handshake().await?;
+                            replayed = true;
+                        }
+                        Some(RecoveryAction::RefreshAccessToken) => {
+                            if matches!(
+                                self.recover_auth_after_unauthorized(
+                                    AuthHeaderMode::ApiKeyOrJwt,
+                                    &auth,
+                                )
+                                .await,
+                                Ok(true)
+                            ) {
+                                replayed = true;
+                            } else {
+                                return self.finish_inference_response(response, session_key).await;
+                            }
+                        }
+                        None => return self.finish_inference_response(response, session_key).await,
+                    }
+                }
+                Err(Error::Session(_)) if !recovered_missing_session => {
                     self.perform_attestation_handshake().await?;
-                    retried_attestation = true;
+                    recovered_missing_session = true;
                 }
                 Err(error) => return Err(error),
             }
@@ -1055,7 +1141,7 @@ impl OpenSecretClient {
         Ok(serde_json::from_slice(&body)?)
     }
 
-    async fn retry_encrypted_stream_call<T: Serialize + Clone>(
+    async fn retry_encrypted_stream_call<T: Serialize>(
         &self,
         endpoint: &str,
         method: &str,
@@ -1063,42 +1149,60 @@ impl OpenSecretClient {
         auth_mode: AuthHeaderMode,
         allow_refresh: bool,
     ) -> Result<(reqwest::Response, [u8; 32])> {
-        let mut retried_attestation = false;
-        let mut retried_refresh = false;
+        let plaintext = data
+            .map(|data| serde_json::to_vec(&data).map(Bytes::from))
+            .transpose()?;
+        let mut replayed = false;
+        let mut recovered_missing_session = false;
 
         loop {
             let auth = self.resolve_auth(auth_mode)?;
             match self
-                .send_encrypted_request(endpoint, method, data.clone(), &auth, true)
+                .send_encrypted_request(endpoint, method, plaintext.as_deref(), &auth, true)
                 .await
             {
-                Ok(response) => return Ok(response),
-                Err(error) if !retried_attestation && Self::is_attestation_retryable(&error) => {
-                    self.perform_attestation_handshake().await?;
-                    retried_attestation = true;
+                Ok((response, session_key)) if response.status().is_success() => {
+                    return Ok((response, session_key))
                 }
-                Err(error @ Error::Api { status: 401, .. })
-                    if allow_refresh && !retried_refresh =>
-                {
-                    if self
-                        .recover_auth_after_unauthorized(auth_mode, &auth)
-                        .await?
-                    {
-                        retried_refresh = true;
-                    } else {
-                        return Err(error);
+                Ok((response, _session_key)) => {
+                    let recovery =
+                        classify_response_recovery(response.status(), response.headers());
+                    if replayed {
+                        return Err(Self::api_error_from_response(response).await);
                     }
+
+                    match recovery {
+                        Some(RecoveryAction::Reattest) => {
+                            self.perform_attestation_handshake().await?;
+                            replayed = true;
+                        }
+                        Some(RecoveryAction::RefreshAccessToken) if allow_refresh => {
+                            if self
+                                .recover_auth_after_unauthorized(auth_mode, &auth)
+                                .await?
+                            {
+                                replayed = true;
+                            } else {
+                                return Err(Self::api_error_from_response(response).await);
+                            }
+                        }
+                        _ => return Err(Self::api_error_from_response(response).await),
+                    }
+                }
+                Err(Error::Session(_)) if !recovered_missing_session => {
+                    self.perform_attestation_handshake().await?;
+                    recovered_missing_session = true;
                 }
                 Err(error) => return Err(error),
             }
         }
     }
 
-    async fn send_encrypted_request<T: Serialize>(
+    async fn send_encrypted_request(
         &self,
         endpoint: &str,
         method: &str,
-        data: Option<T>,
+        plaintext: Option<&[u8]>,
         auth: &ResolvedAuth,
         accept_sse: bool,
     ) -> Result<(reqwest::Response, [u8; 32])> {
@@ -1110,9 +1214,8 @@ impl OpenSecretClient {
 
         let url = format!("{}{}", self.base_url, endpoint);
 
-        let encrypted_body = if let Some(data) = data {
-            let json = serde_json::to_string(&data)?;
-            let encrypted = crypto::encrypt_data(&session.session_key, json.as_bytes())?;
+        let encrypted_body = if let Some(plaintext) = plaintext {
+            let encrypted = crypto::encrypt_data(&session.session_key, plaintext)?;
             Some(EncryptedRequest {
                 encrypted: BASE64.encode(&encrypted),
             })
@@ -1140,18 +1243,6 @@ impl OpenSecretClient {
         } else {
             request_builder.send().await?
         };
-
-        if !response.status().is_success() {
-            let status = response.status().as_u16();
-            let error_msg = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            return Err(Error::Api {
-                status,
-                message: error_msg,
-            });
-        }
 
         Ok((response, session.session_key))
     }
@@ -1219,16 +1310,6 @@ impl OpenSecretClient {
                 }
             }
         }
-    }
-
-    fn is_attestation_retryable(error: &Error) -> bool {
-        matches!(
-            error,
-            Error::Session(_)
-                | Error::Api { status: 400, .. }
-                | Error::Encryption(_)
-                | Error::Decryption(_)
-        )
     }
 
     // Auth Methods
@@ -2556,6 +2637,106 @@ mod tests {
     const DEVELOPMENT_PCR0: &str =
         "62c0407056217a4c10764ed9045694c29fa93255d3cc04c2f989cdd9a1f8050c8b169714c71f1118ebce2fcc9951d1a9";
 
+    #[test]
+    fn response_recovery_classifier_is_versioned_and_fail_closed() {
+        fn headers(contract: Option<&str>, code: Option<&str>) -> HeaderMap {
+            let mut headers = HeaderMap::new();
+            if let Some(contract) = contract {
+                headers.insert(
+                    ERROR_CONTRACT_HEADER,
+                    HeaderValue::from_str(contract).unwrap(),
+                );
+            }
+            if let Some(code) = code {
+                headers.insert(ERROR_CODE_HEADER, HeaderValue::from_str(code).unwrap());
+            }
+            headers
+        }
+
+        for (status, expected) in [
+            (
+                reqwest::StatusCode::BAD_REQUEST,
+                Some(RecoveryAction::Reattest),
+            ),
+            (
+                reqwest::StatusCode::UNAUTHORIZED,
+                Some(RecoveryAction::RefreshAccessToken),
+            ),
+            (reqwest::StatusCode::UNPROCESSABLE_ENTITY, None),
+        ] {
+            assert_eq!(
+                classify_response_recovery(status, &HeaderMap::new()),
+                expected
+            );
+        }
+
+        assert_eq!(
+            classify_response_recovery(
+                reqwest::StatusCode::BAD_REQUEST,
+                &headers(Some("1"), Some("session_not_found")),
+            ),
+            Some(RecoveryAction::Reattest)
+        );
+        assert_eq!(
+            classify_response_recovery(
+                reqwest::StatusCode::UNAUTHORIZED,
+                &headers(Some("1"), Some("access_token_expired")),
+            ),
+            Some(RecoveryAction::RefreshAccessToken)
+        );
+
+        for (status, contract, code) in [
+            (reqwest::StatusCode::BAD_REQUEST, Some("1"), None),
+            (reqwest::StatusCode::BAD_REQUEST, Some("1"), Some("unknown")),
+            (
+                reqwest::StatusCode::BAD_REQUEST,
+                Some("1"),
+                Some("access_token_expired"),
+            ),
+            (
+                reqwest::StatusCode::UNAUTHORIZED,
+                Some("1"),
+                Some("session_not_found"),
+            ),
+            (
+                reqwest::StatusCode::BAD_REQUEST,
+                Some("2"),
+                Some("session_not_found"),
+            ),
+        ] {
+            assert_eq!(
+                classify_response_recovery(status, &headers(contract, code)),
+                None
+            );
+        }
+
+        // A code without the version marker is still a legacy response.
+        assert_eq!(
+            classify_response_recovery(
+                reqwest::StatusCode::BAD_REQUEST,
+                &headers(None, Some("unknown")),
+            ),
+            Some(RecoveryAction::Reattest)
+        );
+
+        let mut duplicate_contract = headers(Some("1"), Some("session_not_found"));
+        duplicate_contract.append(ERROR_CONTRACT_HEADER, HeaderValue::from_static("1"));
+        assert_eq!(
+            classify_response_recovery(reqwest::StatusCode::BAD_REQUEST, &duplicate_contract),
+            None
+        );
+
+        let mut duplicate_code = headers(Some("1"), Some("session_not_found"));
+        duplicate_code.append(
+            ERROR_CODE_HEADER,
+            HeaderValue::from_static("session_not_found"),
+        );
+        assert_eq!(
+            classify_response_recovery(reqwest::StatusCode::BAD_REQUEST, &duplicate_code),
+            None
+        );
+    }
+
     fn synthetic_verified_attestation(pcr0: &str) -> AttestationDocument {
         AttestationDocument {
             module_id: "test-module".to_string(),
@@ -2770,6 +2951,20 @@ mod tests {
     fn encrypted_response_bytes(session_key: &[u8; 32], payload: &[u8]) -> serde_json::Value {
         let encrypted = crypto::encrypt_data(session_key, payload).unwrap();
         json!({ "encrypted": BASE64.encode(encrypted) })
+    }
+
+    fn v1_error_response(
+        status: u16,
+        code: Option<&'static str>,
+        body: &'static str,
+    ) -> ResponseTemplate {
+        let response = ResponseTemplate::new(status)
+            .insert_header(ERROR_CONTRACT_HEADER, "1")
+            .set_body_string(body);
+        match code {
+            Some(code) => response.insert_header(ERROR_CODE_HEADER, code),
+            None => response,
+        }
     }
 
     fn encrypted_sse_data<T: Serialize>(session_key: &[u8; 32], payload: &T) -> String {
@@ -3482,6 +3677,381 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn v1_generic_400_and_401_do_not_recover() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let session_id = Uuid::new_v4();
+        let session_key = [54u8; 32];
+        client
+            .session_manager
+            .set_session(session_id, session_key)
+            .unwrap();
+        client
+            .session_manager
+            .set_tokens(
+                "access_token".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        for (endpoint, status) in [("/generic-400", 400), ("/generic-401", 401)] {
+            Mock::given(method("GET"))
+                .and(path(endpoint))
+                .and(header("authorization", "Bearer access_token"))
+                .and(header("x-session-id", session_id.to_string()))
+                .respond_with(v1_error_response(status, None, "generic error"))
+                .expect(1)
+                .mount(&mock_server)
+                .await;
+        }
+        Mock::given(method("GET"))
+            .and(PathPrefixMatcher("/attestation/"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/refresh"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        for (endpoint, expected_status) in [("/generic-400", 400), ("/generic-401", 401)] {
+            let error = client
+                .authenticated_api_call::<(), serde_json::Value>(endpoint, "GET", None)
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                error,
+                Error::Api { status, .. } if status == expected_status
+            ));
+        }
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn corrupt_successful_response_is_not_replayed() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let session_id = Uuid::new_v4();
+        let session_key = [55u8; 32];
+        client
+            .session_manager
+            .set_session(session_id, session_key)
+            .unwrap();
+        client
+            .session_manager
+            .set_tokens(
+                "access_token".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        Mock::given(method("GET"))
+            .and(path("/corrupt-success"))
+            .and(header("authorization", "Bearer access_token"))
+            .and(header("x-session-id", session_id.to_string()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "encrypted": "AAAA"
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(PathPrefixMatcher("/attestation/"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let error = client
+            .authenticated_api_call::<(), serde_json::Value>("/corrupt-success", "GET", None)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::Decryption(_)));
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn target_replay_budget_is_shared_across_recovery_reasons() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let stale_session_id = Uuid::new_v4();
+        let stale_session_key = [56u8; 32];
+        let server_secret_key = [57u8; 32];
+        let server_public_key =
+            x25519_dalek::PublicKey::from(&x25519_dalek::StaticSecret::from(server_secret_key));
+        let fresh_session_id = Uuid::new_v4();
+        let fresh_session_key = [58u8; 32];
+        client
+            .session_manager
+            .set_session(stale_session_id, stale_session_key)
+            .unwrap();
+        client
+            .session_manager
+            .set_tokens(
+                "expired_access".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        Mock::given(method("GET"))
+            .and(path("/mixed-recovery"))
+            .and(header("authorization", "Bearer expired_access"))
+            .and(header("x-session-id", stale_session_id.to_string()))
+            .respond_with(v1_error_response(
+                400,
+                Some("session_not_found"),
+                "stale session",
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(PathPrefixMatcher("/attestation/"))
+            .respond_with(AttestationResponder {
+                server_public_key: server_public_key.to_bytes(),
+            })
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/key_exchange"))
+            .respond_with(KeyExchangeResponder {
+                server_secret_key,
+                session_key: fresh_session_key,
+                session_id: fresh_session_id.to_string(),
+            })
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/mixed-recovery"))
+            .and(header("authorization", "Bearer expired_access"))
+            .and(header("x-session-id", fresh_session_id.to_string()))
+            .respond_with(v1_error_response(
+                401,
+                Some("access_token_expired"),
+                "expired access token",
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/refresh"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        let error = client
+            .authenticated_api_call::<(), serde_json::Value>("/mixed-recovery", "GET", None)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::Api { status: 401, .. }));
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn expired_target_with_stale_refresh_session_repairs_each_layer_once() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let stale_session_id = Uuid::new_v4();
+        let stale_session_key = [59u8; 32];
+        let server_secret_key = [60u8; 32];
+        let server_public_key =
+            x25519_dalek::PublicKey::from(&x25519_dalek::StaticSecret::from(server_secret_key));
+        let fresh_session_id = Uuid::new_v4();
+        let fresh_session_key = [61u8; 32];
+        client
+            .session_manager
+            .set_session(stale_session_id, stale_session_key)
+            .unwrap();
+        client
+            .session_manager
+            .set_tokens(
+                "expired_access".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        Mock::given(method("GET"))
+            .and(path("/long-idle"))
+            .and(header("authorization", "Bearer expired_access"))
+            .and(header("x-session-id", stale_session_id.to_string()))
+            .respond_with(v1_error_response(
+                401,
+                Some("access_token_expired"),
+                "expired access token",
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/refresh"))
+            .and(MissingHeaderMatcher("authorization"))
+            .and(header("x-session-id", stale_session_id.to_string()))
+            .and(EncryptedJsonBodyMatcher {
+                session_key: stale_session_key,
+                expected: json!({ "refresh_token": "refresh_token" }),
+            })
+            .respond_with(v1_error_response(
+                400,
+                Some("session_not_found"),
+                "stale session",
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(PathPrefixMatcher("/attestation/"))
+            .respond_with(AttestationResponder {
+                server_public_key: server_public_key.to_bytes(),
+            })
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/key_exchange"))
+            .and(MissingHeaderMatcher("authorization"))
+            .respond_with(KeyExchangeResponder {
+                server_secret_key,
+                session_key: fresh_session_key,
+                session_id: fresh_session_id.to_string(),
+            })
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/refresh"))
+            .and(MissingHeaderMatcher("authorization"))
+            .and(header("x-session-id", fresh_session_id.to_string()))
+            .and(EncryptedJsonBodyMatcher {
+                session_key: fresh_session_key,
+                expected: json!({ "refresh_token": "refresh_token" }),
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_json(encrypted_response(
+                &fresh_session_key,
+                &json!({
+                    "access_token": "fresh_access",
+                    "refresh_token": "fresh_refresh"
+                }),
+            )))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/long-idle"))
+            .and(header("authorization", "Bearer fresh_access"))
+            .and(header("x-session-id", fresh_session_id.to_string()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(encrypted_response(
+                &fresh_session_key,
+                &json!({ "ok": true }),
+            )))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = client
+            .authenticated_api_call::<(), serde_json::Value>("/long-idle", "GET", None)
+            .await
+            .unwrap();
+        assert_eq!(response, json!({ "ok": true }));
+        assert_eq!(
+            client.get_access_token().unwrap().as_deref(),
+            Some("fresh_access")
+        );
+        assert_eq!(client.get_session_id().unwrap(), Some(fresh_session_id));
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn establishing_a_missing_local_session_does_not_consume_target_replay() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let server_secret_key = [62u8; 32];
+        let server_public_key =
+            x25519_dalek::PublicKey::from(&x25519_dalek::StaticSecret::from(server_secret_key));
+        let session_id = Uuid::new_v4();
+        let session_key = [63u8; 32];
+        client
+            .session_manager
+            .set_tokens(
+                "expired_access".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        Mock::given(method("GET"))
+            .and(PathPrefixMatcher("/attestation/"))
+            .respond_with(AttestationResponder {
+                server_public_key: server_public_key.to_bytes(),
+            })
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/key_exchange"))
+            .respond_with(KeyExchangeResponder {
+                server_secret_key,
+                session_key,
+                session_id: session_id.to_string(),
+            })
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/missing-local-session"))
+            .and(header("authorization", "Bearer expired_access"))
+            .and(header("x-session-id", session_id.to_string()))
+            .respond_with(v1_error_response(
+                401,
+                Some("access_token_expired"),
+                "expired access token",
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/refresh"))
+            .and(MissingHeaderMatcher("authorization"))
+            .and(header("x-session-id", session_id.to_string()))
+            .and(EncryptedJsonBodyMatcher {
+                session_key,
+                expected: json!({ "refresh_token": "refresh_token" }),
+            })
+            .respond_with(ResponseTemplate::new(200).set_body_json(encrypted_response(
+                &session_key,
+                &json!({
+                    "access_token": "fresh_access",
+                    "refresh_token": "fresh_refresh"
+                }),
+            )))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/missing-local-session"))
+            .and(header("authorization", "Bearer fresh_access"))
+            .and(header("x-session-id", session_id.to_string()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(encrypted_response(&session_key, &json!({ "ok": true }))),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let response = client
+            .authenticated_api_call::<(), serde_json::Value>("/missing-local-session", "GET", None)
+            .await
+            .unwrap();
+        assert_eq!(response, json!({ "ok": true }));
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
     async fn test_corrupted_access_token_recovers_via_refresh_on_next_call() {
         let mock_server = MockServer::start().await;
         let client = OpenSecretClient::new(mock_server.uri()).unwrap();
@@ -3920,6 +4490,8 @@ mod tests {
             })
             .respond_with(
                 ResponseTemplate::new(401)
+                    .insert_header(ERROR_CONTRACT_HEADER, "1")
+                    .insert_header(ERROR_CODE_HEADER, "access_token_expired")
                     .set_delay(Duration::from_millis(50))
                     .set_body_string("jwt expired"),
             )
@@ -4138,13 +4710,38 @@ mod tests {
         let mock_server = MockServer::start().await;
         let client =
             OpenSecretClient::new_with_api_key(mock_server.uri(), "api_key".to_string()).unwrap();
+        let stale_session_id = Uuid::new_v4();
+        let stale_session_key = [33u8; 32];
         let server_secret_key = [34u8; 32];
         let server_public_key =
             x25519_dalek::PublicKey::from(&x25519_dalek::StaticSecret::from(server_secret_key));
-        let session_key = [35u8; 32];
-        let session_id = Uuid::new_v4();
+        let fresh_session_key = [35u8; 32];
+        let fresh_session_id = Uuid::new_v4();
         let request_body = Bytes::from_static(br#"{ "model":"x", "input":"exact bytes" }"#);
         let response_body = Bytes::from_static(br#"{ "ok": true }"#);
+        client
+            .session_manager
+            .set_session(stale_session_id, stale_session_key)
+            .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/embeddings"))
+            .and(query_param("trace", "one two"))
+            .and(header("authorization", "Bearer api_key"))
+            .and(header("x-session-id", stale_session_id.to_string()))
+            .and(header("x-provider-beta", "raw-replay"))
+            .and(EncryptedBytesBodyMatcher {
+                session_key: stale_session_key,
+                expected: request_body.clone(),
+            })
+            .respond_with(v1_error_response(
+                400,
+                Some("session_not_found"),
+                "stale session",
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
 
         Mock::given(method("GET"))
             .and(PathPrefixMatcher("/attestation/"))
@@ -4159,23 +4756,25 @@ mod tests {
             .and(MissingHeaderMatcher("authorization"))
             .respond_with(KeyExchangeResponder {
                 server_secret_key,
-                session_key,
-                session_id: session_id.to_string(),
+                session_key: fresh_session_key,
+                session_id: fresh_session_id.to_string(),
             })
             .expect(1)
             .mount(&mock_server)
             .await;
         Mock::given(method("POST"))
             .and(path("/v1/embeddings"))
+            .and(query_param("trace", "one two"))
             .and(header("authorization", "Bearer api_key"))
-            .and(header("x-session-id", session_id.to_string()))
+            .and(header("x-session-id", fresh_session_id.to_string()))
+            .and(header("x-provider-beta", "raw-replay"))
             .and(EncryptedBytesBodyMatcher {
-                session_key,
+                session_key: fresh_session_key,
                 expected: request_body.clone(),
             })
             .respond_with(
                 ResponseTemplate::new(200)
-                    .set_body_json(encrypted_response_bytes(&session_key, &response_body)),
+                    .set_body_json(encrypted_response_bytes(&fresh_session_key, &response_body)),
             )
             .expect(1)
             .mount(&mock_server)
@@ -4183,7 +4782,8 @@ mod tests {
 
         let request = HttpRequest::builder()
             .method(http::Method::POST)
-            .uri("/v1/embeddings")
+            .uri("/v1/embeddings?trace=one%20two")
+            .header("x-provider-beta", "raw-replay")
             .body(request_body)
             .unwrap();
         let response = client.send_inference_request(request).await.unwrap();
@@ -5226,6 +5826,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn agent_stream_v1_generic_401_does_not_refresh() {
+        let mock_server = MockServer::start().await;
+        let client = OpenSecretClient::new(mock_server.uri()).unwrap();
+        let session_id = Uuid::new_v4();
+        let session_key = [49u8; 32];
+        client
+            .session_manager
+            .set_session(session_id, session_key)
+            .unwrap();
+        client
+            .session_manager
+            .set_tokens(
+                "access_token".to_string(),
+                Some("refresh_token".to_string()),
+            )
+            .unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/agent/chat"))
+            .and(header("authorization", "Bearer access_token"))
+            .and(header("x-session-id", session_id.to_string()))
+            .and(EncryptedJsonBodyMatcher {
+                session_key,
+                expected: json!({ "input": "generic unauthorized" }),
+            })
+            .respond_with(v1_error_response(401, None, "generic unauthorized"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/refresh"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&mock_server)
+            .await;
+
+        match client.agent_chat("generic unauthorized").await {
+            Err(Error::Api { status: 401, .. }) => {}
+            Err(other) => panic!("expected generic 401 API error, got {other:?}"),
+            Ok(_) => panic!("generic 401 unexpectedly started an Agent stream"),
+        }
+        mock_server.verify().await;
+    }
+
+    #[tokio::test]
     async fn concurrent_agent_stream_401s_share_one_refresh_and_decrypt() {
         let mock_server = MockServer::start().await;
         let client = OpenSecretClient::new(mock_server.uri()).unwrap();
@@ -5254,6 +5899,8 @@ mod tests {
             })
             .respond_with(
                 ResponseTemplate::new(401)
+                    .insert_header(ERROR_CONTRACT_HEADER, "1")
+                    .insert_header(ERROR_CODE_HEADER, "access_token_expired")
                     .set_delay(Duration::from_millis(50))
                     .set_body_string("jwt expired"),
             )

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -876,15 +876,13 @@ impl OpenSecretClient {
                             self.perform_attestation_handshake().await?;
                             replayed = true;
                         }
-                        Some(RecoveryAction::RefreshAccessToken) if allow_refresh => {
-                            if self
-                                .recover_auth_after_unauthorized(auth_mode, &auth)
-                                .await?
-                            {
-                                replayed = true;
-                            } else {
-                                return Err(Self::api_error_from_response(response).await);
-                            }
+                        Some(RecoveryAction::RefreshAccessToken)
+                            if allow_refresh
+                                && self
+                                    .recover_auth_after_unauthorized(auth_mode, &auth)
+                                    .await? =>
+                        {
+                            replayed = true;
                         }
                         _ => return Err(Self::api_error_from_response(response).await),
                     }
@@ -1176,15 +1174,13 @@ impl OpenSecretClient {
                             self.perform_attestation_handshake().await?;
                             replayed = true;
                         }
-                        Some(RecoveryAction::RefreshAccessToken) if allow_refresh => {
-                            if self
-                                .recover_auth_after_unauthorized(auth_mode, &auth)
-                                .await?
-                            {
-                                replayed = true;
-                            } else {
-                                return Err(Self::api_error_from_response(response).await);
-                            }
+                        Some(RecoveryAction::RefreshAccessToken)
+                            if allow_refresh
+                                && self
+                                    .recover_auth_after_unauthorized(auth_mode, &auth)
+                                    .await? =>
+                        {
+                            replayed = true;
                         }
                         _ => return Err(Self::api_error_from_response(response).await),
                     }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -2,6 +2,7 @@ import { decryptMessage, encryptMessage } from "./encryption";
 import { getAttestation, type Attestation } from "./getAttestation";
 import * as api from "./api";
 import { serializePcrConfig, snapshotPcrConfig, type PcrConfig } from "./pcr";
+import { classifyRecovery } from "./recovery";
 
 export interface CustomFetchOptions {
   /** Optional API key to use instead of a JWT token. */
@@ -24,6 +25,14 @@ export interface CustomFetchDependencies {
   fetch: typeof globalThis.fetch;
   getAttestation: typeof getAttestation;
   refreshToken: typeof api.refreshToken;
+}
+
+interface RequestSnapshot {
+  url: string;
+  headers: Headers;
+  options: RequestInit;
+  plaintextBody?: string;
+  signal?: AbortSignal | null;
 }
 
 const defaultDependencies: CustomFetchDependencies = {
@@ -54,6 +63,47 @@ async function discardResponse(response: Response): Promise<void> {
   }
 }
 
+function throwIfAborted(signal?: AbortSignal | null): void {
+  signal?.throwIfAborted();
+}
+
+async function snapshotRequest(
+  input: string | URL | Request,
+  init?: RequestInit
+): Promise<RequestSnapshot> {
+  const normalized = new Request(input, init);
+  const signal =
+    init?.signal === null
+      ? null
+      : (init?.signal ?? (input instanceof Request ? input.signal : undefined));
+  const url = normalized.url;
+  const headers = new Headers(normalized.headers);
+  const options: RequestInit = {
+    ...init,
+    method: normalized.method,
+    cache: init?.cache ?? normalized.cache,
+    credentials: init?.credentials ?? normalized.credentials,
+    integrity: init?.integrity ?? normalized.integrity,
+    keepalive: init?.keepalive ?? normalized.keepalive,
+    mode: init?.mode ?? normalized.mode,
+    redirect: init?.redirect ?? normalized.redirect,
+    referrer: init?.referrer ?? normalized.referrer,
+    referrerPolicy: init?.referrerPolicy ?? normalized.referrerPolicy,
+    signal
+  };
+  delete options.body;
+  delete options.headers;
+  const plaintextBody = normalized.body === null ? undefined : await normalized.text();
+
+  return {
+    url,
+    headers,
+    options,
+    plaintextBody,
+    signal
+  };
+}
+
 export function createCustomFetch(
   options?: CustomFetchOptions
 ): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
@@ -81,34 +131,57 @@ export function createCustomFetchWithDependencies(
     failedSessionId: string,
     identity: ReturnType<typeof resolveAttestationIdentity>
   ): Promise<ActiveAttestation> => {
-    // A concurrent request or token refresh may already have replaced the
-    // failed session. Reuse it instead of starting another handshake.
-    const currentAttestation = requireActiveAttestation(
-      await dependencies.getAttestation(false, identity.apiUrl, identity.pcrConfig)
-    );
-    if (currentAttestation.sessionId !== failedSessionId) {
-      return currentAttestation;
-    }
-
-    let attestationRefresh = attestationRefreshes.get(identity.scope);
+    const renewalScope = `${identity.scope}\n${failedSessionId}`;
+    let attestationRefresh = attestationRefreshes.get(renewalScope);
     if (!attestationRefresh) {
-      attestationRefresh = dependencies
-        .getAttestation(true, identity.apiUrl, identity.pcrConfig)
-        .then(requireActiveAttestation)
-        .finally(() => {
-          attestationRefreshes.delete(identity.scope);
-        });
-      attestationRefreshes.set(identity.scope, attestationRefresh);
+      let resolveRefresh!: (attestation: ActiveAttestation) => void;
+      let rejectRefresh!: (reason?: unknown) => void;
+      attestationRefresh = new Promise<ActiveAttestation>((resolve, reject) => {
+        resolveRefresh = resolve;
+        rejectRefresh = reject;
+      });
+      attestationRefreshes.set(renewalScope, attestationRefresh);
+
+      const registeredRefresh = attestationRefresh;
+      void (async () => {
+        try {
+          // A concurrent request or token refresh may already have replaced
+          // the failed generation. This lookup belongs inside the registered
+          // leader so a late caller cannot miss the in-flight renewal after
+          // its forced refresh evicts the cache.
+          const currentAttestation = requireActiveAttestation(
+            await dependencies.getAttestation(false, identity.apiUrl, identity.pcrConfig)
+          );
+          const renewedAttestation =
+            currentAttestation.sessionId === failedSessionId
+              ? requireActiveAttestation(
+                  await dependencies.getAttestation(true, identity.apiUrl, identity.pcrConfig)
+                )
+              : currentAttestation;
+          resolveRefresh(renewedAttestation);
+        } catch (error) {
+          rejectRefresh(error);
+        } finally {
+          if (attestationRefreshes.get(renewalScope) === registeredRefresh) {
+            attestationRefreshes.delete(renewalScope);
+          }
+        }
+      })();
     }
 
     return attestationRefresh;
   };
 
   return async (requestUrl: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    // Authentication mode is part of the logical request snapshot. A caller
+    // may retain and mutate the options object while this request is in
+    // flight; recovery must not switch between API-key and JWT credentials.
+    const apiKey = options?.apiKey;
+    const usesApiKey = Boolean(apiKey);
     const getAuthHeader = () => {
       // If an API key is provided, use it instead of JWT token
-      if (options?.apiKey) {
-        return `Bearer ${options.apiKey}`;
+      if (apiKey) {
+        return `Bearer ${apiKey}`;
       }
 
       // Otherwise, use the standard JWT token
@@ -127,20 +200,22 @@ export function createCustomFetchWithDependencies(
       // unrelated account change during attestation must not send the
       // already-prepared plaintext request under a different token.
       let authHeader = getAuthHeader();
+      const request = await snapshotRequest(requestUrl, init);
+      throwIfAborted(request.signal);
 
       const makeRequest = async (attestation: ActiveAttestation) => {
-        const headers = new Headers(init?.headers);
+        const headers = new Headers(request.headers);
         headers.set("Authorization", authHeader);
         headers.set("x-session-id", attestation.sessionId);
 
-        const requestOptions: RequestInit = { ...init, headers };
+        const requestOptions: RequestInit = { ...request.options, headers };
 
         // Encrypt the original plaintext again for every attempt. Reusing an
         // old request body with a new session ID would make recovery fail.
-        if (init?.body) {
+        if (request.plaintextBody !== undefined) {
           const encryptedBody = dependencies.encryptMessage(
             attestation.sessionKey,
-            init.body as string
+            request.plaintextBody
           );
           requestOptions.body = JSON.stringify({ encrypted: encryptedBody });
           headers.set("Content-Type", "application/json");
@@ -148,7 +223,7 @@ export function createCustomFetchWithDependencies(
 
         return {
           attestation,
-          response: await dependencies.fetch(requestUrl, requestOptions)
+          response: await dependencies.fetch(request.url, requestOptions)
         };
       };
 
@@ -159,18 +234,21 @@ export function createCustomFetchWithDependencies(
           attestationIdentity.pcrConfig
         )
       );
-      let refreshedToken = false;
-      let renewedAttestation = false;
+      throwIfAborted(request.signal);
+      let replayed = false;
       let finalAttempt: Awaited<ReturnType<typeof makeRequest>>;
 
       while (true) {
         const attempt = await makeRequest(attestation);
+        const recovery = classifyRecovery(attempt.response.status, attempt.response.headers);
 
-        if (attempt.response.status === 401 && !options?.apiKey && !refreshedToken) {
-          refreshedToken = true;
+        if (recovery === "refresh_access_token" && !usesApiKey && !replayed) {
+          replayed = true;
           await discardResponse(attempt.response);
+          throwIfAborted(request.signal);
           console.warn("Unauthorized, refreshing access token");
           await dependencies.refreshToken();
+          throwIfAborted(request.signal);
           authHeader = getAuthHeader();
 
           // The encrypted refresh call may itself have replaced a stale
@@ -185,11 +263,13 @@ export function createCustomFetchWithDependencies(
           continue;
         }
 
-        if (attempt.response.status === 400 && !renewedAttestation) {
-          renewedAttestation = true;
+        if (recovery === "renew_session" && !replayed) {
+          replayed = true;
           await discardResponse(attempt.response);
+          throwIfAborted(request.signal);
           console.warn("Bad Request, renewing attestation and retrying once");
           attestation = await renewAttestation(attempt.attestation.sessionId, attestationIdentity);
+          throwIfAborted(request.signal);
           continue;
         }
 

--- a/src/lib/encryptedApi.ts
+++ b/src/lib/encryptedApi.ts
@@ -1,8 +1,10 @@
 import { encryptMessage, decryptMessage } from "./encryption";
-import { getAttestation } from "./getAttestation";
+import { getAttestation, type Attestation } from "./getAttestation";
 import { getApiPcrConfig, getApiUrl, refreshToken } from "./api";
 import { getPlatformApiUrl, getPlatformPcrConfig, platformRefreshToken } from "./platformApi";
 import { apiConfig } from "./apiConfig";
+import { serializePcrConfig, snapshotPcrConfig, type PcrConfig } from "./pcr";
+import { classifyRecovery } from "./recovery";
 
 interface EncryptedResponse {
   encrypted: string;
@@ -14,66 +16,297 @@ interface ApiResponse<T> {
   error?: string;
 }
 
+interface RequestAuthentication {
+  token?: string;
+  refreshAccessToken?: () => Promise<string>;
+}
+
+interface ActiveAttestation {
+  sessionKey: Uint8Array;
+  sessionId: string;
+}
+
+/** @internal Exported for deterministic transport tests, not from the package entry point. */
+export interface EncryptedApiDependencies {
+  decryptMessage: typeof decryptMessage;
+  encryptMessage: typeof encryptMessage;
+  fetch: typeof globalThis.fetch;
+  getAttestation: typeof getAttestation;
+  getApiPcrConfig: typeof getApiPcrConfig;
+  getApiUrl: typeof getApiUrl;
+  getPlatformApiUrl: typeof getPlatformApiUrl;
+  getPlatformPcrConfig: typeof getPlatformPcrConfig;
+  getAccessToken: () => string | null;
+  refreshAccessToken: (url: string) => Promise<void>;
+  resolveEndpoint: typeof apiConfig.resolveEndpoint;
+}
+
+const defaultDependencies: EncryptedApiDependencies = {
+  decryptMessage,
+  encryptMessage,
+  fetch: (...args) => globalThis.fetch(...args),
+  getAttestation,
+  // Keep circular api.ts/platformApi.ts imports lazy until after module setup.
+  getApiPcrConfig: () => getApiPcrConfig(),
+  getApiUrl: () => getApiUrl(),
+  getPlatformApiUrl: () => getPlatformApiUrl(),
+  getPlatformPcrConfig: () => getPlatformPcrConfig(),
+  getAccessToken: () => window.localStorage.getItem("access_token"),
+  refreshAccessToken: async (url) => {
+    console.log("Refreshing access token");
+    const refreshFn = apiConfig.getRefreshFunction(url);
+    console.log(`Using ${refreshFn}`);
+    if (refreshFn === "platformRefreshToken") {
+      await platformRefreshToken();
+    } else {
+      await refreshToken();
+    }
+  },
+  resolveEndpoint: (url) => apiConfig.resolveEndpoint(url)
+};
+
+const attestationRenewals = new WeakMap<
+  EncryptedApiDependencies["getAttestation"],
+  Map<string, Promise<ActiveAttestation>>
+>();
+
+function requireActiveAttestation(attestation: Attestation): ActiveAttestation {
+  if (!attestation.sessionKey || !attestation.sessionId) {
+    throw new Error("Failed to make encrypted API call, no attestation available.");
+  }
+  return {
+    sessionKey: attestation.sessionKey,
+    sessionId: attestation.sessionId
+  };
+}
+
+async function renewAttestation(
+  failedSessionId: string,
+  apiUrl: string,
+  pcrConfig: PcrConfig,
+  dependencies: EncryptedApiDependencies
+): Promise<ActiveAttestation> {
+  let renewals = attestationRenewals.get(dependencies.getAttestation);
+  if (!renewals) {
+    renewals = new Map();
+    attestationRenewals.set(dependencies.getAttestation, renewals);
+  }
+
+  const scope = `${apiUrl}\n${serializePcrConfig(pcrConfig)}\n${failedSessionId}`;
+  let renewal = renewals.get(scope);
+  if (!renewal) {
+    let resolveRenewal!: (attestation: ActiveAttestation) => void;
+    let rejectRenewal!: (reason?: unknown) => void;
+    renewal = new Promise<ActiveAttestation>((resolve, reject) => {
+      resolveRenewal = resolve;
+      rejectRenewal = reject;
+    });
+    renewals.set(scope, renewal);
+
+    const registeredRenewal = renewal;
+    const registeredRenewals = renewals;
+    void (async () => {
+      try {
+        // Keep the cache comparison inside the already-registered leader. A
+        // staggered stale response must join here even while the leader's
+        // forced refresh has temporarily removed the cached session.
+        const currentAttestation = requireActiveAttestation(
+          await dependencies.getAttestation(false, apiUrl, pcrConfig)
+        );
+        const renewedAttestation =
+          currentAttestation.sessionId === failedSessionId
+            ? requireActiveAttestation(await dependencies.getAttestation(true, apiUrl, pcrConfig))
+            : currentAttestation;
+        resolveRenewal(renewedAttestation);
+      } catch (error) {
+        rejectRenewal(error);
+      } finally {
+        if (registeredRenewals.get(scope) === registeredRenewal) {
+          registeredRenewals.delete(scope);
+        }
+        if (
+          registeredRenewals.size === 0 &&
+          attestationRenewals.get(dependencies.getAttestation) === registeredRenewals
+        ) {
+          attestationRenewals.delete(dependencies.getAttestation);
+        }
+      }
+    })();
+  }
+
+  return renewal;
+}
+
+async function discardResponse(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // A bounded recovery no longer needs this error response. It may already
+    // be closed in some fetch implementations.
+  }
+}
+
+async function performEncryptedApiCall<T, U>(
+  url: string,
+  method: string,
+  data: T,
+  authentication: RequestAuthentication,
+  errorMessage: string | undefined,
+  dependencies: EncryptedApiDependencies
+): Promise<ApiResponse<U>> {
+  try {
+    // Snapshot every logical request value before the first transport send.
+    // Only the token, session ID, and ciphertext may change on recovery.
+    const plaintextBody = data ? JSON.stringify(data) : undefined;
+    const endpoint = dependencies.resolveEndpoint(url);
+    const explicitApiUrl =
+      endpoint.context === "platform" ? dependencies.getPlatformApiUrl() : dependencies.getApiUrl();
+    const pcrConfig = snapshotPcrConfig(
+      endpoint.context === "platform"
+        ? dependencies.getPlatformPcrConfig()
+        : dependencies.getApiPcrConfig()
+    );
+
+    let token = authentication.token;
+    let attestation = await dependencies.getAttestation(false, explicitApiUrl, pcrConfig);
+    let replayed = false;
+
+    const requireSession = async (forceRefresh: boolean) => {
+      if (forceRefresh || !attestation.sessionKey || !attestation.sessionId) {
+        attestation = await dependencies.getAttestation(true, explicitApiUrl, pcrConfig);
+      }
+      if (!attestation.sessionKey || !attestation.sessionId) {
+        throw new Error("Failed to make encrypted API call, no attestation available.");
+      }
+      return {
+        sessionKey: attestation.sessionKey,
+        sessionId: attestation.sessionId
+      };
+    };
+
+    while (true) {
+      const session = await requireSession(false);
+      const encryptedData = plaintextBody
+        ? dependencies.encryptMessage(session.sessionKey, plaintextBody)
+        : undefined;
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "x-session-id": session.sessionId
+      };
+      if (token) headers.Authorization = `Bearer ${token}`;
+
+      const response = await dependencies.fetch(url, {
+        method,
+        headers,
+        body: encryptedData ? JSON.stringify({ encrypted: encryptedData }) : undefined
+      });
+      const recovery = classifyRecovery(response.status, response.headers);
+
+      if (!replayed && recovery === "renew_session") {
+        replayed = true;
+        await discardResponse(response);
+        console.log("Session not found, renewing attestation and retrying once");
+        attestation = await renewAttestation(
+          session.sessionId,
+          explicitApiUrl,
+          pcrConfig,
+          dependencies
+        );
+        continue;
+      }
+
+      if (!replayed && recovery === "refresh_access_token" && authentication.refreshAccessToken) {
+        replayed = true;
+        await discardResponse(response);
+        token = await authentication.refreshAccessToken();
+        // The encrypted refresh request can repair a stale session with its
+        // own replay budget, so always reload the current session afterward.
+        attestation = await dependencies.getAttestation(false, explicitApiUrl, pcrConfig);
+        continue;
+      }
+
+      const result: ApiResponse<U> = { status: response.status };
+      if (!response.ok) {
+        try {
+          const errorBody = (await response.json()) as { message?: string };
+          result.error =
+            errorBody.message || errorMessage || `HTTP error! Status: ${response.status}`;
+        } catch {
+          result.error = errorMessage || `HTTP error! Status: ${response.status}`;
+        }
+        return result;
+      }
+
+      try {
+        const encryptedResponse = (await response.json()) as EncryptedResponse;
+        const decryptedResponse = dependencies.decryptMessage(
+          session.sessionKey,
+          encryptedResponse.encrypted
+        );
+        result.data = JSON.parse(decryptedResponse) as U;
+      } catch (error) {
+        console.error("Error decrypting or parsing response:", error);
+        result.status = 500;
+        result.error = "Failed to decrypt or parse the response";
+      }
+      return result;
+    }
+  } catch (error) {
+    return {
+      status: 500,
+      error: error instanceof Error ? error.message : "Unknown error occurred"
+    };
+  }
+}
+
+function unwrapApiResponse<U>(response: ApiResponse<U>, missingDataMessage: string): U {
+  if (response.error) throw new Error(response.error);
+  if (!response.data) throw new Error(missingDataMessage);
+  return response.data;
+}
+
 export async function authenticatedApiCall<T, U>(
   url: string,
   method: string,
   data: T,
   errorMessage?: string
 ): Promise<U> {
-  const tryAuthenticatedRequest = async (forceRefresh: boolean = false): Promise<U> => {
-    try {
-      if (forceRefresh) {
-        console.log("Refreshing access token");
+  return authenticatedApiCallWithDependencies(url, method, data, errorMessage, defaultDependencies);
+}
 
-        // Use the apiConfig to determine which refresh function to use
-        const refreshFn = apiConfig.getRefreshFunction(url);
-        console.log(`Using ${refreshFn}`);
+/** @internal Exported for deterministic transport tests, not from the package entry point. */
+export async function authenticatedApiCallWithDependencies<T, U>(
+  url: string,
+  method: string,
+  data: T,
+  errorMessage: string | undefined,
+  dependencies: EncryptedApiDependencies
+): Promise<U> {
+  try {
+    const accessToken = dependencies.getAccessToken();
+    if (!accessToken) throw new Error("No access token available");
 
-        if (refreshFn === "platformRefreshToken") {
-          await platformRefreshToken();
-        } else {
-          await refreshToken();
+    const response = await performEncryptedApiCall<T, U>(
+      url,
+      method,
+      data,
+      {
+        token: accessToken,
+        refreshAccessToken: async () => {
+          await dependencies.refreshAccessToken(url);
+          const refreshedToken = dependencies.getAccessToken();
+          if (!refreshedToken) throw new Error("No access token available");
+          return refreshedToken;
         }
-      }
-
-      // Always get the latest token from localStorage
-      const accessToken = window.localStorage.getItem("access_token");
-      if (!accessToken) {
-        throw new Error("No access token available");
-      }
-
-      const response = await internalEncryptedApiCall<T, U>(
-        url,
-        method,
-        data,
-        accessToken,
-        errorMessage
-      );
-
-      // Attempt to refresh token once if we get a 401
-      if (response.status === 401 && !forceRefresh) {
-        console.log(`Received 401 for URL ${url}, attempting to refresh token`);
-        return tryAuthenticatedRequest(true);
-      }
-
-      // Throw an error if the response contains an error message
-      if (response.error) {
-        throw new Error(response.error);
-      }
-
-      // Throw an error if no data was received
-      if (!response.data) {
-        throw new Error("No data received from the server");
-      }
-
-      return response.data;
-    } catch (error) {
-      console.error(error);
-      throw error;
-    }
-  };
-
-  return tryAuthenticatedRequest();
+      },
+      errorMessage,
+      dependencies
+    );
+    return unwrapApiResponse(response, "No data received from the server");
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
 }
 
 // Special version for OpenAI endpoints that supports API keys
@@ -84,122 +317,38 @@ export async function openAiAuthenticatedApiCall<T, U>(
   errorMessage?: string,
   apiKey?: string
 ): Promise<U> {
-  // If no API key provided, use regular authenticated call
-  if (!apiKey) {
-    return authenticatedApiCall<T, U>(url, method, data, errorMessage);
-  }
-
-  // For API key auth, call internal encrypted API directly (no refresh logic)
-  const response = await internalEncryptedApiCall<T, U>(url, method, data, apiKey, errorMessage);
-
-  if (response.error) {
-    throw new Error(response.error);
-  }
-
-  if (!response.data) {
-    throw new Error(errorMessage || `Request to ${url} failed`);
-  }
-
-  return response.data;
+  return openAiAuthenticatedApiCallWithDependencies(
+    url,
+    method,
+    data,
+    errorMessage,
+    apiKey,
+    defaultDependencies
+  );
 }
 
-// This internal version can return a specific
-async function internalEncryptedApiCall<T, U>(
+/** @internal Exported for deterministic transport tests, not from the package entry point. */
+export async function openAiAuthenticatedApiCallWithDependencies<T, U>(
   url: string,
   method: string,
   data: T,
-  accessToken?: string,
-  errorMessage?: string
-): Promise<ApiResponse<U>> {
-  // Use apiConfig to determine the context and get the appropriate API URL
-  const endpoint = apiConfig.resolveEndpoint(url);
-  const explicitApiUrl = endpoint.context === "platform" ? getPlatformApiUrl() : getApiUrl();
-  const pcrConfig = endpoint.context === "platform" ? getPlatformPcrConfig() : getApiPcrConfig();
+  errorMessage: string | undefined,
+  apiKey: string | undefined,
+  dependencies: EncryptedApiDependencies
+): Promise<U> {
+  if (!apiKey) {
+    return authenticatedApiCallWithDependencies(url, method, data, errorMessage, dependencies);
+  }
 
-  let { sessionKey, sessionId } = await getAttestation(false, explicitApiUrl, pcrConfig);
-
-  const makeRequest = async (token: string | undefined, forceNewAttestation: boolean = false) => {
-    if (forceNewAttestation || !sessionKey || !sessionId) {
-      const newAttestation = await getAttestation(true, explicitApiUrl, pcrConfig);
-      sessionKey = newAttestation.sessionKey;
-      sessionId = newAttestation.sessionId;
-    }
-
-    if (!sessionKey || !sessionId) {
-      throw new Error("Failed to make encrypted API call, no attestation available.");
-    }
-
-    const jsonData = data ? JSON.stringify(data) : undefined;
-    const encryptedData = jsonData ? encryptMessage(sessionKey, jsonData) : undefined;
-
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-      "x-session-id": sessionId
-    };
-
-    // Only add Authorization header if a token is provided
-    if (token) {
-      headers["Authorization"] = `Bearer ${token}`;
-    }
-
-    const response = await fetch(url, {
-      method,
-      headers,
-      body: encryptedData ? JSON.stringify({ encrypted: encryptedData }) : undefined
-    });
-
-    const result: ApiResponse<U> = {
-      status: response.status
-    };
-
-    if (!response.ok) {
-      try {
-        const errorBody = await response.json();
-        result.error =
-          errorBody.message || errorMessage || `HTTP error! Status: ${response.status}`;
-      } catch {
-        result.error = errorMessage || `HTTP error! Status: ${response.status}`;
-      }
-    } else {
-      try {
-        const encryptedResponse: EncryptedResponse = await response.json();
-        const decryptedResponse = decryptMessage(sessionKey, encryptedResponse.encrypted);
-        result.data = JSON.parse(decryptedResponse);
-      } catch (error) {
-        console.error("Error decrypting or parsing response:", error);
-        result.status = 500;
-        result.error = "Failed to decrypt or parse the response";
-      }
-    }
-
-    return result;
-  };
-
-  const tryEncryptedRequest = async (
-    token: string | undefined,
-    forceNewAttestation: boolean = false
-  ): Promise<ApiResponse<U>> => {
-    try {
-      const response = await makeRequest(token, forceNewAttestation);
-
-      // Retry with new attestation if we get a 400 or encryption error, but only once
-      if (response.status === 400 || response.error?.includes("Encryption error")) {
-        if (!forceNewAttestation) {
-          console.log("Encryption error or Bad Request, attempting to renew attestation");
-          return tryEncryptedRequest(token, true);
-        }
-      }
-
-      return response;
-    } catch (error) {
-      return {
-        status: 500,
-        error: error instanceof Error ? error.message : "Unknown error occurred"
-      };
-    }
-  };
-
-  return tryEncryptedRequest(accessToken);
+  const response = await performEncryptedApiCall<T, U>(
+    url,
+    method,
+    data,
+    { token: apiKey },
+    errorMessage,
+    dependencies
+  );
+  return unwrapApiResponse(response, errorMessage || `Request to ${url} failed`);
 }
 
 export async function encryptedApiCall<T, U>(
@@ -209,23 +358,32 @@ export async function encryptedApiCall<T, U>(
   accessToken?: string,
   errorMessage?: string
 ): Promise<U> {
-  const response = await internalEncryptedApiCall<T, U>(
+  return encryptedApiCallWithDependencies(
     url,
     method,
     data,
     accessToken,
-    errorMessage
+    errorMessage,
+    defaultDependencies
   );
+}
 
-  // Throw an error if the response contains an error message
-  if (response.error) {
-    throw new Error(response.error);
-  }
-
-  // Throw an error if no data was received
-  if (!response.data) {
-    throw new Error("No data received from the server");
-  }
-
-  return response.data;
+/** @internal Exported for deterministic transport tests, not from the package entry point. */
+export async function encryptedApiCallWithDependencies<T, U>(
+  url: string,
+  method: string,
+  data: T,
+  accessToken: string | undefined,
+  errorMessage: string | undefined,
+  dependencies: EncryptedApiDependencies
+): Promise<U> {
+  const response = await performEncryptedApiCall<T, U>(
+    url,
+    method,
+    data,
+    { token: accessToken },
+    errorMessage,
+    dependencies
+  );
+  return unwrapApiResponse(response, "No data received from the server");
 }

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -1,0 +1,36 @@
+export const ERROR_CONTRACT_HEADER = "x-opensecret-error-contract";
+export const ERROR_CODE_HEADER = "x-opensecret-error-code";
+
+const ERROR_CONTRACT_VERSION = "1";
+const SESSION_NOT_FOUND_ERROR_CODE = "session_not_found";
+const ACCESS_TOKEN_EXPIRED_ERROR_CODE = "access_token_expired";
+
+export type RecoveryAction = "renew_session" | "refresh_access_token";
+
+/**
+ * Classify the only failures that are safe to replay before response handling.
+ *
+ * A missing contract marker means an older server, whose broad 400/401
+ * behavior remains supported. Once a server advertises a contract, malformed,
+ * missing, future, or status-mismatched codes fail closed.
+ */
+export function classifyRecovery(status: number, headers: Headers): RecoveryAction | undefined {
+  const contractVersion = headers.get(ERROR_CONTRACT_HEADER);
+
+  if (contractVersion === null) {
+    if (status === 400) return "renew_session";
+    if (status === 401) return "refresh_access_token";
+    return undefined;
+  }
+
+  if (contractVersion !== ERROR_CONTRACT_VERSION) return undefined;
+
+  const errorCode = headers.get(ERROR_CODE_HEADER);
+  if (status === 400 && errorCode === SESSION_NOT_FOUND_ERROR_CODE) {
+    return "renew_session";
+  }
+  if (status === 401 && errorCode === ACCESS_TOKEN_EXPIRED_ERROR_CODE) {
+    return "refresh_access_token";
+  }
+  return undefined;
+}

--- a/src/lib/test/customFetch.test.ts
+++ b/src/lib/test/customFetch.test.ts
@@ -3,6 +3,7 @@ import { createCustomFetchWithDependencies, type CustomFetchDependencies } from 
 import { getApiPcrConfig, getApiUrl, setApiUrl } from "../api";
 import type { Attestation } from "../getAttestation";
 import type { PcrConfig } from "../pcr";
+import { ERROR_CODE_HEADER, ERROR_CONTRACT_HEADER } from "../recovery";
 
 const staleKey = new Uint8Array(32).fill(1);
 const freshKey = new Uint8Array(32).fill(2);
@@ -36,6 +37,12 @@ function decryptForTest(sessionKey: Uint8Array, ciphertext: string): string {
     throw new Error(`Ciphertext was not encrypted for key ${sessionKey[0]}`);
   }
   return ciphertext.slice(expectedPrefix.length);
+}
+
+function contractError(status: number, body: string, code?: string): Response {
+  const headers = new Headers({ [ERROR_CONTRACT_HEADER]: "1" });
+  if (code) headers.set(ERROR_CODE_HEADER, code);
+  return new Response(body, { status, headers });
 }
 
 function dependencies(overrides: Partial<CustomFetchDependencies>): CustomFetchDependencies {
@@ -86,7 +93,11 @@ describe("createCustomFetch stale-session recovery", () => {
           requests.push(request);
 
           if (request.sessionId === staleAttestation.sessionId) {
-            return new Response('{"status":400,"message":"Bad Request"}', { status: 400 });
+            return contractError(
+              400,
+              '{"status":400,"message":"Bad Request"}',
+              "session_not_found"
+            );
           }
 
           return Response.json({ encrypted: '2:{"ok":true}' });
@@ -133,7 +144,7 @@ describe("createCustomFetch stale-session recovery", () => {
         },
         fetch: async () => {
           requests += 1;
-          return new Response("still bad", { status: 400 });
+          return contractError(400, "still bad", "session_not_found");
         }
       })
     );
@@ -148,6 +159,115 @@ describe("createCustomFetch stale-session recovery", () => {
     expect(forcedAttestations).toBe(1);
     expect(requests).toBe(2);
   });
+
+  test("keeps legacy headerless 400 session recovery", async () => {
+    let currentAttestation = staleAttestation;
+    let forcedAttestations = 0;
+    let requests = 0;
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) {
+            forcedAttestations += 1;
+            currentAttestation = freshAttestation;
+          }
+          return currentAttestation;
+        },
+        fetch: async () => {
+          requests += 1;
+          return requests === 1
+            ? new Response("legacy stale session", { status: 400 })
+            : Response.json({ encrypted: '2:{"ok":true}' });
+        }
+      })
+    );
+
+    expect(
+      await (
+        await customFetch("https://example.test/v1/responses", {
+          method: "POST",
+          body: '{"prompt":"hello"}'
+        })
+      ).json()
+    ).toEqual({ ok: true });
+    expect(requests).toBe(2);
+    expect(forcedAttestations).toBe(1);
+  });
+
+  test("keeps legacy headerless 401 JWT recovery", async () => {
+    window.localStorage.setItem("access_token", "expired-access-token");
+    let requests = 0;
+    let tokenRefreshes = 0;
+    const customFetch = createCustomFetchWithDependencies(
+      undefined,
+      dependencies({
+        refreshToken: async () => {
+          tokenRefreshes += 1;
+          window.localStorage.setItem("access_token", "fresh-access-token");
+          return {
+            access_token: "fresh-access-token",
+            refresh_token: "fresh-refresh-token"
+          };
+        },
+        fetch: async () => {
+          requests += 1;
+          return requests === 1
+            ? new Response("legacy expired JWT", { status: 401 })
+            : Response.json({ encrypted: '1:{"ok":true}' });
+        }
+      })
+    );
+
+    expect(await (await customFetch("https://example.test/v1/responses")).json()).toEqual({
+      ok: true
+    });
+    expect(requests).toBe(2);
+    expect(tokenRefreshes).toBe(1);
+  });
+
+  for (const ordinaryError of [
+    { status: 400, code: undefined, name: "ordinary v1 400" },
+    { status: 401, code: "invalid_jwt", name: "ordinary v1 401" }
+  ]) {
+    test(`${ordinaryError.name} fails closed without replay`, async () => {
+      window.localStorage.setItem("access_token", "access-token");
+      let requests = 0;
+      let forcedAttestations = 0;
+      let tokenRefreshes = 0;
+      const customFetch = createCustomFetchWithDependencies(
+        undefined,
+        dependencies({
+          getAttestation: async (forceRefresh) => {
+            if (forceRefresh) forcedAttestations += 1;
+            return staleAttestation;
+          },
+          refreshToken: async () => {
+            tokenRefreshes += 1;
+            return {
+              access_token: "unused-access-token",
+              refresh_token: "unused-refresh-token"
+            };
+          },
+          fetch: async () => {
+            requests += 1;
+            return contractError(
+              ordinaryError.status,
+              `ordinary-${ordinaryError.status}`,
+              ordinaryError.code
+            );
+          }
+        })
+      );
+
+      await expect(customFetch("https://example.test/v1/responses")).rejects.toThrow(
+        `Request failed with status ${ordinaryError.status}: ordinary-${ordinaryError.status}`
+      );
+      expect(requests).toBe(1);
+      expect(forcedAttestations).toBe(0);
+      expect(tokenRefreshes).toBe(0);
+    });
+  }
 
   test("rebuilds the request after a JWT refresh replaces the attestation", async () => {
     window.localStorage.setItem("access_token", "expired-access-token");
@@ -174,7 +294,9 @@ describe("createCustomFetch stale-session recovery", () => {
         },
         fetch: async (_input, init) => {
           requests.push(recordRequest(init));
-          if (requests.length === 1) return new Response("expired JWT", { status: 401 });
+          if (requests.length === 1) {
+            return contractError(401, "expired JWT", "access_token_expired");
+          }
           return Response.json({ encrypted: '2:{"ok":true}' });
         }
       })
@@ -202,6 +324,382 @@ describe("createCustomFetch stale-session recovery", () => {
     ]);
   });
 
+  test("uses one target replay budget when recoverable reasons alternate", async () => {
+    window.localStorage.setItem("access_token", "expired-access-token");
+    let requests = 0;
+    let tokenRefreshes = 0;
+    let forcedAttestations = 0;
+    const customFetch = createCustomFetchWithDependencies(
+      undefined,
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) forcedAttestations += 1;
+          return staleAttestation;
+        },
+        refreshToken: async () => {
+          tokenRefreshes += 1;
+          window.localStorage.setItem("access_token", "fresh-access-token");
+          return {
+            access_token: "fresh-access-token",
+            refresh_token: "fresh-refresh-token"
+          };
+        },
+        fetch: async () => {
+          requests += 1;
+          return requests === 1
+            ? contractError(401, "expired", "access_token_expired")
+            : contractError(400, "stale", "session_not_found");
+        }
+      })
+    );
+
+    await expect(customFetch("https://example.test/v1/responses")).rejects.toThrow(
+      "Request failed with status 400: stale"
+    );
+    expect(requests).toBe(2);
+    expect(tokenRefreshes).toBe(1);
+    expect(forcedAttestations).toBe(0);
+  });
+
+  test("never refreshes a JWT for an API-key 401", async () => {
+    let requests = 0;
+    let tokenRefreshes = 0;
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "invalid-api-key" },
+      dependencies({
+        refreshToken: async () => {
+          tokenRefreshes += 1;
+          return {
+            access_token: "unused-access-token",
+            refresh_token: "unused-refresh-token"
+          };
+        },
+        fetch: async () => {
+          requests += 1;
+          return contractError(401, "expired", "access_token_expired");
+        }
+      })
+    );
+
+    await expect(customFetch("https://example.test/v1/responses")).rejects.toThrow(
+      "Request failed with status 401: expired"
+    );
+    expect(requests).toBe(1);
+    expect(tokenRefreshes).toBe(0);
+  });
+
+  test("keeps API-key authentication pinned when options mutate in flight", async () => {
+    const options = { apiKey: "original-api-key" };
+    let requests = 0;
+    let tokenRefreshes = 0;
+    const customFetch = createCustomFetchWithDependencies(
+      options,
+      dependencies({
+        refreshToken: async () => {
+          tokenRefreshes += 1;
+          return {
+            access_token: "unused-access-token",
+            refresh_token: "unused-refresh-token"
+          };
+        },
+        fetch: async (_input, init) => {
+          requests += 1;
+          expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer original-api-key");
+          options.apiKey = "";
+          return contractError(401, "expired", "access_token_expired");
+        }
+      })
+    );
+
+    await expect(customFetch("https://example.test/v1/responses")).rejects.toThrow(
+      "Request failed with status 401: expired"
+    );
+    expect(requests).toBe(1);
+    expect(tokenRefreshes).toBe(0);
+  });
+
+  test("keeps JWT authentication pinned when options mutate in flight", async () => {
+    const options: { apiKey?: string } = {};
+    window.localStorage.setItem("access_token", "original-access-token");
+    let requests = 0;
+    let tokenRefreshes = 0;
+    const customFetch = createCustomFetchWithDependencies(
+      options,
+      dependencies({
+        refreshToken: async () => {
+          tokenRefreshes += 1;
+          window.localStorage.setItem("access_token", "fresh-access-token");
+          return {
+            access_token: "fresh-access-token",
+            refresh_token: "fresh-refresh-token"
+          };
+        },
+        fetch: async (_input, init) => {
+          requests += 1;
+          const authorization = new Headers(init?.headers).get("Authorization");
+          if (requests === 1) {
+            expect(authorization).toBe("Bearer original-access-token");
+            options.apiKey = "late-api-key";
+            return contractError(401, "expired", "access_token_expired");
+          }
+
+          expect(authorization).toBe("Bearer fresh-access-token");
+          return Response.json({ encrypted: '1:{"ok":true}' });
+        }
+      })
+    );
+
+    const response = await customFetch("https://example.test/v1/responses");
+    expect(await response.json()).toEqual({ ok: true });
+    expect(requests).toBe(2);
+    expect(tokenRefreshes).toBe(1);
+  });
+
+  test("snapshots and preserves the complete logical request across recovery", async () => {
+    let currentAttestation = staleAttestation;
+    const controller = new AbortController();
+    const url = new URL("https://example.test/v1/responses?model=private&stream=true");
+    const sourceHeaders = new Headers({
+      "content-type": "application/json",
+      "x-safe-provider-header": "preserve-me"
+    });
+    const sourceInit: RequestInit = {
+      method: "POST",
+      headers: sourceHeaders,
+      body: '{"prompt":"original"}',
+      cache: "no-store",
+      credentials: "include",
+      redirect: "manual",
+      referrerPolicy: "no-referrer",
+      signal: controller.signal
+    };
+    const requests: Array<{
+      url: string;
+      method: string | undefined;
+      safeHeader: string | null;
+      plaintext: string;
+      cache: RequestCache | undefined;
+      credentials: RequestCredentials | undefined;
+      redirect: RequestRedirect | undefined;
+      referrerPolicy: ReferrerPolicy | undefined;
+      sameSignal: boolean;
+    }> = [];
+
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) currentAttestation = freshAttestation;
+          return currentAttestation;
+        },
+        fetch: async (input, init) => {
+          const recorded = recordRequest(init);
+          const key = recorded.sessionId === "stale-session" ? staleKey : freshKey;
+          requests.push({
+            url: String(input),
+            method: init?.method,
+            safeHeader: new Headers(init?.headers).get("x-safe-provider-header"),
+            plaintext: decryptForTest(key, recorded.encryptedBody!),
+            cache: init?.cache,
+            credentials: init?.credentials,
+            redirect: init?.redirect,
+            referrerPolicy: init?.referrerPolicy,
+            sameSignal: init?.signal === controller.signal
+          });
+
+          if (requests.length === 1) {
+            url.searchParams.set("model", "mutated");
+            sourceHeaders.set("x-safe-provider-header", "mutated");
+            sourceInit.method = "PUT";
+            sourceInit.body = '{"prompt":"mutated"}';
+            sourceInit.credentials = "omit";
+            return contractError(400, "stale", "session_not_found");
+          }
+          return Response.json({ encrypted: '2:{"ok":true}' });
+        }
+      })
+    );
+
+    const responsePromise = customFetch(url, sourceInit);
+    // snapshotRequest reads the body asynchronously; mutations during that
+    // yield must not leak into either transport attempt.
+    sourceInit.cache = "reload";
+    sourceInit.referrerPolicy = "origin";
+
+    expect(await (await responsePromise).json()).toEqual({ ok: true });
+    expect(requests).toEqual([
+      {
+        url: "https://example.test/v1/responses?model=private&stream=true",
+        method: "POST",
+        safeHeader: "preserve-me",
+        plaintext: '{"prompt":"original"}',
+        cache: "no-store",
+        credentials: "include",
+        redirect: "manual",
+        referrerPolicy: "no-referrer",
+        sameSignal: true
+      },
+      {
+        url: "https://example.test/v1/responses?model=private&stream=true",
+        method: "POST",
+        safeHeader: "preserve-me",
+        plaintext: '{"prompt":"original"}',
+        cache: "no-store",
+        credentials: "include",
+        redirect: "manual",
+        referrerPolicy: "no-referrer",
+        sameSignal: true
+      }
+    ]);
+  });
+
+  test("an abort after the first response prevents recovery and replay", async () => {
+    const controller = new AbortController();
+    let requests = 0;
+    let forcedAttestations = 0;
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) forcedAttestations += 1;
+          return staleAttestation;
+        },
+        fetch: async () => {
+          requests += 1;
+          controller.abort();
+          return contractError(400, "stale", "session_not_found");
+        }
+      })
+    );
+
+    await expect(
+      customFetch("https://example.test/v1/responses", { signal: controller.signal })
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(requests).toBe(1);
+    expect(forcedAttestations).toBe(0);
+  });
+
+  test("a pre-aborted request performs no attestation or transport work", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let attestations = 0;
+    let requests = 0;
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async () => {
+          attestations += 1;
+          return staleAttestation;
+        },
+        fetch: async () => {
+          requests += 1;
+          return Response.json({});
+        }
+      })
+    );
+
+    await expect(
+      customFetch("https://example.test/v1/responses", { signal: controller.signal })
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(attestations).toBe(0);
+    expect(requests).toBe(0);
+  });
+
+  test("an abort during initial attestation prevents the first transport send", async () => {
+    const controller = new AbortController();
+    let attestations = 0;
+    let requests = 0;
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async () => {
+          attestations += 1;
+          controller.abort();
+          return staleAttestation;
+        },
+        fetch: async () => {
+          requests += 1;
+          return Response.json({});
+        }
+      })
+    );
+
+    await expect(
+      customFetch("https://example.test/v1/responses", { signal: controller.signal })
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(attestations).toBe(1);
+    expect(requests).toBe(0);
+  });
+
+  test("an explicit null signal detaches from a Request source across recovery", async () => {
+    const sourceController = new AbortController();
+    const sourceRequest = new Request("https://example.test/v1/responses", {
+      method: "POST",
+      body: '{"prompt":"detached"}',
+      signal: sourceController.signal
+    });
+    let currentAttestation = staleAttestation;
+    let forcedAttestations = 0;
+    const signals: Array<AbortSignal | null | undefined> = [];
+    let requests = 0;
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) {
+            forcedAttestations += 1;
+            sourceController.abort();
+            currentAttestation = freshAttestation;
+          }
+          return currentAttestation;
+        },
+        fetch: async (_input, init) => {
+          requests += 1;
+          signals.push(init?.signal);
+          return requests === 1
+            ? contractError(400, "stale", "session_not_found")
+            : Response.json({ encrypted: '2:{"ok":true}' });
+        }
+      })
+    );
+
+    const response = await customFetch(sourceRequest, { signal: null });
+    expect(await response.json()).toEqual({ ok: true });
+    expect(sourceController.signal.aborted).toBe(true);
+    expect(forcedAttestations).toBe(1);
+    expect(requests).toBe(2);
+    expect(signals).toEqual([null, null]);
+  });
+
+  test("an explicit undefined signal inherits a Request source signal", async () => {
+    const sourceController = new AbortController();
+    const sourceRequest = new Request("https://example.test/v1/responses", {
+      signal: sourceController.signal
+    });
+    let attestations = 0;
+    let requests = 0;
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async () => {
+          attestations += 1;
+          sourceController.abort();
+          return staleAttestation;
+        },
+        fetch: async () => {
+          requests += 1;
+          return Response.json({});
+        }
+      })
+    );
+
+    await expect(customFetch(sourceRequest, { signal: undefined })).rejects.toMatchObject({
+      name: "AbortError"
+    });
+    expect(attestations).toBe(1);
+    expect(requests).toBe(0);
+  });
+
   test("keeps a stale retry bound to the identity that initiated the request", async () => {
     window.localStorage.setItem("access_token", "initiating-account-token");
     let currentAttestation = staleAttestation;
@@ -223,7 +721,7 @@ describe("createCustomFetch stale-session recovery", () => {
           const request = recordRequest(init);
           requests.push(request);
           if (request.sessionId === staleAttestation.sessionId) {
-            return new Response("stale", { status: 400 });
+            return contractError(400, "stale", "session_not_found");
           }
           return Response.json({ encrypted: '2:{"ok":true}' });
         }
@@ -255,7 +753,7 @@ describe("createCustomFetch stale-session recovery", () => {
         },
         fetch: async (_input, init) => {
           if (recordRequest(init).sessionId === staleAttestation.sessionId) {
-            return new Response("stale", { status: 400 });
+            return contractError(400, "stale", "session_not_found");
           }
 
           return new Response(
@@ -297,7 +795,7 @@ describe("createCustomFetch stale-session recovery", () => {
           const request = recordRequest(init);
           requests.push(request);
           if (request.sessionId === staleAttestation.sessionId) {
-            return new Response("stale", { status: 400 });
+            return contractError(400, "stale", "session_not_found");
           }
           return Response.json({ encrypted: '2:{"ok":true}' });
         }
@@ -324,6 +822,83 @@ describe("createCustomFetch stale-session recovery", () => {
     ).toBe(true);
   });
 
+  test("a staggered stale response joins renewal after the leader evicts the cache", async () => {
+    const lateKey = new Uint8Array(32).fill(3);
+    const lateAttestation: Attestation = {
+      sessionKey: lateKey,
+      sessionId: "late-extra-session"
+    };
+    let currentAttestation: Attestation | null = staleAttestation;
+    let forcedAttestations = 0;
+    let fullHandshakes = 0;
+    let staleSends = 0;
+    let releaseCacheCleared!: () => void;
+    const cacheCleared = new Promise<void>((resolve) => {
+      releaseCacheCleared = resolve;
+    });
+    let releaseLateResponse!: () => void;
+    const lateResponseReturned = new Promise<void>((resolve) => {
+      releaseLateResponse = resolve;
+    });
+    const requests: RecordedRequest[] = [];
+
+    const customFetch = createCustomFetchWithDependencies(
+      { apiKey: "test-api-key" },
+      dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) {
+            forcedAttestations += 1;
+            fullHandshakes += 1;
+            currentAttestation = null;
+            releaseCacheCleared();
+            await lateResponseReturned;
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            currentAttestation = freshAttestation;
+            return freshAttestation;
+          }
+          if (currentAttestation) return currentAttestation;
+
+          // This is the cache-miss handshake the old compare-before-map
+          // ordering allowed the staggered caller to start.
+          fullHandshakes += 1;
+          currentAttestation = lateAttestation;
+          return lateAttestation;
+        },
+        fetch: async (_input, init) => {
+          const request = recordRequest(init);
+          requests.push(request);
+          if (request.sessionId === staleAttestation.sessionId) {
+            staleSends += 1;
+            if (staleSends === 2) {
+              await cacheCleared;
+              releaseLateResponse();
+            }
+            return contractError(400, "stale", "session_not_found");
+          }
+
+          const key = request.sessionId === freshAttestation.sessionId ? freshKey : lateKey;
+          return Response.json({ encrypted: encryptForTest(key, JSON.stringify({ ok: true })) });
+        }
+      })
+    );
+
+    const results = await Promise.all(
+      ["first", "late"].map((prompt) =>
+        customFetch("https://example.test/v1/responses", {
+          method: "POST",
+          body: JSON.stringify({ prompt })
+        }).then((response) => response.json())
+      )
+    );
+
+    expect(results).toEqual([{ ok: true }, { ok: true }]);
+    expect(forcedAttestations).toBe(1);
+    expect(fullHandshakes).toBe(1);
+    expect(requests.filter(({ sessionId }) => sessionId === "stale-session")).toHaveLength(2);
+    expect(requests.filter(({ sessionId }) => sessionId === "fresh-session")).toHaveLength(2);
+    expect(requests.some(({ sessionId }) => sessionId === "late-extra-session")).toBe(false);
+  });
+
   test("does not replay non-400 application errors", async () => {
     let requests = 0;
     let forcedAttestations = 0;
@@ -337,7 +912,7 @@ describe("createCustomFetch stale-session recovery", () => {
         },
         fetch: async () => {
           requests += 1;
-          return new Response("invalid request", { status: 422 });
+          return contractError(422, "invalid request");
         }
       })
     );
@@ -382,7 +957,7 @@ describe("createCustomFetch stale-session recovery", () => {
             pcrConfig.environment = "production";
             pcrConfig.pcr0DevValues = ["4c".repeat(48)];
             pcrConfig.remoteAttestation = true;
-            return new Response("stale", { status: 400 });
+            return contractError(400, "stale", "session_not_found");
           }
           return Response.json({ encrypted: '2:{"ok":true}' });
         }

--- a/src/lib/test/encryptedApi.test.ts
+++ b/src/lib/test/encryptedApi.test.ts
@@ -1,0 +1,603 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  authenticatedApiCallWithDependencies,
+  encryptedApiCallWithDependencies,
+  openAiAuthenticatedApiCallWithDependencies,
+  type EncryptedApiDependencies
+} from "../encryptedApi";
+import type { Attestation } from "../getAttestation";
+import { snapshotPcrConfig } from "../pcr";
+import { ERROR_CODE_HEADER, ERROR_CONTRACT_HEADER } from "../recovery";
+
+const staleKey = new Uint8Array(32).fill(1);
+const freshKey = new Uint8Array(32).fill(2);
+const staleAttestation: Attestation = { sessionKey: staleKey, sessionId: "stale-session" };
+const freshAttestation: Attestation = { sessionKey: freshKey, sessionId: "fresh-session" };
+
+function encryptForTest(sessionKey: Uint8Array, plaintext: string): string {
+  return `${sessionKey[0]}:${plaintext}`;
+}
+
+function decryptForTest(sessionKey: Uint8Array, ciphertext: string): string {
+  const prefix = `${sessionKey[0]}:`;
+  if (!ciphertext.startsWith(prefix)) throw new Error(`wrong key ${sessionKey[0]}`);
+  return ciphertext.slice(prefix.length);
+}
+
+function contractError(status: number, message: string, code?: string): Response {
+  const headers = new Headers({ [ERROR_CONTRACT_HEADER]: "1" });
+  if (code) headers.set(ERROR_CODE_HEADER, code);
+  return Response.json({ status, message }, { status, headers });
+}
+
+function encryptedSuccess(sessionKey: Uint8Array, value: unknown): Response {
+  return Response.json(
+    { encrypted: encryptForTest(sessionKey, JSON.stringify(value)) },
+    { headers: { [ERROR_CONTRACT_HEADER]: "1" } }
+  );
+}
+
+function dependencies(overrides: Partial<EncryptedApiDependencies> = {}): EncryptedApiDependencies {
+  return {
+    decryptMessage: decryptForTest,
+    encryptMessage: encryptForTest,
+    fetch: async () => new Response(null, { status: 500 }),
+    getAttestation: async () => staleAttestation,
+    getApiPcrConfig: () => snapshotPcrConfig({ environment: "development" }),
+    getApiUrl: () => "https://api.example.test",
+    getPlatformApiUrl: () => "https://platform.example.test",
+    getPlatformPcrConfig: () => snapshotPcrConfig({ environment: "development" }),
+    getAccessToken: () => window.localStorage.getItem("access_token"),
+    refreshAccessToken: async () => {},
+    resolveEndpoint: (url) => ({
+      baseUrl: "https://api.example.test",
+      context: url.includes("/platform/") ? "platform" : "app"
+    }),
+    ...overrides
+  };
+}
+
+function recordedRequest(init: RequestInit | undefined, sessionKey: Uint8Array) {
+  const headers = new Headers(init?.headers);
+  const envelope = init?.body
+    ? (JSON.parse(String(init.body)) as { encrypted: string })
+    : undefined;
+  return {
+    authorization: headers.get("Authorization"),
+    method: init?.method,
+    plaintext: envelope ? decryptForTest(sessionKey, envelope.encrypted) : undefined,
+    sessionId: headers.get("x-session-id")
+  };
+}
+
+describe("encrypted API recovery", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  test("v1 session recovery re-encrypts one exact typed request", async () => {
+    let currentAttestation = staleAttestation;
+    let forcedAttestations = 0;
+    const data = { operation: "original" };
+    const urls: string[] = [];
+    const requests: ReturnType<typeof recordedRequest>[] = [];
+    const deps = dependencies({
+      getAttestation: async (forceRefresh) => {
+        if (forceRefresh) {
+          forcedAttestations += 1;
+          currentAttestation = freshAttestation;
+        }
+        return currentAttestation;
+      },
+      fetch: async (input, init) => {
+        urls.push(String(input));
+        const key =
+          new Headers(init?.headers).get("x-session-id") === "stale-session" ? staleKey : freshKey;
+        requests.push(recordedRequest(init, key));
+        if (requests.length === 1) {
+          data.operation = "mutated";
+          return contractError(400, "Bad Request", "session_not_found");
+        }
+        return encryptedSuccess(freshKey, { ok: true });
+      }
+    });
+
+    const result = await encryptedApiCallWithDependencies<{ operation: string }, { ok: boolean }>(
+      "https://api.example.test/protected/action?mode=exact",
+      "PATCH",
+      data,
+      "api-key",
+      undefined,
+      deps
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(forcedAttestations).toBe(1);
+    expect(urls).toEqual([
+      "https://api.example.test/protected/action?mode=exact",
+      "https://api.example.test/protected/action?mode=exact"
+    ]);
+    expect(requests).toEqual([
+      {
+        authorization: "Bearer api-key",
+        method: "PATCH",
+        plaintext: '{"operation":"original"}',
+        sessionId: "stale-session"
+      },
+      {
+        authorization: "Bearer api-key",
+        method: "PATCH",
+        plaintext: '{"operation":"original"}',
+        sessionId: "fresh-session"
+      }
+    ]);
+  });
+
+  test("shares one session renewal across concurrent typed stale requests", async () => {
+    const callCount = 8;
+    let currentAttestation = staleAttestation;
+    let forcedAttestations = 0;
+    let attestationDocuments = 0;
+    let keyExchanges = 0;
+    let staleSends = 0;
+    let releaseStaleResponses!: () => void;
+    const allStaleRequestsStarted = new Promise<void>((resolve) => {
+      releaseStaleResponses = resolve;
+    });
+    const requests: Array<
+      ReturnType<typeof recordedRequest> & {
+        ciphertext: string | undefined;
+      }
+    > = [];
+
+    const deps = dependencies({
+      getAttestation: async (forceRefresh) => {
+        if (forceRefresh) {
+          forcedAttestations += 1;
+          attestationDocuments += 1;
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          keyExchanges += 1;
+          currentAttestation = freshAttestation;
+        }
+        return currentAttestation;
+      },
+      fetch: async (_input, init) => {
+        const sessionId = new Headers(init?.headers).get("x-session-id");
+        const key = sessionId === freshAttestation.sessionId ? freshKey : staleKey;
+        const envelope = init?.body
+          ? (JSON.parse(String(init.body)) as { encrypted: string })
+          : undefined;
+        const request = {
+          ...recordedRequest(init, key),
+          ciphertext: envelope?.encrypted
+        };
+        requests.push(request);
+
+        if (sessionId === staleAttestation.sessionId) {
+          staleSends += 1;
+          if (staleSends === callCount) releaseStaleResponses();
+          await allStaleRequestsStarted;
+          return contractError(400, "Bad Request", "session_not_found");
+        }
+
+        const payload = JSON.parse(request.plaintext || "{}") as { operation?: string };
+        return encryptedSuccess(freshKey, { operation: payload.operation });
+      }
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: callCount }, (_, index) =>
+        encryptedApiCallWithDependencies<{ operation: string }, { operation: string }>(
+          "https://api.example.test/protected/action",
+          "POST",
+          { operation: `call-${index}` },
+          "api-key",
+          undefined,
+          deps
+        )
+      )
+    );
+
+    expect(results).toEqual(
+      Array.from({ length: callCount }, (_, index) => ({ operation: `call-${index}` }))
+    );
+    expect(forcedAttestations).toBe(1);
+    expect(attestationDocuments).toBe(1);
+    expect(keyExchanges).toBe(1);
+    expect(requests.filter(({ sessionId }) => sessionId === "stale-session")).toHaveLength(
+      callCount
+    );
+    const freshRequests = requests.filter(({ sessionId }) => sessionId === "fresh-session");
+    expect(freshRequests).toHaveLength(callCount);
+    expect(freshRequests.every(({ ciphertext }) => ciphertext?.startsWith("2:") === true)).toBe(
+      true
+    );
+    expect(freshRequests.map(({ plaintext }) => plaintext).sort()).toEqual(
+      Array.from({ length: callCount }, (_, index) => `{"operation":"call-${index}"}`).sort()
+    );
+  });
+
+  test("a staggered typed stale response joins after the leader clears the cache", async () => {
+    const lateKey = new Uint8Array(32).fill(3);
+    const lateAttestation: Attestation = {
+      sessionKey: lateKey,
+      sessionId: "late-extra-session"
+    };
+    let currentAttestation: Attestation | null = staleAttestation;
+    let forcedAttestations = 0;
+    let fullHandshakes = 0;
+    let staleSends = 0;
+    let releaseCacheCleared!: () => void;
+    const cacheCleared = new Promise<void>((resolve) => {
+      releaseCacheCleared = resolve;
+    });
+    let releaseLateResponse!: () => void;
+    const lateResponseReturned = new Promise<void>((resolve) => {
+      releaseLateResponse = resolve;
+    });
+    const sessionIds: Array<string | null> = [];
+
+    const deps = dependencies({
+      getAttestation: async (forceRefresh) => {
+        if (forceRefresh) {
+          forcedAttestations += 1;
+          fullHandshakes += 1;
+          currentAttestation = null;
+          releaseCacheCleared();
+          await lateResponseReturned;
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          currentAttestation = freshAttestation;
+          return freshAttestation;
+        }
+        if (currentAttestation) return currentAttestation;
+
+        fullHandshakes += 1;
+        currentAttestation = lateAttestation;
+        return lateAttestation;
+      },
+      fetch: async (_input, init) => {
+        const sessionId = new Headers(init?.headers).get("x-session-id");
+        sessionIds.push(sessionId);
+        if (sessionId === staleAttestation.sessionId) {
+          staleSends += 1;
+          if (staleSends === 2) {
+            await cacheCleared;
+            releaseLateResponse();
+          }
+          return contractError(400, "Bad Request", "session_not_found");
+        }
+
+        const key = sessionId === freshAttestation.sessionId ? freshKey : lateKey;
+        return encryptedSuccess(key, { ok: true });
+      }
+    });
+
+    const results = await Promise.all(
+      ["first", "late"].map((operation) =>
+        encryptedApiCallWithDependencies<{ operation: string }, { ok: boolean }>(
+          "https://api.example.test/protected/action",
+          "POST",
+          { operation },
+          "api-key",
+          undefined,
+          deps
+        )
+      )
+    );
+
+    expect(results).toEqual([{ ok: true }, { ok: true }]);
+    expect(forcedAttestations).toBe(1);
+    expect(fullHandshakes).toBe(1);
+    expect(sessionIds.filter((sessionId) => sessionId === "stale-session")).toHaveLength(2);
+    expect(sessionIds.filter((sessionId) => sessionId === "fresh-session")).toHaveLength(2);
+    expect(sessionIds).not.toContain("late-extra-session");
+  });
+
+  test("v1 access-token expiry refreshes once and replays with the new token", async () => {
+    window.localStorage.setItem("access_token", "expired-access-token");
+    let tokenRefreshes = 0;
+    const authorizations: Array<string | null> = [];
+    const deps = dependencies({
+      refreshAccessToken: async () => {
+        tokenRefreshes += 1;
+        window.localStorage.setItem("access_token", "fresh-access-token");
+      },
+      fetch: async (_input, init) => {
+        authorizations.push(new Headers(init?.headers).get("Authorization"));
+        return authorizations.length === 1
+          ? contractError(401, "Invalid JWT", "access_token_expired")
+          : encryptedSuccess(staleKey, { ok: true });
+      }
+    });
+
+    expect(
+      await authenticatedApiCallWithDependencies<undefined, { ok: boolean }>(
+        "https://api.example.test/protected/user",
+        "GET",
+        undefined,
+        undefined,
+        deps
+      )
+    ).toEqual({ ok: true });
+    expect(tokenRefreshes).toBe(1);
+    expect(authorizations).toEqual(["Bearer expired-access-token", "Bearer fresh-access-token"]);
+  });
+
+  for (const ordinary of [
+    { status: 400, code: undefined, message: "Encryption error" },
+    { status: 401, code: "invalid_jwt", message: "Invalid JWT" }
+  ]) {
+    test(`v1 ordinary ${ordinary.status} fails closed`, async () => {
+      window.localStorage.setItem("access_token", "access-token");
+      let sends = 0;
+      let forcedAttestations = 0;
+      let tokenRefreshes = 0;
+      const deps = dependencies({
+        getAttestation: async (forceRefresh) => {
+          if (forceRefresh) forcedAttestations += 1;
+          return staleAttestation;
+        },
+        refreshAccessToken: async () => {
+          tokenRefreshes += 1;
+        },
+        fetch: async () => {
+          sends += 1;
+          return contractError(ordinary.status, ordinary.message, ordinary.code);
+        }
+      });
+
+      await expect(
+        authenticatedApiCallWithDependencies<undefined, never>(
+          "https://api.example.test/protected/user",
+          "GET",
+          undefined,
+          undefined,
+          deps
+        )
+      ).rejects.toThrow(ordinary.message);
+      expect(sends).toBe(1);
+      expect(forcedAttestations).toBe(0);
+      expect(tokenRefreshes).toBe(0);
+    });
+  }
+
+  test("headerless 400 and 401 retain legacy recovery", async () => {
+    window.localStorage.setItem("access_token", "expired-access-token");
+    let currentAttestation = staleAttestation;
+    let sessionSends = 0;
+    let authSends = 0;
+    let forcedAttestations = 0;
+    let tokenRefreshes = 0;
+    const deps = dependencies({
+      getAttestation: async (forceRefresh) => {
+        if (forceRefresh) {
+          forcedAttestations += 1;
+          currentAttestation = freshAttestation;
+        }
+        return currentAttestation;
+      },
+      refreshAccessToken: async () => {
+        tokenRefreshes += 1;
+        window.localStorage.setItem("access_token", "fresh-access-token");
+      },
+      fetch: async (input) => {
+        if (String(input).endsWith("/legacy-session")) {
+          sessionSends += 1;
+          return sessionSends === 1
+            ? Response.json({ message: "Bad Request" }, { status: 400 })
+            : encryptedSuccess(freshKey, { ok: "session" });
+        }
+        authSends += 1;
+        return authSends === 1
+          ? Response.json({ message: "Invalid JWT" }, { status: 401 })
+          : encryptedSuccess(freshKey, { ok: "auth" });
+      }
+    });
+
+    expect(
+      await encryptedApiCallWithDependencies<undefined, { ok: string }>(
+        "https://api.example.test/legacy-session",
+        "GET",
+        undefined,
+        undefined,
+        undefined,
+        deps
+      )
+    ).toEqual({ ok: "session" });
+    expect(
+      await authenticatedApiCallWithDependencies<undefined, { ok: string }>(
+        "https://api.example.test/protected/legacy-auth",
+        "GET",
+        undefined,
+        undefined,
+        deps
+      )
+    ).toEqual({ ok: "auth" });
+    expect(sessionSends).toBe(2);
+    expect(authSends).toBe(2);
+    expect(forcedAttestations).toBe(1);
+    expect(tokenRefreshes).toBe(1);
+  });
+
+  test("one target replay budget stops alternating recovery reasons", async () => {
+    window.localStorage.setItem("access_token", "access-token");
+    let currentAttestation = staleAttestation;
+    let sends = 0;
+    let forcedAttestations = 0;
+    let tokenRefreshes = 0;
+    const deps = dependencies({
+      getAttestation: async (forceRefresh) => {
+        if (forceRefresh) {
+          forcedAttestations += 1;
+          currentAttestation = freshAttestation;
+        }
+        return currentAttestation;
+      },
+      refreshAccessToken: async () => {
+        tokenRefreshes += 1;
+      },
+      fetch: async () => {
+        sends += 1;
+        return sends === 1
+          ? contractError(400, "Bad Request", "session_not_found")
+          : contractError(401, "Invalid JWT", "access_token_expired");
+      }
+    });
+
+    await expect(
+      authenticatedApiCallWithDependencies<undefined, never>(
+        "https://api.example.test/protected/action",
+        "POST",
+        undefined,
+        undefined,
+        deps
+      )
+    ).rejects.toThrow("Invalid JWT");
+    expect(sends).toBe(2);
+    expect(forcedAttestations).toBe(1);
+    expect(tokenRefreshes).toBe(0);
+  });
+
+  test("expired target JWT can refresh through one stale-session repair", async () => {
+    window.localStorage.setItem("access_token", "expired-access-token");
+    let currentAttestation = staleAttestation;
+    let forcedAttestations = 0;
+    let targetSends = 0;
+    let refreshSends = 0;
+    const targetRequests: ReturnType<typeof recordedRequest>[] = [];
+    const refreshRequests: ReturnType<typeof recordedRequest>[] = [];
+    let deps!: EncryptedApiDependencies;
+
+    deps = dependencies({
+      getAttestation: async (forceRefresh) => {
+        if (forceRefresh) {
+          forcedAttestations += 1;
+          currentAttestation = freshAttestation;
+        }
+        return currentAttestation;
+      },
+      refreshAccessToken: async () => {
+        const tokens = await encryptedApiCallWithDependencies<
+          { refresh_token: string },
+          { access_token: string; refresh_token: string }
+        >(
+          "https://api.example.test/refresh",
+          "POST",
+          { refresh_token: "refresh-token" },
+          undefined,
+          undefined,
+          deps
+        );
+        window.localStorage.setItem("access_token", tokens.access_token);
+      },
+      fetch: async (input, init) => {
+        const url = String(input);
+        const sessionId = new Headers(init?.headers).get("x-session-id");
+        const key = sessionId === "fresh-session" ? freshKey : staleKey;
+        if (url.includes("/refresh")) {
+          refreshSends += 1;
+          refreshRequests.push(recordedRequest(init, key));
+          return refreshSends === 1
+            ? contractError(400, "Bad Request", "session_not_found")
+            : encryptedSuccess(freshKey, {
+                access_token: "fresh-access-token",
+                refresh_token: "fresh-refresh-token"
+              });
+        }
+
+        targetSends += 1;
+        targetRequests.push(recordedRequest(init, key));
+        return targetSends === 1
+          ? contractError(401, "Invalid JWT", "access_token_expired")
+          : encryptedSuccess(freshKey, { ok: true });
+      }
+    });
+
+    expect(
+      await authenticatedApiCallWithDependencies<{ prompt: string }, { ok: boolean }>(
+        "https://api.example.test/v1/chat/completions?stream=false",
+        "POST",
+        { prompt: "same prompt" },
+        undefined,
+        deps
+      )
+    ).toEqual({ ok: true });
+    expect(targetSends).toBe(2);
+    expect(refreshSends).toBe(2);
+    expect(forcedAttestations).toBe(1);
+    expect(refreshRequests.map(({ plaintext }) => plaintext)).toEqual([
+      '{"refresh_token":"refresh-token"}',
+      '{"refresh_token":"refresh-token"}'
+    ]);
+    expect(targetRequests).toEqual([
+      {
+        authorization: "Bearer expired-access-token",
+        method: "POST",
+        plaintext: '{"prompt":"same prompt"}',
+        sessionId: "stale-session"
+      },
+      {
+        authorization: "Bearer fresh-access-token",
+        method: "POST",
+        plaintext: '{"prompt":"same prompt"}',
+        sessionId: "fresh-session"
+      }
+    ]);
+  });
+
+  test("a successful response decryption failure never replays", async () => {
+    let sends = 0;
+    let forcedAttestations = 0;
+    const deps = dependencies({
+      getAttestation: async (forceRefresh) => {
+        if (forceRefresh) forcedAttestations += 1;
+        return staleAttestation;
+      },
+      fetch: async () => {
+        sends += 1;
+        return Response.json({ encrypted: '2:{"ok":true}' });
+      }
+    });
+
+    await expect(
+      encryptedApiCallWithDependencies<undefined, never>(
+        "https://api.example.test/action",
+        "POST",
+        undefined,
+        undefined,
+        undefined,
+        deps
+      )
+    ).rejects.toThrow("Failed to decrypt or parse the response");
+    expect(sends).toBe(1);
+    expect(forcedAttestations).toBe(0);
+  });
+
+  test("API-key 401 never invokes access-token refresh", async () => {
+    let sends = 0;
+    let tokenRefreshes = 0;
+    const deps = dependencies({
+      refreshAccessToken: async () => {
+        tokenRefreshes += 1;
+      },
+      fetch: async () => {
+        sends += 1;
+        return contractError(401, "Invalid JWT", "access_token_expired");
+      }
+    });
+
+    await expect(
+      openAiAuthenticatedApiCallWithDependencies<undefined, never>(
+        "https://api.example.test/v1/models",
+        "GET",
+        undefined,
+        undefined,
+        "api-key",
+        deps
+      )
+    ).rejects.toThrow("Invalid JWT");
+    expect(sends).toBe(1);
+    expect(tokenRefreshes).toBe(0);
+  });
+});

--- a/src/lib/test/recovery.test.ts
+++ b/src/lib/test/recovery.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import {
+  classifyRecovery,
+  ERROR_CODE_HEADER,
+  ERROR_CONTRACT_HEADER,
+  type RecoveryAction
+} from "../recovery";
+
+interface RecoveryCase {
+  name: string;
+  status: number;
+  contract?: string;
+  code?: string;
+  expected?: RecoveryAction;
+}
+
+const cases: RecoveryCase[] = [
+  { name: "legacy 400", status: 400, expected: "renew_session" },
+  { name: "legacy 401", status: 401, expected: "refresh_access_token" },
+  { name: "legacy other status", status: 422 },
+  {
+    name: "v1 session not found",
+    status: 400,
+    contract: "1",
+    code: "session_not_found",
+    expected: "renew_session"
+  },
+  {
+    name: "v1 access token expired",
+    status: 401,
+    contract: "1",
+    code: "access_token_expired",
+    expected: "refresh_access_token"
+  },
+  { name: "v1 missing code", status: 400, contract: "1" },
+  { name: "v1 unknown code", status: 400, contract: "1", code: "other" },
+  {
+    name: "v1 malformed code",
+    status: 400,
+    contract: "1",
+    code: "session_not_found;foo"
+  },
+  {
+    name: "v1 session code with wrong status",
+    status: 401,
+    contract: "1",
+    code: "session_not_found"
+  },
+  {
+    name: "v1 access code with wrong status",
+    status: 400,
+    contract: "1",
+    code: "access_token_expired"
+  },
+  { name: "empty contract marker", status: 400, contract: "" },
+  {
+    name: "malformed contract marker",
+    status: 400,
+    contract: "1;foo",
+    code: "session_not_found"
+  },
+  {
+    name: "future contract marker",
+    status: 400,
+    contract: "2",
+    code: "session_not_found"
+  },
+  {
+    name: "legacy marker absence ignores an unversioned code",
+    status: 400,
+    code: "unknown",
+    expected: "renew_session"
+  }
+];
+
+describe("recovery contract classifier", () => {
+  for (const recoveryCase of cases) {
+    test(recoveryCase.name, () => {
+      const headers = new Headers();
+      if (recoveryCase.contract !== undefined) {
+        headers.set(ERROR_CONTRACT_HEADER, recoveryCase.contract);
+      }
+      if (recoveryCase.code !== undefined) {
+        headers.set(ERROR_CODE_HEADER, recoveryCase.code);
+      }
+
+      expect(classifyRecovery(recoveryCase.status, headers)).toBe(recoveryCase.expected);
+    });
+  }
+
+  test("duplicate contract markers fail closed", () => {
+    const headers = new Headers();
+    headers.append(ERROR_CONTRACT_HEADER, "1");
+    headers.append(ERROR_CONTRACT_HEADER, "1");
+    headers.set(ERROR_CODE_HEADER, "session_not_found");
+
+    expect(classifyRecovery(400, headers)).toBeUndefined();
+  });
+
+  test("duplicate error codes fail closed", () => {
+    const headers = new Headers();
+    headers.set(ERROR_CONTRACT_HEADER, "1");
+    headers.append(ERROR_CODE_HEADER, "session_not_found");
+    headers.append(ERROR_CODE_HEADER, "session_not_found");
+
+    expect(classifyRecovery(400, headers)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add one shared, fail-closed recovery classifier for Rust and TypeScript.
- Replay the original target request at most once. A nested `/refresh` request has its own one-replay budget.
- Snapshot the logical method, query, safe headers, plaintext body, abort signal, and authentication mode, then rebuild and re-encrypt the replay under the refreshed session.
- Coalesce concurrent typed and custom-fetch session renewals, including staggered stale responses.
- Preserve legacy headerless `400` and `401` recovery for older servers.
- Keep the public Rust and TypeScript APIs unchanged.

## Dependency

Precise new-server classification depends on OpenSecretCloud/opensecret#287. The headerless fallback keeps the SDK compatible with older backend versions.

## Testing

- Rust library tests — 82 passed
- Rust CI test suite, Clippy, build, documentation, formatting, and security checks
- TypeScript recovery tests — 51 passed, 161 expectations
- TypeScript build and formatting
- Combined expired-JWT plus stale-refresh-session recovery
- Exact-request preservation, one-replay limits, concurrency, abort, and fail-closed regressions
- Locally linked packaged Maple Chat and Agent recovery smoke tests