### PR TITLE
chore: bump SDK release versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensecret/react",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensecret/react",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "1.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/react",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "packageManager": "bun@1.3.5",
   "license": "MIT",
   "type": "module",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1256,7 +1256,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opensecret"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensecret"
-version = "3.6.1"
+version = "3.6.2"
 edition = "2021"
 authors = ["OpenSecret"]
 description = "Rust SDK for OpenSecret - secure AI API interactions with nitro attestation"

--- a/rust/README.md
+++ b/rust/README.md
@@ -17,7 +17,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-opensecret = "3.6.1"
+opensecret = "3.6.2"
 bytes = "1"
 futures = "0.3"
 http = "1"


### PR DESCRIPTION
## Summary

- bump @opensecret/react from 3.4.1 to 3.5.0 for the merged model-discovery feature and encrypted-request recovery fix
- bump the Rust opensecret crate from 3.6.1 to 3.6.2 for the encrypted-request recovery fix
- keep npm lock metadata, the Cargo lock entry, and the published Rust install example aligned

Both target versions were unclaimed in their registries immediately before this PR.

## SemVer

- React receives a minor bump because #107 adds backward-compatible pre-sign-in model discovery; the #108 fix is included in that release
- Rust receives a patch bump because only the backward-compatible #108 retry fix affects the crate

## Validation

- frozen Bun install
- bun audit --audit-level=high: no vulnerabilities
- TypeScript format check and production build
- deterministic TypeScript suite: 75 passed
- npm package dry-run: @opensecret/react@3.5.0, expected six-file boundary
- Rust format, strict Clippy, and cargo check
- Rust library suite: 83 passed
- Rust documentation with warnings denied
- cargo package --locked and cargo publish --dry-run --locked verified opensecret@3.6.2 from the clean commit
- git diff --check

The credential-backed TypeScript and Rust integration suites are left to GitHub CI, which supplies their test environment. This PR prepares version metadata only; it does not publish either package or create tags.