### PR TITLE
Fix Firefox GET requests receiving encrypted empty bodies

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -67,6 +67,23 @@ function throwIfAborted(signal?: AbortSignal | null): void {
   signal?.throwIfAborted();
 }
 
+function allowsRequestBody(method: string): boolean {
+  return method !== "GET" && method !== "HEAD";
+}
+
+async function snapshotPlaintextBody(
+  normalized: Request,
+  init?: RequestInit
+): Promise<string | undefined> {
+  if (!allowsRequestBody(normalized.method)) return undefined;
+
+  const bodyKnownPresent = init?.body != null || normalized.body != null;
+  const plaintextBody = await normalized.text();
+  return bodyKnownPresent || normalized.bodyUsed || plaintextBody !== ""
+    ? plaintextBody
+    : undefined;
+}
+
 async function snapshotRequest(
   input: string | URL | Request,
   init?: RequestInit
@@ -93,7 +110,9 @@ async function snapshotRequest(
   };
   delete options.body;
   delete options.headers;
-  const plaintextBody = normalized.body === null ? undefined : await normalized.text();
+  // Firefox does not expose Request.body. Gate on the normalized method first,
+  // then use the plaintext and explicit init body as fallback presence signals.
+  const plaintextBody = await snapshotPlaintextBody(normalized, init);
 
   return {
     url,
@@ -212,7 +231,10 @@ export function createCustomFetchWithDependencies(
 
         // Encrypt the original plaintext again for every attempt. Reusing an
         // old request body with a new session ID would make recovery fail.
-        if (request.plaintextBody !== undefined) {
+        if (
+          request.plaintextBody !== undefined &&
+          allowsRequestBody(request.options.method ?? "GET")
+        ) {
           const encryptedBody = dependencies.encryptMessage(
             attestation.sessionKey,
             request.plaintextBody

--- a/src/lib/test/customFetch.test.ts
+++ b/src/lib/test/customFetch.test.ts
@@ -59,6 +59,43 @@ function dependencies(overrides: Partial<CustomFetchDependencies>): CustomFetchD
   };
 }
 
+async function withRequestBodyUnavailable<T>(callback: () => Promise<T>): Promise<T> {
+  const OriginalRequest = globalThis.Request;
+  const plaintextBodies = new WeakMap<Request, string>();
+  class RequestWithoutBody extends OriginalRequest {
+    constructor(input: RequestInfo | URL, init?: RequestInit) {
+      const plaintextBody =
+        typeof init?.body === "string"
+          ? init.body
+          : input instanceof RequestWithoutBody
+            ? plaintextBodies.get(input)
+            : undefined;
+      super(
+        input,
+        plaintextBody !== undefined && init?.body == null ? { ...init, body: plaintextBody } : init
+      );
+      if (plaintextBody !== undefined) plaintextBodies.set(this, plaintextBody);
+    }
+
+    get body() {
+      return undefined;
+    }
+
+    async text(): Promise<string> {
+      const storedPlaintextBody = plaintextBodies.get(this);
+      const plaintextBody = await super.text();
+      return storedPlaintextBody ?? plaintextBody;
+    }
+  }
+
+  globalThis.Request = RequestWithoutBody as unknown as typeof Request;
+  try {
+    return await callback();
+  } finally {
+    globalThis.Request = OriginalRequest;
+  }
+}
+
 describe("createCustomFetch stale-session recovery", () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -126,6 +163,174 @@ describe("createCustomFetch stale-session recovery", () => {
       }
     ]);
   });
+
+  for (const method of ["GET", "HEAD", "POST"] as const) {
+    test(`keeps Firefox ${method} requests bodyless across stale-session recovery`, async () => {
+      await withRequestBodyUnavailable(async () => {
+        let currentAttestation = staleAttestation;
+        let forcedAttestations = 0;
+        let encryptions = 0;
+        const requests: Array<{
+          body: BodyInit | null | undefined;
+          method: string | undefined;
+          safeHeader: string | null;
+          sessionId: string | null;
+          url: string;
+        }> = [];
+
+        const customFetch = createCustomFetchWithDependencies(
+          { apiKey: "test-api-key" },
+          dependencies({
+            encryptMessage: (sessionKey, plaintext) => {
+              encryptions += 1;
+              return encryptForTest(sessionKey, plaintext);
+            },
+            getAttestation: async (forceRefresh) => {
+              if (forceRefresh) {
+                forcedAttestations += 1;
+                currentAttestation = freshAttestation;
+              }
+              return currentAttestation;
+            },
+            fetch: async (input, init) => {
+              const headers = new Headers(init?.headers);
+              requests.push({
+                body: init?.body,
+                method: init?.method,
+                safeHeader: headers.get("x-safe-provider-header"),
+                sessionId: headers.get("x-session-id"),
+                url: String(input)
+              });
+
+              return requests.length === 1
+                ? contractError(400, "stale", "session_not_found")
+                : Response.json({ encrypted: '2:{"ok":true}' });
+            }
+          })
+        );
+        const sourceRequest = new Request(
+          "https://example.test/v1/conversations/conversation-1?limit=20",
+          {
+            method,
+            headers: { "x-safe-provider-header": "preserve-me" }
+          }
+        );
+
+        expect(await (await customFetch(sourceRequest)).json()).toEqual({ ok: true });
+        expect(forcedAttestations).toBe(1);
+        expect(encryptions).toBe(0);
+        expect(requests).toEqual([
+          {
+            body: undefined,
+            method,
+            safeHeader: "preserve-me",
+            sessionId: "stale-session",
+            url: "https://example.test/v1/conversations/conversation-1?limit=20"
+          },
+          {
+            body: undefined,
+            method,
+            safeHeader: "preserve-me",
+            sessionId: "fresh-session",
+            url: "https://example.test/v1/conversations/conversation-1?limit=20"
+          }
+        ]);
+      });
+    });
+  }
+
+  test("keeps Firefox POST plaintext encryption and replay intact", async () => {
+    await withRequestBodyUnavailable(async () => {
+      let currentAttestation = staleAttestation;
+      let forcedAttestations = 0;
+      const requests: RecordedRequest[] = [];
+
+      const customFetch = createCustomFetchWithDependencies(
+        { apiKey: "test-api-key" },
+        dependencies({
+          getAttestation: async (forceRefresh) => {
+            if (forceRefresh) {
+              forcedAttestations += 1;
+              currentAttestation = freshAttestation;
+            }
+            return currentAttestation;
+          },
+          fetch: async (_input, init) => {
+            const request = recordRequest(init);
+            requests.push(request);
+            return requests.length === 1
+              ? contractError(400, "stale", "session_not_found")
+              : Response.json({ encrypted: '2:{"ok":true}' });
+          }
+        })
+      );
+      const sourceRequest = new Request("https://example.test/v1/responses", {
+        method: "POST",
+        body: '{"prompt":"preserve this"}'
+      });
+
+      expect(await (await customFetch(sourceRequest)).json()).toEqual({ ok: true });
+      expect(forcedAttestations).toBe(1);
+      expect(requests).toEqual([
+        {
+          authorization: "Bearer test-api-key",
+          encryptedBody: '1:{"prompt":"preserve this"}',
+          sessionId: "stale-session"
+        },
+        {
+          authorization: "Bearer test-api-key",
+          encryptedBody: '2:{"prompt":"preserve this"}',
+          sessionId: "fresh-session"
+        }
+      ]);
+    });
+  });
+
+  for (const source of ["RequestInit", "Request"] as const) {
+    test(`preserves an explicitly empty Firefox POST body from ${source}`, async () => {
+      await withRequestBodyUnavailable(async () => {
+        let currentAttestation = staleAttestation;
+        const requests: RecordedRequest[] = [];
+
+        const customFetch = createCustomFetchWithDependencies(
+          { apiKey: "test-api-key" },
+          dependencies({
+            getAttestation: async (forceRefresh) => {
+              if (forceRefresh) currentAttestation = freshAttestation;
+              return currentAttestation;
+            },
+            fetch: async (_input, init) => {
+              const request = recordRequest(init);
+              requests.push(request);
+              return requests.length === 1
+                ? contractError(400, "stale", "session_not_found")
+                : Response.json({ encrypted: '2:{"ok":true}' });
+            }
+          })
+        );
+        const url = "https://example.test/v1/responses";
+
+        const response =
+          source === "RequestInit"
+            ? await customFetch(url, { method: "POST", body: "" })
+            : await customFetch(new Request(url, { method: "POST", body: "" }));
+
+        expect(await response.json()).toEqual({ ok: true });
+        expect(requests).toEqual([
+          {
+            authorization: "Bearer test-api-key",
+            encryptedBody: "1:",
+            sessionId: "stale-session"
+          },
+          {
+            authorization: "Bearer test-api-key",
+            encryptedBody: "2:",
+            sessionId: "fresh-session"
+          }
+        ]);
+      });
+    });
+  }
 
   test("stops after one attestation retry when 400 persists", async () => {
     let currentAttestation = staleAttestation;


### PR DESCRIPTION
Closes #110

## Summary

- Keep normalized `GET` and `HEAD` requests bodyless when Firefox exposes `Request.body` as `undefined`.
- Preserve bodyless and explicit zero-length body semantics for body-capable methods while retaining plaintext snapshotting and fresh-session re-encryption from #108.
- Add Firefox-style regression coverage for `GET`, `HEAD`, bodyless `POST`, non-empty `POST`, and explicit empty `POST` bodies supplied through both `RequestInit` and `Request`.

## Validation

- Reproduced in local Maple on Firefox 153.0.3: opening an existing conversation failed with `TypeError: Window.fetch: HEAD or GET Request cannot have a body.`
- Linked this SDK worktree into local Maple; existing conversation retrieval and item polling complete without the Firefox body error, and encrypted POST prompts complete successfully.
- Verified the same linked build in Chrome: an existing conversation loaded and an encrypted POST completed as `FF110_CHROME_OK`.
- Restarted only the local OpenSecret backend to invalidate encrypted sessions. Both an existing-conversation GET and a POST recovered through one attestation renewal/replay; the POST completed as `FF110_STALE_POST_TRACE_OK`.
- `bun test src/lib/test/*.test.ts --timeout 30000` — 81 passed
- `bun run format:check`
- `bun run pack`
