### PR TITLE
chore: bump React SDK to 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensecret/react",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensecret/react",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "1.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/react",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "packageManager": "bun@1.3.5",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- bump `@opensecret/react` from 3.5.0 to 3.5.1 for the Firefox `Request` body fix merged in #111
- update the npm lockfile's root package metadata
- leave the Rust SDK at 3.6.2 because #111 affected only the TypeScript SDK

This PR only prepares the npm package version; it does not tag or publish a release.

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bun audit --audit-level=high`
- `bun run format:check`
- `bun run build`
- `bun test src/lib/test/*.test.ts --timeout 30000` (81 passed)
- `bun run pack` (`@opensecret/react@3.5.1`, 6 files)
- `git diff --check`
