### PR TITLE
chore: prepare React SDK 3.5.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ bun run pack
 
 Only `dist/` is included in the package.
 
+Publish a freshly built npm artifact with:
+
+```sh
+just publish-npm
+```
+
 ## Rust SDK
 
 Add the crate to a Rust application:
@@ -115,6 +121,12 @@ nix develop --no-update-lock-file -c bash -lc '
 
 Integration tests use the variables documented in `rust/.env.example` and are
 separate from the default local validation path.
+
+Publish the locked Rust crate with:
+
+```sh
+just publish-cargo
+```
 
 ## Change discipline
 

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,6 @@
           pkg-config
           openssl
           zlib
-          gcc
           clang
           libclang
           
@@ -55,7 +54,7 @@
         ];
         
         linuxOnlyInputs = with pkgs; [
-          # Add Linux-specific dependencies if needed
+          gcc
         ];
         
         allInputs = commonInputs

--- a/justfile
+++ b/justfile
@@ -1,0 +1,10 @@
+# Build a fresh npm tarball and publish that exact artifact.
+publish-npm:
+    nix develop --no-update-lock-file -c bun install --frozen-lockfile --ignore-scripts
+    nix develop --no-update-lock-file -c bun run build
+    nix develop --no-update-lock-file -c bun pm pack --filename opensecret-react-publish.tgz
+    nix develop --no-update-lock-file -c npm publish ./opensecret-react-publish.tgz --access public
+
+# Publish the Rust crate using the committed lockfile.
+publish-cargo:
+    nix develop --no-update-lock-file -c cargo publish --locked --manifest-path rust/Cargo.toml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensecret/react",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensecret/react",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "MIT",
       "dependencies": {
         "@peculiar/x509": "1.14.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/react",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "packageManager": "bun@1.3.5",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- bump `@opensecret/react` from 3.5.1 to 3.5.2 because the published 3.5.1 artifact contained stale 3.5.0 bundles and therefore omitted the Firefox fix from #111
- add `just publish-npm`, which installs from the frozen lockfile, rebuilds, packs, and publishes that exact npm tarball inside Nix
- add `just publish-cargo`, which publishes the locked Rust crate inside Nix
- fix the Darwin Nix shell to select Clang by making GCC Linux-only

No package was published while preparing this PR.

## Validation

- `cargo publish --dry-run --locked --manifest-path rust/Cargo.toml` passes in the Nix shell
- npm 3.5.2 tarball publish dry-run passes and contains the Firefox body-snapshot fix
- 81 TypeScript unit tests pass
- formatting, build, audit, and diff checks pass
